### PR TITLE
feat(verification): implement comprehensive LLM usage tracking and agent metrics

### DIFF
--- a/src/karenina/benchmark/exporter.py
+++ b/src/karenina/benchmark/exporter.py
@@ -202,6 +202,9 @@ def export_verification_results_json(job: VerificationJob, results: dict[str, Ve
             # Metric trait fields
             "metric_trait_confusion_lists": result.metric_trait_confusion_lists,
             "metric_trait_metrics": result.metric_trait_metrics,
+            # LLM usage tracking fields
+            "usage_metadata": result.usage_metadata,
+            "agent_metrics": result.agent_metrics,
         }
 
     return json.dumps(export_data, indent=2, ensure_ascii=False)
@@ -390,6 +393,9 @@ def export_verification_results_csv(
             # Metric trait fields
             "metric_trait_confusion_lists",
             "metric_trait_metrics",
+            # LLM usage tracking fields
+            "usage_metadata",
+            "agent_metrics",
         ]
     )
 
@@ -404,7 +410,7 @@ def export_verification_results_csv(
     for _question_id, result in results.items():
         row = {
             "question_id": result.question_id,
-            "completed_without_errors": result.completed_without_errors,
+            "success": result.completed_without_errors,  # Header uses 'success', not 'completed_without_errors'
             "error": result.error or "",
             "question_text": result.question_text,
             "raw_llm_response": result.raw_llm_response,
@@ -469,6 +475,13 @@ def export_verification_results_csv(
             "metric_trait_metrics": _safe_json_serialize(
                 result.metric_trait_metrics, result.question_id, "metric_trait_metrics"
             ),
+            # LLM usage tracking fields
+            "usage_metadata": _safe_json_serialize(result.usage_metadata, result.question_id, "usage_metadata")
+            if result.usage_metadata
+            else "",
+            "agent_metrics": _safe_json_serialize(result.agent_metrics, result.question_id, "agent_metrics")
+            if result.agent_metrics
+            else "",
         }
 
         # Add global rubric trait values (optimized with dictionary comprehension)

--- a/src/karenina/benchmark/task_eval/helpers.py
+++ b/src/karenina/benchmark/task_eval/helpers.py
@@ -87,7 +87,9 @@ def evaluate_standalone_rubrics(
         try:
             evaluator = RubricEvaluator(parsing_model, callable_registry)
             question = f"Evaluate the overall quality of the {context} outputs."
-            rubric_scores = evaluator.evaluate_rubric(question=question, answer=concatenated_logs, rubric=merged_rubric)
+            rubric_scores, _ = evaluator.evaluate_rubric(
+                question=question, answer=concatenated_logs, rubric=merged_rubric
+            )
         except Exception as e:
             print(f"Warning: {context.title()} rubric evaluation failed: {e}")
             rubric_scores = {}

--- a/src/karenina/benchmark/task_eval/task_eval.py
+++ b/src/karenina/benchmark/task_eval/task_eval.py
@@ -541,7 +541,7 @@ class TaskEval:
             if rubric and (rubric.traits or rubric.manual_traits):
                 try:
                     evaluator = RubricEvaluator(parsing_model, self.callable_registry)
-                    rubric_scores = evaluator.evaluate_rubric(
+                    rubric_scores, _ = evaluator.evaluate_rubric(
                         question=question_text, answer=response_text, rubric=rubric
                     )
                 except Exception as e:
@@ -586,7 +586,9 @@ class TaskEval:
             try:
                 evaluator = RubricEvaluator(parsing_model, self.callable_registry)
                 question_text = question_dict.get("question", "")
-                rubric_scores = evaluator.evaluate_rubric(question=question_text, answer=response_text, rubric=rubric)
+                rubric_scores, _ = evaluator.evaluate_rubric(
+                    question=question_text, answer=response_text, rubric=rubric
+                )
             except Exception as e:
                 print(f"Warning: RubricEvaluator failed in fallback: {e}")
                 rubric_scores = {}

--- a/src/karenina/benchmark/verification/evaluators/deep_judgment.py
+++ b/src/karenina/benchmark/verification/evaluators/deep_judgment.py
@@ -183,8 +183,9 @@ Return JSON format:
 
         # Invoke parsing model with excerpt-specific system prompt
         messages = [SystemMessage(content=excerpt_system_prompt), HumanMessage(content=excerpt_prompt)]
-        raw_response = _invoke_llm_with_retry(parsing_llm, messages)
+        raw_response, _, usage_metadata, _ = _invoke_llm_with_retry(parsing_llm, messages, is_agent=False)
         model_calls += 1
+        # TODO: Aggregate usage_metadata in Phase 4
         cleaned_response = _strip_markdown_fences(raw_response)
 
         try:
@@ -435,8 +436,9 @@ Return JSON format with assessments for ALL excerpts:
             messages = [SystemMessage(content=assessment_system_prompt), HumanMessage(content=assessment_prompt)]
 
             try:
-                raw_response = _invoke_llm_with_retry(parsing_llm, messages)
+                raw_response, _, usage_metadata, _ = _invoke_llm_with_retry(parsing_llm, messages, is_agent=False)
                 model_calls += 1
+                # TODO: Aggregate usage_metadata in Phase 4
                 cleaned_response = _strip_markdown_fences(raw_response)
                 assessment_data = {} if cleaned_response is None else json.loads(cleaned_response)
 
@@ -572,8 +574,9 @@ Return JSON format with ONLY the attributes listed above:
 </extracted_excerpts>"""
 
     messages = [SystemMessage(content=reasoning_system_prompt), HumanMessage(content=reasoning_prompt)]
-    raw_response = _invoke_llm_with_retry(parsing_llm, messages)
+    raw_response, _, usage_metadata, _ = _invoke_llm_with_retry(parsing_llm, messages, is_agent=False)
     model_calls += 1
+    # TODO: Aggregate usage_metadata in Phase 4
     cleaned_response = _strip_markdown_fences(raw_response)
 
     try:
@@ -652,8 +655,9 @@ Your task is to extract the final attribute values based on the reasoning traces
 </reasoning_traces>"""
 
     messages = [SystemMessage(content=parsing_system_prompt), HumanMessage(content=parsing_prompt)]
-    raw_response = _invoke_llm_with_retry(parsing_llm, messages)
+    raw_response, _, usage_metadata, _ = _invoke_llm_with_retry(parsing_llm, messages, is_agent=False)
     model_calls += 1
+    # TODO: Aggregate usage_metadata in Phase 4
     cleaned_response = _strip_markdown_fences(raw_response)
 
     # Parse with PydanticOutputParser (standard logic)

--- a/src/karenina/benchmark/verification/utils/__init__.py
+++ b/src/karenina/benchmark/verification/utils/__init__.py
@@ -19,6 +19,7 @@ from .prompts import (
     ANSWER_EVALUATION_SYS,
     ANSWER_EVALUATION_USER,
 )
+from .usage_tracker import UsageMetadata, UsageTracker
 from .validation import validate_answer_template
 
 __all__ = [
@@ -41,4 +42,7 @@ __all__ = [
     "ANSWER_EVALUATION_USER",
     # Validation
     "validate_answer_template",
+    # Usage tracking
+    "UsageMetadata",
+    "UsageTracker",
 ]

--- a/src/karenina/benchmark/verification/utils/usage_tracker.py
+++ b/src/karenina/benchmark/verification/utils/usage_tracker.py
@@ -1,0 +1,272 @@
+"""
+Usage tracking utilities for LangChain LLM calls.
+
+Provides classes to track and aggregate token usage and agent metrics across
+verification stages.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class UsageMetadata:
+    """
+    Metadata for a single LLM call.
+
+    Attributes:
+        model_name: Model identifier (e.g., "gpt-4.1-mini-2025-04-14")
+        input_tokens: Number of tokens in the input/prompt
+        output_tokens: Number of tokens in the output/completion
+        total_tokens: Total tokens (input + output)
+        input_token_details: Additional input token details (audio, cache_read)
+        output_token_details: Additional output token details (audio, reasoning)
+    """
+
+    model_name: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+    input_token_details: dict[str, int] = field(default_factory=dict)
+    output_token_details: dict[str, int] = field(default_factory=dict)
+
+    @classmethod
+    def from_callback_metadata(cls, callback_metadata: dict[str, Any]) -> "UsageMetadata":
+        """
+        Create UsageMetadata from LangChain callback metadata.
+
+        Args:
+            callback_metadata: Dict from get_usage_metadata_callback().usage_metadata
+                Expected format:
+                {
+                    'model-name': {
+                        'input_tokens': 11,
+                        'output_tokens': 20,
+                        'total_tokens': 31,
+                        'input_token_details': {'audio': 0, 'cache_read': 0},
+                        'output_token_details': {'audio': 0, 'reasoning': 0}
+                    }
+                }
+
+        Returns:
+            UsageMetadata instance
+        """
+        if not callback_metadata:
+            return cls(model_name="unknown")
+
+        # LangChain returns metadata keyed by model name
+        # Extract the first (and usually only) model entry
+        if isinstance(callback_metadata, dict):
+            for model_name, metadata in callback_metadata.items():
+                return cls(
+                    model_name=model_name,
+                    input_tokens=metadata.get("input_tokens", 0),
+                    output_tokens=metadata.get("output_tokens", 0),
+                    total_tokens=metadata.get("total_tokens", 0),
+                    input_token_details=metadata.get("input_token_details", {}),
+                    output_token_details=metadata.get("output_token_details", {}),
+                )
+
+        # Fallback for unexpected format
+        return cls(model_name="unknown")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "model": self.model_name,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "total_tokens": self.total_tokens,
+            "input_token_details": self.input_token_details,
+            "output_token_details": self.output_token_details,
+        }
+
+
+class UsageTracker:
+    """
+    Tracks and aggregates LLM usage metadata across multiple calls and stages.
+
+    Usage:
+        tracker = UsageTracker()
+
+        # Track calls
+        tracker.track_call("answer_generation", "gpt-4.1-mini", callback_metadata)
+        tracker.track_call("parsing", "gpt-4.1-mini", callback_metadata)
+
+        # Track agent metrics (if agent used)
+        tracker.track_agent_metrics(agent_response)
+
+        # Get summaries
+        answer_summary = tracker.get_stage_summary("answer_generation")
+        total_summary = tracker.get_total_summary()
+        agent_metrics = tracker.get_agent_metrics()
+    """
+
+    def __init__(self) -> None:
+        """Initialize empty tracking structures."""
+        # Stage name -> list of UsageMetadata
+        self._stage_calls: dict[str, list[UsageMetadata]] = {}
+        # Agent metrics (only populated if agent used)
+        self._agent_metrics: dict[str, Any] | None = None
+
+    def track_call(
+        self,
+        stage_name: str,
+        model_name: str,
+        callback_metadata: dict[str, Any],
+    ) -> None:
+        """
+        Record a single LLM call.
+
+        Args:
+            stage_name: Name of verification stage (e.g., "answer_generation")
+            model_name: Model identifier for fallback if not in metadata
+            callback_metadata: Dict from get_usage_metadata_callback().usage_metadata
+        """
+        if not callback_metadata:
+            # Create minimal metadata if callback returned nothing
+            metadata = UsageMetadata(model_name=model_name)
+        else:
+            metadata = UsageMetadata.from_callback_metadata(callback_metadata)
+
+        if stage_name not in self._stage_calls:
+            self._stage_calls[stage_name] = []
+
+        self._stage_calls[stage_name].append(metadata)
+
+    def track_agent_metrics(self, response: Any) -> None:
+        """
+        Extract and store agent execution metrics from response.
+
+        Args:
+            response: Agent response object from LangGraph (dict with "messages" key)
+        """
+        if not response or not isinstance(response, dict):
+            return
+
+        messages = response.get("messages", [])
+        if not messages:
+            return
+
+        # Count iterations (AI message cycles)
+        iterations = 0
+        tool_calls = 0
+        tools_used = set()
+
+        for msg in messages:
+            # Check message type
+            msg_type = getattr(msg, "__class__", None)
+            if msg_type:
+                type_name = msg_type.__name__
+
+                # Count AI messages as iterations
+                if type_name == "AIMessage":
+                    iterations += 1
+
+                # Count tool messages and extract tool names
+                elif type_name == "ToolMessage":
+                    tool_calls += 1
+                    # Extract tool name from ToolMessage
+                    tool_name = getattr(msg, "name", None)
+                    if tool_name:
+                        tools_used.add(tool_name)
+
+        self._agent_metrics = {
+            "iterations": iterations,
+            "tool_calls": tool_calls,
+            "tools_used": sorted(tools_used),  # Sort for deterministic output
+        }
+
+    def get_stage_summary(self, stage_name: str) -> dict[str, Any] | None:
+        """
+        Get aggregated metadata for a single stage.
+
+        Args:
+            stage_name: Name of verification stage
+
+        Returns:
+            Aggregated metadata dict or None if stage not tracked
+        """
+        if stage_name not in self._stage_calls:
+            return None
+
+        calls = self._stage_calls[stage_name]
+        if not calls:
+            return None
+
+        # Aggregate across all calls in this stage
+        total_input = sum(c.input_tokens for c in calls)
+        total_output = sum(c.output_tokens for c in calls)
+        total_tokens = sum(c.total_tokens for c in calls)
+
+        # Use model name from first call (should be consistent within stage)
+        model_name = calls[0].model_name
+
+        # Aggregate token details (sum across calls)
+        input_details: dict[str, int] = {}
+        output_details: dict[str, int] = {}
+
+        for call in calls:
+            for key, val in call.input_token_details.items():
+                input_details[key] = input_details.get(key, 0) + val
+            for key, val in call.output_token_details.items():
+                output_details[key] = output_details.get(key, 0) + val
+
+        return {
+            "input_tokens": total_input,
+            "output_tokens": total_output,
+            "total_tokens": total_tokens,
+            "model": model_name,
+            "input_token_details": input_details if input_details else {"audio": 0, "cache_read": 0},
+            "output_token_details": output_details if output_details else {"audio": 0, "reasoning": 0},
+        }
+
+    def get_total_summary(self) -> dict[str, dict[str, Any]]:
+        """
+        Get aggregated metadata for all stages plus overall total.
+
+        Returns:
+            Dict with per-stage summaries and a "total" entry aggregating all stages
+        """
+        result = {}
+
+        # Per-stage summaries
+        for stage_name in self._stage_calls:
+            summary = self.get_stage_summary(stage_name)
+            if summary:
+                result[stage_name] = summary
+
+        # Overall total
+        if result:
+            total_input = sum(s["input_tokens"] for s in result.values())
+            total_output = sum(s["output_tokens"] for s in result.values())
+            total_tokens = sum(s["total_tokens"] for s in result.values())
+
+            result["total"] = {
+                "input_tokens": total_input,
+                "output_tokens": total_output,
+                "total_tokens": total_tokens,
+            }
+
+        return result
+
+    def set_agent_metrics(self, agent_metrics: dict[str, Any]) -> None:
+        """
+        Directly set agent metrics (when already extracted).
+
+        Args:
+            agent_metrics: Pre-extracted agent metrics dict with keys:
+                - iterations: Number of agent think-act cycles
+                - tool_calls: Total tool invocations
+                - tools_used: List of unique tool names
+        """
+        self._agent_metrics = agent_metrics
+
+    def get_agent_metrics(self) -> dict[str, Any] | None:
+        """
+        Get agent execution metrics if available.
+
+        Returns:
+            Agent metrics dict or None if no agent was used
+        """
+        return self._agent_metrics

--- a/src/karenina/schemas/workflow/verification.py
+++ b/src/karenina/schemas/workflow/verification.py
@@ -360,6 +360,21 @@ class VerificationResult(BaseModel):
     # Scale: "none" = lowest risk (strong external evidence), "high" = highest risk (weak/no evidence)
     # Only populated when deep_judgment_search_enabled=True
 
+    # LLM usage tracking metadata
+    usage_metadata: dict[str, dict[str, Any]] | None = None  # Token usage breakdown by verification stage
+    # Structure: {
+    #   "answer_generation": {
+    #     "input_tokens": 150, "output_tokens": 200, "total_tokens": 350,
+    #     "model": "gpt-4.1-mini-2025-04-14",
+    #     "input_token_details": {"audio": 0, "cache_read": 0},
+    #     "output_token_details": {"audio": 0, "reasoning": 0}
+    #   },
+    #   "parsing": {...}, "rubric_evaluation": {...}, "abstention_check": {...},
+    #   "total": {"input_tokens": 600, "output_tokens": 360, "total_tokens": 960}
+    # }
+    agent_metrics: dict[str, Any] | None = None  # MCP agent execution metrics (only if agent used)
+    # Structure: {"iterations": 3, "tool_calls": 5, "tools_used": ["mcp__brave_search", "mcp__read_resource"]}
+
     # Metric trait evaluation metadata (confusion-matrix analysis)
     metric_trait_confusion_lists: dict[str, dict[str, list[str]]] | None = None  # Confusion lists per metric trait
     # Structure: {"trait_name": {"tp": ["excerpt1", ...], "tn": [...], "fp": [...], "fn": [...]}}

--- a/src/karenina/storage/models.py
+++ b/src/karenina/storage/models.py
@@ -290,6 +290,10 @@ class VerificationResultModel(Base):
     metric_trait_confusion_lists: Mapped[dict[str, dict[str, list[str]]] | None] = mapped_column(JSON, nullable=True)
     metric_trait_metrics: Mapped[dict[str, dict[str, float]] | None] = mapped_column(JSON, nullable=True)
 
+    # LLM usage tracking metadata
+    usage_metadata: Mapped[dict[str, dict[str, Any]] | None] = mapped_column(JSON, nullable=True)
+    agent_metrics: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
 

--- a/src/karenina/storage/operations.py
+++ b/src/karenina/storage/operations.py
@@ -588,6 +588,9 @@ def _create_result_model(run_id: str, result: "VerificationResult") -> Verificat
         # Metric trait fields
         metric_trait_confusion_lists=result.metric_trait_confusion_lists,
         metric_trait_metrics=result.metric_trait_metrics,
+        # LLM usage tracking fields
+        usage_metadata=result.usage_metadata,
+        agent_metrics=result.agent_metrics,
     )
 
 
@@ -638,11 +641,14 @@ def _update_result_model(model: VerificationResultModel, result: "VerificationRe
     # Metric trait fields
     model.metric_trait_confusion_lists = result.metric_trait_confusion_lists
     model.metric_trait_metrics = result.metric_trait_metrics
+    # LLM usage tracking fields
+    model.usage_metadata = result.usage_metadata
+    model.agent_metrics = result.agent_metrics
 
 
 def _model_to_verification_result(model: VerificationResultModel) -> "VerificationResult":
     """Convert VerificationResultModel to VerificationResult."""
-    from ...schemas.workflow import VerificationResult
+    from karenina.schemas.workflow import VerificationResult
 
     return VerificationResult(
         question_id=model.question_id,
@@ -700,4 +706,7 @@ def _model_to_verification_result(model: VerificationResultModel) -> "Verificati
         # Metric trait fields
         metric_trait_confusion_lists=model.metric_trait_confusion_lists,
         metric_trait_metrics=model.metric_trait_metrics,
+        # LLM usage tracking fields
+        usage_metadata=model.usage_metadata,
+        agent_metrics=model.agent_metrics,
     )

--- a/tests/test_usage_tracking.py
+++ b/tests/test_usage_tracking.py
@@ -1,0 +1,325 @@
+"""Tests for LLM usage tracking functionality.
+
+This module tests the UsageTracker utility class which aggregates
+token usage metadata across verification stages.
+"""
+
+from karenina.benchmark.verification.utils import UsageTracker
+
+
+class TestUsageTracker:
+    """Test suite for UsageTracker class."""
+
+    def test_track_single_call(self):
+        """Test tracking a single LLM call."""
+        tracker = UsageTracker()
+
+        # Sample metadata from LangChain callback
+        metadata = {
+            "gpt-4o-mini": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            }
+        }
+
+        tracker.track_call("answer_generation", "openai/gpt-4o-mini", metadata)
+
+        # Get stage summary
+        summary = tracker.get_stage_summary("answer_generation")
+
+        assert summary is not None
+        # Model name comes from metadata dict key, not the model_name parameter
+        assert summary["model"] == "gpt-4o-mini"
+        assert summary["input_tokens"] == 100
+        assert summary["output_tokens"] == 50
+        assert summary["total_tokens"] == 150
+
+    def test_track_multiple_calls_same_stage(self):
+        """Test tracking multiple calls to the same stage aggregates correctly."""
+        tracker = UsageTracker()
+
+        # First call
+        metadata1 = {
+            "gpt-4o-mini": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            }
+        }
+        tracker.track_call("parsing", "openai/gpt-4o-mini", metadata1)
+
+        # Second call (e.g., retry)
+        metadata2 = {
+            "gpt-4o-mini": {
+                "input_tokens": 80,
+                "output_tokens": 40,
+                "total_tokens": 120,
+            }
+        }
+        tracker.track_call("parsing", "openai/gpt-4o-mini", metadata2)
+
+        # Get aggregated summary
+        summary = tracker.get_stage_summary("parsing")
+
+        assert summary is not None
+        assert summary["input_tokens"] == 180  # 100 + 80
+        assert summary["output_tokens"] == 90  # 50 + 40
+        assert summary["total_tokens"] == 270  # 150 + 120
+
+    def test_track_multiple_stages(self):
+        """Test tracking calls across different stages."""
+        tracker = UsageTracker()
+
+        # Answer generation
+        metadata1 = {
+            "gpt-4o-mini": {
+                "input_tokens": 200,
+                "output_tokens": 100,
+                "total_tokens": 300,
+            }
+        }
+        tracker.track_call("answer_generation", "openai/gpt-4o-mini", metadata1)
+
+        # Parsing
+        metadata2 = {
+            "gpt-4o-mini": {
+                "input_tokens": 150,
+                "output_tokens": 80,
+                "total_tokens": 230,
+            }
+        }
+        tracker.track_call("parsing", "openai/gpt-4o-mini", metadata2)
+
+        # Rubric evaluation
+        metadata3 = {
+            "gpt-4o-mini": {
+                "input_tokens": 180,
+                "output_tokens": 90,
+                "total_tokens": 270,
+            }
+        }
+        tracker.track_call("rubric_evaluation", "openai/gpt-4o-mini", metadata3)
+
+        # Verify each stage tracked separately
+        answer_summary = tracker.get_stage_summary("answer_generation")
+        parsing_summary = tracker.get_stage_summary("parsing")
+        rubric_summary = tracker.get_stage_summary("rubric_evaluation")
+
+        assert answer_summary["total_tokens"] == 300
+        assert parsing_summary["total_tokens"] == 230
+        assert rubric_summary["total_tokens"] == 270
+
+    def test_get_total_summary(self):
+        """Test getting aggregated summary across all stages with totals."""
+        tracker = UsageTracker()
+
+        # Track multiple stages
+        tracker.track_call(
+            "answer_generation",
+            "openai/gpt-4o-mini",
+            {"gpt-4o-mini": {"input_tokens": 200, "output_tokens": 100, "total_tokens": 300}},
+        )
+
+        tracker.track_call(
+            "parsing",
+            "openai/gpt-4o-mini",
+            {"gpt-4o-mini": {"input_tokens": 150, "output_tokens": 80, "total_tokens": 230}},
+        )
+
+        tracker.track_call(
+            "rubric_evaluation",
+            "openai/gpt-4o-mini",
+            {"gpt-4o-mini": {"input_tokens": 180, "output_tokens": 90, "total_tokens": 270}},
+        )
+
+        # Get total summary
+        total = tracker.get_total_summary()
+
+        # Should have stage breakdowns + total
+        assert "answer_generation" in total
+        assert "parsing" in total
+        assert "rubric_evaluation" in total
+        assert "total" in total
+
+        # Verify totals
+        total_summary = total["total"]
+        assert total_summary["input_tokens"] == 530  # 200 + 150 + 180
+        assert total_summary["output_tokens"] == 270  # 100 + 80 + 90
+        assert total_summary["total_tokens"] == 800  # 300 + 230 + 270
+
+    def test_track_agent_metrics(self):
+        """Test tracking agent execution metrics."""
+        tracker = UsageTracker()
+
+        # Create mock message objects with proper types
+        class MockAIMessage:
+            __class__ = type("AIMessage", (), {})
+
+        class MockToolMessage:
+            __class__ = type("ToolMessage", (), {})
+
+            def __init__(self, tool_name):
+                self.name = tool_name
+
+        # Simulate agent response with messages
+        agent_response = {
+            "messages": [
+                MockAIMessage(),  # Iteration 1
+                MockToolMessage("web_search"),
+                MockToolMessage("calculator"),
+                MockAIMessage(),  # Iteration 2
+                MockToolMessage("file_read"),
+                MockToolMessage("calculator"),  # Duplicate tool
+                MockAIMessage(),  # Iteration 3
+                MockToolMessage("web_search"),  # Duplicate tool
+            ]
+        }
+
+        # Track agent metrics
+        tracker.track_agent_metrics(agent_response)
+
+        # Retrieve agent metrics
+        retrieved_metrics = tracker.get_agent_metrics()
+
+        assert retrieved_metrics is not None
+        assert retrieved_metrics["iterations"] == 3
+        assert retrieved_metrics["tool_calls"] == 5
+        assert len(retrieved_metrics["tools_used"]) == 3  # Unique tools
+        assert "web_search" in retrieved_metrics["tools_used"]
+        assert "calculator" in retrieved_metrics["tools_used"]
+        assert "file_read" in retrieved_metrics["tools_used"]
+
+    def test_get_stage_summary_nonexistent(self):
+        """Test getting summary for a stage that wasn't tracked."""
+        tracker = UsageTracker()
+
+        summary = tracker.get_stage_summary("nonexistent_stage")
+
+        assert summary is None
+
+    def test_empty_tracker_total_summary(self):
+        """Test getting total summary from empty tracker."""
+        tracker = UsageTracker()
+
+        total = tracker.get_total_summary()
+
+        # Should be empty dict if no calls tracked
+        assert total == {}
+        assert "total" not in total
+
+    def test_track_with_empty_metadata(self):
+        """Test tracking with empty metadata doesn't crash."""
+        tracker = UsageTracker()
+
+        # Empty metadata
+        tracker.track_call("answer_generation", "openai/gpt-4o-mini", {})
+
+        summary = tracker.get_stage_summary("answer_generation")
+
+        # Should exist but with zero tokens
+        assert summary is not None
+        assert summary["input_tokens"] == 0
+        assert summary["output_tokens"] == 0
+        assert summary["total_tokens"] == 0
+
+    def test_track_with_partial_metadata(self):
+        """Test tracking with partial/incomplete metadata."""
+        tracker = UsageTracker()
+
+        # Metadata missing some fields
+        metadata = {"gpt-4o-mini": {"input_tokens": 100}}
+
+        tracker.track_call("parsing", "openai/gpt-4o-mini", metadata)
+
+        summary = tracker.get_stage_summary("parsing")
+
+        assert summary is not None
+        assert summary["input_tokens"] == 100
+        assert summary["output_tokens"] == 0  # Should default to 0
+        assert summary["total_tokens"] == 0
+
+    def test_track_with_token_details(self):
+        """Test tracking metadata with detailed token breakdown."""
+        tracker = UsageTracker()
+
+        # Metadata with token details (e.g., cache hits)
+        metadata = {
+            "gpt-4o-mini": {
+                "input_tokens": 200,
+                "output_tokens": 100,
+                "total_tokens": 300,
+                "input_token_details": {"cache_read": 50, "audio": 0},
+                "output_token_details": {"reasoning": 20, "audio": 0},
+            }
+        }
+
+        tracker.track_call("answer_generation", "openai/gpt-4o-mini", metadata)
+
+        summary = tracker.get_stage_summary("answer_generation")
+
+        assert summary is not None
+        assert "input_token_details" in summary
+        assert summary["input_token_details"]["cache_read"] == 50
+
+    def test_multiple_models_same_stage(self):
+        """Test tracking different models in same stage (edge case)."""
+        tracker = UsageTracker()
+
+        # First call with gpt-4o-mini
+        metadata1 = {
+            "gpt-4o-mini": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            }
+        }
+        tracker.track_call("answer_generation", "openai/gpt-4o-mini", metadata1)
+
+        # Second call with different model (e.g., after retry with different model)
+        metadata2 = {
+            "gpt-4o": {
+                "input_tokens": 120,
+                "output_tokens": 60,
+                "total_tokens": 180,
+            }
+        }
+        tracker.track_call("answer_generation", "openai/gpt-4o", metadata2)
+
+        # Should aggregate tokens, model name comes from first call
+        summary = tracker.get_stage_summary("answer_generation")
+
+        assert summary is not None
+        assert summary["input_tokens"] == 220  # 100 + 120
+        assert summary["output_tokens"] == 110  # 50 + 60
+        assert summary["total_tokens"] == 330  # 150 + 180
+        # Model name from first call's metadata key
+        assert summary["model"] == "gpt-4o-mini"
+
+    def test_get_agent_metrics_when_none(self):
+        """Test getting agent metrics when none were tracked."""
+        tracker = UsageTracker()
+
+        metrics = tracker.get_agent_metrics()
+
+        assert metrics is None
+
+    def test_stage_summary_includes_model(self):
+        """Test that stage summary includes model information."""
+        tracker = UsageTracker()
+
+        metadata = {
+            "gpt-4o-mini": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            }
+        }
+
+        tracker.track_call("answer_generation", "openai/gpt-4o-mini", metadata)
+
+        summary = tracker.get_stage_summary("answer_generation")
+
+        assert "model" in summary
+        # Model name comes from metadata dict key
+        assert summary["model"] == "gpt-4o-mini"

--- a/tests/test_verification/test_generate_answer_stage.py
+++ b/tests/test_verification/test_generate_answer_stage.py
@@ -70,9 +70,9 @@ class TestGenerateAnswerStage:
         mock_llm = MagicMock()
         mock_init_llm.return_value = mock_llm
 
-        # Mock LLM response
+        # Mock LLM response (4-tuple: response, recursion_limit_reached, usage_metadata, agent_metrics)
         mock_response = AIMessage(content="The answer is 4")
-        mock_invoke.return_value = (mock_response, False)
+        mock_invoke.return_value = (mock_response, False, {}, None)
 
         # Execute stage
         stage = GenerateAnswerStage()
@@ -110,9 +110,9 @@ class TestGenerateAnswerStage:
         mock_llm = MagicMock()
         mock_init_llm.return_value = mock_llm
 
-        # Mock LLM response
+        # Mock LLM response (4-tuple: response, recursion_limit_reached, usage_metadata, agent_metrics)
         mock_response = AIMessage(content="Answer from MCP agent")
-        mock_invoke.return_value = (mock_response, False)
+        mock_invoke.return_value = (mock_response, False, {}, None)
 
         # Execute stage
         stage = GenerateAnswerStage()
@@ -148,8 +148,9 @@ class TestGenerateAnswerStage:
         mock_init_llm.return_value = mock_llm
 
         # Mock successful response (retry logic is in _invoke_llm_with_retry)
+        # 4-tuple: response, recursion_limit_reached, usage_metadata, agent_metrics
         mock_response = AIMessage(content="Success after retry")
-        mock_invoke.return_value = (mock_response, False)
+        mock_invoke.return_value = (mock_response, False, {}, None)
 
         # Execute stage
         stage = GenerateAnswerStage()
@@ -181,8 +182,9 @@ class TestGenerateAnswerStage:
         mock_init_llm.return_value = mock_llm
 
         # Mock response with recursion limit flag
+        # 4-tuple: response, recursion_limit_reached, usage_metadata, agent_metrics
         mock_response = AIMessage(content="Partial response before recursion limit")
-        mock_invoke.return_value = (mock_response, True)  # recursion_limit_reached = True
+        mock_invoke.return_value = (mock_response, True, {}, None)  # recursion_limit_reached = True
 
         # Execute stage
         stage = GenerateAnswerStage()
@@ -225,9 +227,9 @@ class TestGenerateAnswerStage:
         mock_llm = MagicMock()
         mock_init_llm.return_value = mock_llm
 
-        # Mock response
+        # Mock response (4-tuple: response, recursion_limit_reached, usage_metadata, agent_metrics)
         mock_response = AIMessage(content="Answer using few-shot examples")
-        mock_invoke.return_value = (mock_response, False)
+        mock_invoke.return_value = (mock_response, False, {}, None)
 
         # Execute stage
         stage = GenerateAnswerStage()

--- a/tests/test_verification/test_usage_tracking_stages.py
+++ b/tests/test_verification/test_usage_tracking_stages.py
@@ -1,0 +1,588 @@
+"""Integration tests for usage tracking across verification stages.
+
+Tests verify that:
+1. Each stage properly captures usage metadata from LLM calls
+2. UsageTracker is passed through context correctly
+3. Agent metrics are tracked when MCP agents are used
+4. End-to-end pipeline aggregates usage correctly
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+from langchain_core.messages import AIMessage
+
+from karenina.benchmark.verification.stage import VerificationContext
+from karenina.benchmark.verification.stages.abstention_check import AbstentionCheckStage
+from karenina.benchmark.verification.stages.generate_answer import GenerateAnswerStage
+from karenina.benchmark.verification.stages.parse_template import ParseTemplateStage
+from karenina.benchmark.verification.stages.rubric_evaluation import RubricEvaluationStage
+from karenina.benchmark.verification.utils import UsageTracker
+from karenina.schemas.domain import BaseAnswer, Rubric, RubricTrait
+
+
+class TestGenerateAnswerStageUsageTracking:
+    """Test usage tracking in GenerateAnswerStage."""
+
+    @patch("karenina.benchmark.verification.stages.generate_answer._invoke_llm_with_retry")
+    @patch("karenina.benchmark.verification.stages.generate_answer.init_chat_model_unified")
+    def test_tracks_usage_metadata(
+        self,
+        mock_init_llm: Mock,
+        mock_invoke: Mock,
+        basic_context: VerificationContext,
+    ) -> None:
+        """Test that GenerateAnswerStage tracks usage metadata."""
+
+        # Set up Answer artifact
+        class MockAnswer(BaseAnswer):
+            def verify(self) -> bool:
+                return True
+
+        basic_context.set_artifact("Answer", MockAnswer)
+
+        # Mock LLM initialization
+        mock_llm = MagicMock()
+        mock_init_llm.return_value = mock_llm
+
+        # Mock LLM response with usage metadata (4-tuple)
+        mock_response = AIMessage(content="The answer is 4")
+        usage_metadata = {
+            "gpt-4.1-mini": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+                "input_token_details": {"audio": 0, "cache_read": 0},
+                "output_token_details": {"audio": 0, "reasoning": 0},
+            }
+        }
+        mock_invoke.return_value = (mock_response, False, usage_metadata, None)
+
+        # Execute stage
+        stage = GenerateAnswerStage()
+        stage.execute(basic_context)
+
+        # Verify no error
+        assert basic_context.error is None
+
+        # Verify usage tracker was created and stored in context
+        assert basic_context.has_artifact("usage_tracker")
+        tracker = basic_context.get_artifact("usage_tracker")
+        assert isinstance(tracker, UsageTracker)
+
+        # Verify usage was tracked for answer_generation stage
+        summary = tracker.get_stage_summary("answer_generation")
+        assert summary is not None
+        assert summary["total_tokens"] == 150
+        assert summary["input_tokens"] == 100
+        assert summary["output_tokens"] == 50
+
+    @patch("karenina.benchmark.verification.stages.generate_answer._invoke_llm_with_retry")
+    @patch("karenina.benchmark.verification.stages.generate_answer.init_chat_model_unified")
+    def test_tracks_agent_metrics(
+        self,
+        mock_init_llm: Mock,
+        mock_invoke: Mock,
+        basic_context: VerificationContext,
+    ) -> None:
+        """Test that GenerateAnswerStage tracks agent metrics for MCP agents."""
+        # Configure context for MCP
+        basic_context.answering_model.mcp_urls_dict = {"test-server": "http://localhost:8000"}
+
+        # Set up Answer artifact
+        class MockAnswer(BaseAnswer):
+            def verify(self) -> bool:
+                return True
+
+        basic_context.set_artifact("Answer", MockAnswer)
+
+        # Mock LLM with MCP support
+        mock_llm = MagicMock()
+        mock_init_llm.return_value = mock_llm
+
+        # Mock LLM response with agent metrics (4-tuple)
+        mock_response = "Agent response after harmonization"
+        usage_metadata = {
+            "gpt-4.1-mini": {
+                "input_tokens": 200,
+                "output_tokens": 100,
+                "total_tokens": 300,
+            }
+        }
+        agent_metrics = {
+            "iterations": 3,
+            "tool_calls": 5,
+            "tools_used": ["mcp__brave_search", "mcp__read_resource"],
+        }
+        mock_invoke.return_value = (mock_response, False, usage_metadata, agent_metrics)
+
+        # Execute stage
+        stage = GenerateAnswerStage()
+        stage.execute(basic_context)
+
+        # Verify agent metrics were stored in UsageTracker
+        tracker = basic_context.get_artifact("usage_tracker")
+        assert tracker is not None
+        stored_metrics = tracker.get_agent_metrics()
+        assert stored_metrics is not None
+        assert stored_metrics == agent_metrics
+        assert stored_metrics["iterations"] == 3
+        assert stored_metrics["tool_calls"] == 5
+        assert "mcp__brave_search" in stored_metrics["tools_used"]
+
+
+class TestParseTemplateStageUsageTracking:
+    """Test usage tracking in ParseTemplateStage."""
+
+    @patch("karenina.benchmark.verification.stages.parse_template.init_chat_model_unified")
+    def test_tracks_usage_metadata_standard_parsing(
+        self,
+        mock_init_llm: Mock,
+        basic_context: VerificationContext,
+    ) -> None:
+        """Test that ParseTemplateStage tracks usage metadata for standard parsing."""
+
+        # Set up required artifacts
+        class MockAnswer(BaseAnswer):
+            result: int
+            correct: dict
+
+            def verify(self) -> bool:
+                return True
+
+        basic_context.set_artifact("RawAnswer", MockAnswer)
+        basic_context.set_artifact("Answer", MockAnswer)
+        basic_context.set_artifact("raw_llm_response", '{"result": 4, "correct": {"value": 4}}')
+
+        # Initialize usage tracker (as if coming from previous stage)
+        tracker = UsageTracker()
+        tracker.track_call(
+            "answer_generation",
+            "gpt-4.1-mini",
+            {
+                "gpt-4.1-mini": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "total_tokens": 150,
+                }
+            },
+        )
+        basic_context.set_artifact("usage_tracker", tracker)
+
+        # Mock parsing LLM
+        mock_llm = MagicMock()
+        mock_init_llm.return_value = mock_llm
+
+        # Mock parsing response with usage metadata callback
+        mock_parsed_response = AIMessage(content='{"result": 4, "correct": {"value": 4}}')
+        mock_llm.invoke.return_value = mock_parsed_response
+
+        # We need to mock the usage metadata callback
+        with patch("karenina.benchmark.verification.stages.parse_template.get_usage_metadata_callback") as mock_cb:
+            # Create a mock callback context manager
+            mock_cb_instance = MagicMock()
+            mock_cb_instance.usage_metadata = {
+                "gpt-4.1-mini": {
+                    "input_tokens": 50,
+                    "output_tokens": 30,
+                    "total_tokens": 80,
+                }
+            }
+            mock_cb.return_value.__enter__.return_value = mock_cb_instance
+            mock_cb.return_value.__exit__.return_value = None
+
+            # Execute stage
+            stage = ParseTemplateStage()
+            stage.execute(basic_context)
+
+        # Verify usage tracker was updated
+        tracker = basic_context.get_artifact("usage_tracker")
+        assert tracker is not None
+
+        # Verify parsing stage usage was tracked
+        parsing_summary = tracker.get_stage_summary("parsing")
+        assert parsing_summary is not None
+        assert parsing_summary["total_tokens"] == 80
+        assert parsing_summary["input_tokens"] == 50
+        assert parsing_summary["output_tokens"] == 30
+
+        # Verify total includes both stages
+        total_summary = tracker.get_total_summary()
+        assert total_summary["total"]["total_tokens"] == 230  # 150 + 80
+
+
+class TestRubricEvaluationStageUsageTracking:
+    """Test usage tracking in RubricEvaluationStage."""
+
+    @patch("karenina.benchmark.verification.stages.rubric_evaluation.RubricEvaluator")
+    def test_tracks_usage_metadata(
+        self,
+        mock_evaluator_class: Mock,
+        basic_context: VerificationContext,
+    ) -> None:
+        """Test that RubricEvaluationStage tracks usage metadata from rubric evaluation."""
+
+        # Set up required artifacts
+        basic_context.set_artifact("raw_llm_response", "The answer is 4")
+        basic_context.set_artifact("parsed_answer", {"result": 4})
+
+        # Create rubric with traits
+        rubric = Rubric(
+            traits=[
+                RubricTrait(
+                    name="Accuracy",
+                    description="Is the answer accurate?",
+                    kind="score",
+                    min_score=1,
+                    max_score=10,
+                ),
+            ],
+        )
+        basic_context.rubric = rubric
+
+        # Initialize usage tracker (as if coming from previous stages)
+        tracker = UsageTracker()
+        tracker.track_call(
+            "answer_generation",
+            "gpt-4.1-mini",
+            {"gpt-4.1-mini": {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}},
+        )
+        basic_context.set_artifact("usage_tracker", tracker)
+
+        # Mock rubric evaluator
+        mock_evaluator = MagicMock()
+        mock_evaluator_class.return_value = mock_evaluator
+
+        # Mock evaluate_rubric to return results with usage metadata (tuple)
+        rubric_results = {"Accuracy": 10}
+        usage_metadata_list = [
+            {
+                "gpt-4.1-mini": {
+                    "input_tokens": 80,
+                    "output_tokens": 20,
+                    "total_tokens": 100,
+                }
+            }
+        ]
+        mock_evaluator.evaluate_rubric.return_value = (rubric_results, usage_metadata_list)
+        mock_evaluator.evaluate_metric_traits.return_value = ({}, [])
+
+        # Execute stage
+        stage = RubricEvaluationStage()
+        stage.execute(basic_context)
+
+        # Verify usage tracker was updated
+        tracker = basic_context.get_artifact("usage_tracker")
+        assert tracker is not None
+
+        # Verify rubric evaluation usage was tracked
+        rubric_summary = tracker.get_stage_summary("rubric_evaluation")
+        assert rubric_summary is not None
+        assert rubric_summary["total_tokens"] == 100
+        assert rubric_summary["input_tokens"] == 80
+        assert rubric_summary["output_tokens"] == 20
+
+        # Verify total includes all stages
+        total_summary = tracker.get_total_summary()
+        assert total_summary["total"]["total_tokens"] == 250  # 150 + 100
+
+
+class TestAbstentionCheckStageUsageTracking:
+    """Test usage tracking in AbstentionCheckStage."""
+
+    @patch("karenina.benchmark.verification.stages.abstention_check.detect_abstention")
+    def test_tracks_usage_metadata(
+        self,
+        mock_detect: Mock,
+        basic_context: VerificationContext,
+    ) -> None:
+        """Test that AbstentionCheckStage tracks usage metadata."""
+
+        # Enable abstention checking
+        basic_context.abstention_enabled = True
+
+        # Set up required artifacts
+        basic_context.set_artifact("raw_llm_response", "The answer is 4")
+
+        # Initialize usage tracker (as if coming from previous stages)
+        tracker = UsageTracker()
+        tracker.track_call(
+            "answer_generation",
+            "gpt-4.1-mini",
+            {"gpt-4.1-mini": {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}},
+        )
+        basic_context.set_artifact("usage_tracker", tracker)
+
+        # Mock detect_abstention to return 4-tuple with usage metadata
+        usage_metadata = {
+            "gpt-4.1-mini": {
+                "input_tokens": 40,
+                "output_tokens": 10,
+                "total_tokens": 50,
+            }
+        }
+        mock_detect.return_value = (False, True, "No abstention detected", usage_metadata)
+
+        # Execute stage
+        stage = AbstentionCheckStage()
+        stage.execute(basic_context)
+
+        # Verify usage tracker was updated
+        tracker = basic_context.get_artifact("usage_tracker")
+        assert tracker is not None
+
+        # Verify abstention check usage was tracked
+        abstention_summary = tracker.get_stage_summary("abstention_check")
+        assert abstention_summary is not None
+        assert abstention_summary["total_tokens"] == 50
+        assert abstention_summary["input_tokens"] == 40
+        assert abstention_summary["output_tokens"] == 10
+
+        # Verify total includes all stages
+        total_summary = tracker.get_total_summary()
+        assert total_summary["total"]["total_tokens"] == 200  # 150 + 50
+
+
+class TestEndToEndUsageTracking:
+    """Test end-to-end usage tracking through multiple stages."""
+
+    @patch("karenina.benchmark.verification.stages.abstention_check.detect_abstention")
+    @patch("karenina.benchmark.verification.stages.rubric_evaluation.RubricEvaluator")
+    @patch("karenina.benchmark.verification.stages.parse_template.init_chat_model_unified")
+    @patch("karenina.benchmark.verification.stages.generate_answer._invoke_llm_with_retry")
+    @patch("karenina.benchmark.verification.stages.generate_answer.init_chat_model_unified")
+    def test_usage_tracking_across_all_stages(
+        self,
+        mock_init_answer_llm: Mock,
+        mock_invoke: Mock,
+        mock_init_parsing_llm: Mock,
+        mock_evaluator_class: Mock,
+        mock_detect_abstention: Mock,
+        basic_context: VerificationContext,
+    ) -> None:
+        """Test that usage metadata is tracked and aggregated across all stages."""
+
+        # Enable all features
+        basic_context.abstention_enabled = True
+        rubric = Rubric(
+            traits=[
+                RubricTrait(
+                    name="Accuracy",
+                    description="Is the answer accurate?",
+                    kind="score",
+                    min_score=1,
+                    max_score=10,
+                ),
+            ],
+        )
+        basic_context.rubric = rubric
+
+        # Set up Answer artifact
+        class MockAnswer(BaseAnswer):
+            result: int
+            correct: dict
+
+            def verify(self) -> bool:
+                return True
+
+        basic_context.set_artifact("Answer", MockAnswer)
+
+        # === Stage 1: GenerateAnswer ===
+        mock_answer_llm = MagicMock()
+        mock_init_answer_llm.return_value = mock_answer_llm
+
+        mock_response = AIMessage(content="The answer is 4")
+        answer_usage = {
+            "gpt-4.1-mini": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            }
+        }
+        mock_invoke.return_value = (mock_response, False, answer_usage, None)
+
+        generate_stage = GenerateAnswerStage()
+        generate_stage.execute(basic_context)
+
+        # Verify tracker was created
+        assert basic_context.has_artifact("usage_tracker")
+        tracker = basic_context.get_artifact("usage_tracker")
+        assert tracker.get_stage_summary("answer_generation") is not None
+
+        # === Stage 2: ParseTemplate ===
+        basic_context.set_artifact("RawAnswer", MockAnswer)
+        basic_context.set_artifact("raw_llm_response", '{"result": 4, "correct": {"value": 4}}')
+
+        mock_parsing_llm = MagicMock()
+        mock_init_parsing_llm.return_value = mock_parsing_llm
+        mock_parsing_response = AIMessage(content='{"result": 4, "correct": {"value": 4}}')
+        mock_parsing_llm.invoke.return_value = mock_parsing_response
+
+        with patch("karenina.benchmark.verification.stages.parse_template.get_usage_metadata_callback") as mock_cb:
+            mock_cb_instance = MagicMock()
+            mock_cb_instance.usage_metadata = {
+                "gpt-4.1-mini": {
+                    "input_tokens": 50,
+                    "output_tokens": 30,
+                    "total_tokens": 80,
+                }
+            }
+            mock_cb.return_value.__enter__.return_value = mock_cb_instance
+            mock_cb.return_value.__exit__.return_value = None
+
+            parse_stage = ParseTemplateStage()
+            parse_stage.execute(basic_context)
+
+        # Verify parsing was tracked
+        tracker = basic_context.get_artifact("usage_tracker")
+        assert tracker.get_stage_summary("parsing") is not None
+
+        # === Stage 3: RubricEvaluation ===
+        basic_context.set_artifact("parsed_answer", {"result": 4})
+
+        mock_evaluator = MagicMock()
+        mock_evaluator_class.return_value = mock_evaluator
+        rubric_results = {"Accuracy": 10}
+        rubric_usage = [
+            {
+                "gpt-4.1-mini": {
+                    "input_tokens": 80,
+                    "output_tokens": 20,
+                    "total_tokens": 100,
+                }
+            }
+        ]
+        mock_evaluator.evaluate_rubric.return_value = (rubric_results, rubric_usage)
+        mock_evaluator.evaluate_metric_traits.return_value = ({}, [])
+
+        rubric_stage = RubricEvaluationStage()
+        rubric_stage.execute(basic_context)
+
+        # Verify rubric evaluation was tracked
+        tracker = basic_context.get_artifact("usage_tracker")
+        assert tracker.get_stage_summary("rubric_evaluation") is not None
+
+        # === Stage 4: AbstentionCheck ===
+        abstention_usage = {
+            "gpt-4.1-mini": {
+                "input_tokens": 40,
+                "output_tokens": 10,
+                "total_tokens": 50,
+            }
+        }
+        mock_detect_abstention.return_value = (False, True, "No abstention", abstention_usage)
+
+        abstention_stage = AbstentionCheckStage()
+        abstention_stage.execute(basic_context)
+
+        # === Verify Final Aggregation ===
+        tracker = basic_context.get_artifact("usage_tracker")
+        total_summary = tracker.get_total_summary()
+
+        # Verify all stages are present
+        assert "answer_generation" in total_summary
+        assert "parsing" in total_summary
+        assert "rubric_evaluation" in total_summary
+        assert "abstention_check" in total_summary
+        assert "total" in total_summary
+
+        # Verify totals are correct
+        assert total_summary["answer_generation"]["total_tokens"] == 150
+        assert total_summary["parsing"]["total_tokens"] == 80
+        assert total_summary["rubric_evaluation"]["total_tokens"] == 100
+        assert total_summary["abstention_check"]["total_tokens"] == 50
+
+        # Verify grand total
+        assert total_summary["total"]["total_tokens"] == 380  # 150 + 80 + 100 + 50
+        assert total_summary["total"]["input_tokens"] == 270  # 100 + 50 + 80 + 40
+        assert total_summary["total"]["output_tokens"] == 110  # 50 + 30 + 20 + 10
+
+    @patch("karenina.benchmark.verification.stages.generate_answer._invoke_llm_with_retry")
+    @patch("karenina.benchmark.verification.stages.generate_answer.init_chat_model_unified")
+    def test_usage_tracking_with_mcp_agent(
+        self,
+        mock_init_llm: Mock,
+        mock_invoke: Mock,
+        basic_context: VerificationContext,
+    ) -> None:
+        """Test that agent metrics are properly tracked in end-to-end flow."""
+        # Configure context for MCP
+        basic_context.answering_model.mcp_urls_dict = {"test-server": "http://localhost:8000"}
+
+        # Set up Answer artifact
+        class MockAnswer(BaseAnswer):
+            def verify(self) -> bool:
+                return True
+
+        basic_context.set_artifact("Answer", MockAnswer)
+
+        # Mock LLM with MCP support
+        mock_llm = MagicMock()
+        mock_init_llm.return_value = mock_llm
+
+        # Mock agent response with both usage and agent metrics
+        mock_response = "Agent response"
+        usage_metadata = {
+            "gpt-4.1-mini": {
+                "input_tokens": 200,
+                "output_tokens": 150,
+                "total_tokens": 350,
+            }
+        }
+        agent_metrics = {
+            "iterations": 4,
+            "tool_calls": 8,
+            "tools_used": ["mcp__brave_search", "mcp__read_resource", "mcp__write_file"],
+        }
+        mock_invoke.return_value = (mock_response, False, usage_metadata, agent_metrics)
+
+        # Execute stage
+        stage = GenerateAnswerStage()
+        stage.execute(basic_context)
+
+        # Verify both usage and agent metrics were tracked
+        tracker = basic_context.get_artifact("usage_tracker")
+        assert tracker is not None
+
+        # Verify usage tracking
+        summary = tracker.get_stage_summary("answer_generation")
+        assert summary["total_tokens"] == 350
+
+        # Verify agent metrics were stored separately
+        stored_agent_metrics = tracker.get_agent_metrics()
+        assert stored_agent_metrics is not None
+        assert stored_agent_metrics["iterations"] == 4
+        assert stored_agent_metrics["tool_calls"] == 8
+        assert len(stored_agent_metrics["tools_used"]) == 3
+
+    def test_usage_tracker_created_even_without_prior_tracker(
+        self,
+        basic_context: VerificationContext,
+    ) -> None:
+        """Test that stages create UsageTracker if not present in context."""
+
+        # Set up minimal artifacts for AbstentionCheckStage
+        basic_context.abstention_enabled = True
+        basic_context.set_artifact("raw_llm_response", "The answer is 4")
+
+        # Ensure no tracker exists
+        basic_context.artifacts.pop("usage_tracker", None)
+
+        with patch("karenina.benchmark.verification.stages.abstention_check.detect_abstention") as mock_detect:
+            usage_metadata = {
+                "gpt-4.1-mini": {
+                    "input_tokens": 40,
+                    "output_tokens": 10,
+                    "total_tokens": 50,
+                }
+            }
+            mock_detect.return_value = (False, True, "No abstention", usage_metadata)
+
+            # Execute stage
+            stage = AbstentionCheckStage()
+            stage.execute(basic_context)
+
+            # Verify tracker was created
+            assert basic_context.has_artifact("usage_tracker")
+            tracker = basic_context.get_artifact("usage_tracker")
+            assert isinstance(tracker, UsageTracker)
+            assert tracker.get_stage_summary("abstention_check") is not None


### PR DESCRIPTION
# feat(verification): implement comprehensive LLM usage tracking and agent metrics

## Summary

Adds comprehensive LLM usage tracking across all verification stages, capturing token consumption per stage and agent execution metrics for MCP-based agents. This enables cost analysis, performance monitoring, and optimization insights for evaluation runs. The tracked metadata is exposed in verification results and can be exported for further analysis.

## Changes Made

### Core Usage Tracking Infrastructure
- **New `UsageTracker` class** (`src/karenina/benchmark/verification/utils/usage_tracker.py`):
  - Tracks token usage per verification stage (answer_generation, parsing, rubric_evaluation, abstention_check)
  - Aggregates usage metadata with detailed token breakdowns (input/output totals, cache hits, reasoning tokens)
  - Tracks agent execution metrics (iterations, tool calls, tools used) for MCP agents
  - Provides stage-level and total summaries

- **Enhanced `_invoke_llm_with_retry` function** (`src/karenina/benchmark/verification/verification_utils.py`):
  - Returns 4-tuple: `(response, recursion_limit_reached, usage_metadata, agent_metrics)`
  - Captures usage metadata via LangChain's `get_usage_metadata_callback()` for both standard LLM calls and async agent invocations
  - Extracts agent metrics (iterations, tool calls, tools used) from LangGraph agent responses

### Verification Stage Integration
- **GenerateAnswerStage** (`src/karenina/benchmark/verification/stages/generate_answer.py`):
  - Initializes `UsageTracker` and tracks answer generation calls
  - Captures agent metrics for MCP agents
  - Stores tracker in context for downstream stages

- **ParseTemplateStage** (`src/karenina/benchmark/verification/stages/parse_template.py`):
  - Retrieves or initializes `UsageTracker` from context
  - Tracks parsing calls with usage metadata callback
  - Continues tracking chain for subsequent stages

- **RubricEvaluationStage** (`src/karenina/benchmark/verification/stages/rubric_evaluation.py`):
  - Enhanced `RubricEvaluator.evaluate_rubric()` to return usage metadata list
  - Enhanced `RubricEvaluator.evaluate_metric_traits()` to return usage metadata list
  - Tracks all rubric evaluation calls (standard traits and metric traits)

- **AbstentionCheckStage** (`src/karenina/benchmark/verification/stages/abstention_check.py`):
  - Enhanced `detect_abstention()` to return usage metadata
  - Tracks abstention detection calls

- **FinalizeResultStage** (`src/karenina/benchmark/verification/stages/finalize_result.py`):
  - Aggregates usage metadata from tracker into `VerificationResult`
  - Adds `usage_metadata` and `agent_metrics` fields to result schema
  - Logs usage summary for monitoring

### Schema Updates
- **VerificationResult schema** (`src/karenina/schemas/workflow/verification.py`):
  - Added `usage_metadata: Optional[Dict[str, Dict[str, Any]]]` - per-stage token usage breakdown
  - Added `agent_metrics: Optional[Dict[str, Any]]` - agent execution metrics (iterations, tool_calls, tools_used)

### Storage & Export
- **Storage operations** (`src/karenina/storage/operations.py`):
  - Updated to persist `usage_metadata` and `agent_metrics` fields
  - No schema migration required (new optional fields)

- **Exporter** (`src/karenina/benchmark/exporter.py`):
  - Includes `usage_metadata` and `agent_metrics` in exported JSON/JSONLD

### Refactoring
- Moved `_invoke_llm_with_retry` from `parsing.py` to `verification_utils.py` for shared usage
- Updated import in `parsing.py` to reference shared utility

### Testing
- **New test suite** (`tests/test_usage_tracking.py`):
  - Unit tests for `UsageTracker` class (325 lines)
  - Tests aggregation, multiple stages, agent metrics, edge cases

- **New integration tests** (`tests/test_verification/test_usage_tracking_stages.py`):
  - End-to-end usage tracking across all verification stages (588 lines)
  - Tests UsageTracker propagation through context
  - Tests agent metrics extraction
  - Tests aggregate summaries

- **Updated existing tests**:
  - `tests/test_verification/test_generate_answer_stage.py` - Updated mocks for 4-tuple return value
  - `tests/storage/test_operations.py` - Added tests for usage metadata persistence (322 lines)
  - `tests/test_exporter.py` - Added tests for usage metadata export (335 lines)

## Testing

### Unit Tests
- All `UsageTracker` methods tested (aggregation, edge cases, agent metrics)
- `_invoke_llm_with_retry` signature and behavior verified

### Integration Tests
- End-to-end tracking across full verification pipeline
- UsageTracker context propagation verified
- Agent metrics extraction validated for MCP agents
- Storage persistence and export verified

### Manual Testing
1. Run verification with standard LLM: verify `usage_metadata` populated per stage
2. Run verification with MCP agent: verify both `usage_metadata` and `agent_metrics` populated
3. Export results: verify usage data included in JSON/JSONLD
4. Check database: verify usage fields persisted correctly

## Cross-References for Multi-Package Changes

### Related PRs
This change adds LLM usage tracking across the Karenina suite:
- [ ] #50 - Adds usage tracking backend implementation in karenina (this PR)
- [ ] biocypher/karenina-gui#47 - Adds usage metrics visualization in karenina-gui

**Merge order:** This PR should be merged first, as karenina-gui depends on the schema changes and data structure defined here.

## Additional Context

### Breaking Changes
- `_invoke_llm_with_retry` signature changed from 2-tuple to 4-tuple return value
  - **Migration:** All callers updated in this PR; external code using this function must be updated
- `RubricEvaluator.evaluate_rubric()` and `evaluate_metric_traits()` now return tuples with usage metadata
  - **Migration:** All callers updated in this PR; external evaluators must be updated

### Performance Implications
- Minimal overhead: Usage tracking uses LangChain's callback system (no additional LLM calls)
- Token counting happens synchronously during LLM invocation
- Agent metrics extraction parses message history (negligible for typical message counts)

### Impact on Existing Evaluation Datasets
- New optional fields (`usage_metadata`, `agent_metrics`) - backward compatible
- Existing verification results without usage data will have `None` for these fields
- No migration needed for existing data

