### PR TITLE
feat(llm): add OpenAI Endpoint interface for custom API endpoints

### DIFF
--- a/src/karenina/benchmark/verification/stages/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/generate_answer.py
@@ -97,6 +97,8 @@ class GenerateAnswerStage(BaseVerificationStage):
         # Build model string for result
         if answering_model.interface == "openrouter":
             answering_model_str = answering_model.model_name
+        elif answering_model.interface == "openai_endpoint":
+            answering_model_str = f"endpoint/{answering_model.model_name}"
         else:
             answering_model_str = f"{answering_model.model_provider}/{answering_model.model_name}"
         context.set_artifact("answering_model_str", answering_model_str)
@@ -128,6 +130,23 @@ class GenerateAnswerStage(BaseVerificationStage):
                     temperature=answering_model.temperature,
                     interface=answering_model.interface,
                     question_hash=context.question_id,
+                    mcp_urls_dict=answering_model.mcp_urls_dict,
+                    mcp_tool_filter=answering_model.mcp_tool_filter,
+                )
+            elif answering_model.interface == "openai_endpoint":
+                # Require endpoint configuration
+                if not answering_model.endpoint_base_url:
+                    raise ValueError("endpoint_base_url is required for openai_endpoint interface")
+                if not answering_model.endpoint_api_key:
+                    raise ValueError("endpoint_api_key is required for openai_endpoint interface")
+
+                answering_llm = init_chat_model_unified(
+                    model=answering_model.model_name,
+                    provider=answering_model.model_provider,
+                    temperature=answering_model.temperature,
+                    interface=answering_model.interface,
+                    endpoint_base_url=answering_model.endpoint_base_url,
+                    endpoint_api_key=answering_model.endpoint_api_key.get_secret_value(),
                     mcp_urls_dict=answering_model.mcp_urls_dict,
                     mcp_tool_filter=answering_model.mcp_tool_filter,
                 )

--- a/src/karenina/schemas/workflow/models.py
+++ b/src/karenina/schemas/workflow/models.py
@@ -2,13 +2,14 @@
 
 from typing import Any, Literal, cast
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 
 # Interface constants
 INTERFACE_OPENROUTER = "openrouter"
 INTERFACE_MANUAL = "manual"
 INTERFACE_LANGCHAIN = "langchain"
-INTERFACES_NO_PROVIDER_REQUIRED = [INTERFACE_OPENROUTER, INTERFACE_MANUAL]
+INTERFACE_OPENAI_ENDPOINT = "openai_endpoint"
+INTERFACES_NO_PROVIDER_REQUIRED = [INTERFACE_OPENROUTER, INTERFACE_MANUAL, INTERFACE_OPENAI_ENDPOINT]
 
 
 class QuestionFewShotConfig(BaseModel):
@@ -357,8 +358,11 @@ class ModelConfig(BaseModel):
     model_provider: str
     model_name: str
     temperature: float = 0.1
-    interface: Literal["langchain", "openrouter", "manual"] = "langchain"
+    interface: Literal["langchain", "openrouter", "manual", "openai_endpoint"] = "langchain"
     system_prompt: str
     max_retries: int = 2  # Optional max retries for template generation
     mcp_urls_dict: dict[str, str] | None = None  # Optional MCP server URLs
     mcp_tool_filter: list[str] | None = None  # Optional list of MCP tools to include
+    # OpenAI Endpoint configuration (for openai_endpoint interface)
+    endpoint_base_url: str | None = None  # Custom endpoint base URL
+    endpoint_api_key: SecretStr | None = None  # User-provided API key


### PR DESCRIPTION
## Summary

This PR implements the OpenAI Endpoint interface, enabling users to connect to custom OpenAI-compatible API endpoints such as vLLM, Ollama, Azure OpenAI, and LocalAI. This extends Karenina's LLM interface support beyond LangChain providers and OpenRouter.

