### PR TITLE
fix(rubric): ensure manual rubric traits are evaluated during verification

### DIFF
--- a/src/karenina/benchmark/verification/runner.py
+++ b/src/karenina/benchmark/verification/runner.py
@@ -613,7 +613,7 @@ Original Question: {question_text}
 
         # Step 6: Run rubric evaluation (optional)
         rubric_result = None
-        if rubric and rubric.traits:
+        if rubric and (rubric.traits or rubric.manual_traits):
             try:
                 # Use parsing model for rubric evaluation
                 evaluator = RubricEvaluator(parsing_model)


### PR DESCRIPTION
## Summary

Fixes rubric evaluation logic to include manual traits when determining whether to run rubric evaluation. Previously, rubrics containing only manual traits (regex-based validation) were skipped during verification. This single-line fix ensures both LLM-based and manual traits trigger rubric evaluation.

## Changes Made

### Verification Runner (`src/karenina/benchmark/verification/runner.py`)
- **Fixed condition**: Changed `if rubric and rubric.traits:` to `if rubric and (rubric.traits or rubric.manual_traits):`
- **Location**: Line 616 in `_verify_single_item` method
- **Impact**: Manual-only rubrics now properly trigger rubric evaluation

### Behavior Change

**Before:**
```python
if rubric and rubric.traits:
    # Run rubric evaluation
```
- ❌ Rubrics with only `manual_traits` were skipped
- ✅ Rubrics with `traits` were evaluated

**After:**
```python
if rubric and (rubric.traits or rubric.manual_traits):
    # Run rubric evaluation
```
- ✅ Rubrics with only `manual_traits` are evaluated
- ✅ Rubrics with only `traits` are evaluated
- ✅ Rubrics with both types are evaluated

## Testing

### Manual Testing Steps
1. Create a rubric with only manual traits:
   ```python
   rubric = Rubric(
       traits=[],
       manual_traits=[
           ManualRubricTrait(
               name="Has Email",
               pattern=r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
           )
       ]
   )
   ```

2. Run verification with this rubric:
   ```python
   results = runner.run_verification(
       questions=questions,
       templates=templates,
       answering_models=[model],
       parsing_models=[model],
       rubric=rubric
   )
   ```

3. Verify that `rubric_result` is populated in verification results
   - Before fix: `rubric_result` would be `None`
   - After fix: `rubric_result` contains manual trait evaluation scores

### Expected Impact
- Manual trait evaluation scores now appear in verification results
- No change to existing behavior for LLM-based traits
- Mixed rubrics (LLM + manual) work correctly

## Related PRs

This change adds manual rubric trait support across the Karenina suite:
- [ ] biocypher/karenina#42 - Ensures manual traits are evaluated during verification (this PR)
- [ ] biocypher/karenina-server#19 - Adds manual trait validation to rubric API
- [ ] biocypher/karenina-gui#39 - Adds manual trait UI and checkpoint persistence

**Merge order**: biocypher/karenina#42 (this PR) → biocypher/karenina-server#19 → biocypher/karenina-gui#39

**Dependencies**: This is the foundation PR. The server and GUI PRs depend on this fix being merged first.

## Additional Context

### Breaking Changes
None. This is a bug fix that enables advertised functionality.

### Root Cause
The original condition only checked for `rubric.traits`, which excluded rubrics with only manual traits. The `RubricEvaluator` class already supports manual traits, so this was simply a gate-keeping logic issue.

### Performance
- No performance impact
- Manual trait evaluation uses regex matching (fast)
- LLM-based trait evaluation unchanged

### Rubric Structure
```python
@dataclass
class Rubric:
    traits: list[RubricTrait]           # LLM-based traits
    manual_traits: list[ManualRubricTrait]  # Regex/callable traits (optional)
```

### Why This Matters
Manual traits enable deterministic pattern matching for common validation scenarios:
- Email/URL detection
- Structured format validation
- Keyword presence checks
- XML/JSON tag extraction

Without this fix, users creating manual-only rubrics would see no evaluation results despite valid configuration.