**Part 1 of 3** in the OpenAI Endpoint feature implementation:
- **Part 1: This PR** - Backend implementation
- Part 2: [karenina-server PR #25](https://github.com/biocypher/karenina-server/pull/25) - Middleware/API layer
- Part 3: [karenina-gui PR #48](https://github.com/biocypher/karenina-gui/pull/48) - Frontend implementation

## Changes Made

### LLM Interface ([infrastructure/llm/interface.py](src/karenina/infrastructure/llm/interface.py))

**New ChatOpenAIEndpoint Class**:
- Extends LangChain's `ChatOpenAI` with custom endpoint support
- **Security**: Requires explicit API key (no environment variable fallback)
- **Rationale**: Prevents accidental use of default OpenAI keys when user intends to connect to local endpoints
- Overrides `lc_secrets` property to return empty dict (disables env reading)

```python
class ChatOpenAIEndpoint(ChatOpenAI):
    """ChatOpenAI wrapper for user-provided custom endpoints.
    Unlike ChatOpenRouter, this does NOT automatically read from environment.
    API key must be explicitly provided by the user.
    """
    openai_api_key: SecretStr | None = Field(alias="api_key", default=None)

    @property
    def lc_secrets(self) -> dict[str, str]:
        # Return empty dict - we don't want LangChain trying to read from env
        return {}
```

**Updated init_chat_model_unified()**:
- Added `endpoint_base_url` and `endpoint_api_key` parameters
- Added `openai_endpoint` to interface options
- Routes to `ChatOpenAIEndpoint` when `interface="openai_endpoint"`
- Validates that API key is provided (raises ValueError if missing)

### Schema Updates ([schemas/workflow/models.py](src/karenina/schemas/workflow/models.py))

**ModelConfig Changes**:
- Extended interface Literal: `"langchain" | "openrouter" | "manual" | "openai_endpoint"`
- Added `endpoint_base_url: str | None` field (required for openai_endpoint)
- Added `endpoint_api_key: SecretStr | None` field (required for openai_endpoint)
- Updated `INTERFACES_NO_PROVIDER_REQUIRED` constant to include `"openai_endpoint"`

**Field Usage by Interface**:
- `langchain`: Uses `model_provider` and `model_name`
- `openrouter`: Uses `model_name` only
- `openai_endpoint`: Uses `endpoint_base_url`, `endpoint_api_key`, and `model_name`
- `manual`: No LLM fields (manual trace upload)

### Verification Stage ([benchmark/stages/verify.py](src/karenina/benchmark/stages/verify.py))

**Updated _initialize_models_for_run()**:
- Added handling for `openai_endpoint` interface in model initialization
- Passes `endpoint_base_url` and `endpoint_api_key` to `init_chat_model_unified()`
- Maintains validation that required fields are present

```python
elif model_config.interface == "openai_endpoint":
    # Validate required fields
    if not model_config.endpoint_base_url:
        raise ValueError(f"endpoint_base_url is required for openai_endpoint interface")
    if not model_config.endpoint_api_key:
        raise ValueError(f"endpoint_api_key is required for openai_endpoint interface")
    
    # Initialize with endpoint configuration
    chat_model = init_chat_model_unified(
        interface="openai_endpoint",
        model_name=model_config.model_name,
        temperature=model_config.temperature,
        endpoint_base_url=model_config.endpoint_base_url,
        endpoint_api_key=model_config.endpoint_api_key.get_secret_value(),
    )
```

## Testing

### Unit Tests
Added comprehensive tests in [tests/infrastructure/llm/test_interface.py](tests/infrastructure/llm/test_interface.py):

**Test Coverage**:
1. `test_init_chat_model_unified_openai_endpoint_success()` - Successful initialization with all required fields
2. `test_init_chat_model_unified_openai_endpoint_missing_api_key()` - Validates error when API key is missing
3. `test_init_chat_model_unified_openai_endpoint_missing_base_url()` - Validates error when base URL is missing
4. `test_chat_openai_endpoint_no_env_fallback()` - Confirms env variables are NOT used as fallback

**Key Test Validations**:
- ChatOpenAIEndpoint requires explicit `openai_api_key` parameter
- Raises `ValueError` with clear message when API key is missing
- Does not fall back to `OPENAI_API_KEY` environment variable
- Properly initializes with custom `base_url`

### Manual Testing
1. Configure a local vLLM or Ollama server
2. Use OpenAI Endpoint interface with custom URL (e.g., `http://localhost:11434/v1`)
3. Provide API key explicitly
4. Run verification to confirm model initialization and API calls work correctly

## Use Cases

**Supported Endpoints**:
- **vLLM**: Self-hosted LLM serving with OpenAI-compatible API
- **Ollama**: Local LLM deployment (use `/v1` suffix in URL)
- **Azure OpenAI**: Microsoft's hosted OpenAI models with custom endpoints
- **LocalAI**: OpenAI-compatible API for local models
- **Any OpenAI-compatible server**: Custom deployments following OpenAI API spec

**Example Configuration**:
```python
ModelConfig(
    interface="openai_endpoint",
    endpoint_base_url="http://localhost:11434/v1",
    endpoint_api_key=SecretStr("my-custom-key"),
    model_name="llama2",
    temperature=0.0,
)
```

## Security Considerations

**API Key Handling**:
- Uses Pydantic's `SecretStr` type to prevent accidental logging
- No environment variable fallback (explicit-only)
- Frontend stores API key in browser localStorage (not server-side)
- Server only stores/validates the base URL

**Why No Environment Fallback?**
- Users might have `OPENAI_API_KEY` set for actual OpenAI usage
- Prevents accidental charges to OpenAI when user meant to use local endpoint
- Forces explicit configuration, reducing confusion and errors

## Related PRs

This is the first PR in the OpenAI Endpoint feature implementation:
- ✅ **This PR** - Backend `ChatOpenAIEndpoint` class and schema updates (karenina)
- ⏳ [#25](https://github.com/biocypher/karenina-server/pull/25) - Middleware configuration API and validation (karenina-server)
- ⏳ [#48](https://github.com/biocypher/karenina-gui/pull/48) - Frontend UI components and state management (karenina-gui)

**Merge Order**: This PR → #25 → #48

All three PRs must be merged for the feature to be fully functional.

## Breaking Changes

None - this is additive functionality.

## Additional Context

**Future Enhancements**:
- Add endpoint health checks before verification runs
- Support for additional authentication methods (bearer tokens, custom headers)
- Endpoint discovery/validation in the GUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>