### PR TITLE
feat(model): add extra_kwargs to ModelConfig for vendor-specific parameters

### DIFF
--- a/src/karenina/benchmark/verification/evaluators/abstention_checker.py
+++ b/src/karenina/benchmark/verification/evaluators/abstention_checker.py
@@ -132,12 +132,19 @@ def detect_abstention(
             # Note: model_name is guaranteed non-None by ModelConfig validator
             assert parsing_model.model_name is not None, "model_name must not be None"
 
-            llm = init_chat_model_unified(
-                model=parsing_model.model_name,
-                provider=parsing_model.model_provider,
-                temperature=0.0,  # Use temperature 0 for consistent detection
-                interface=parsing_model.interface,
-            )
+            # Build kwargs for model initialization
+            model_kwargs: dict[str, Any] = {
+                "model": parsing_model.model_name,
+                "provider": parsing_model.model_provider,
+                "temperature": 0.0,  # Use temperature 0 for consistent detection
+                "interface": parsing_model.interface,
+            }
+
+            # Add any extra kwargs if provided (e.g., vendor-specific API keys)
+            if parsing_model.extra_kwargs:
+                model_kwargs.update(parsing_model.extra_kwargs)
+
+            llm = init_chat_model_unified(**model_kwargs)
 
             # Construct the prompt
             user_prompt = ABSTENTION_DETECTION_USER.format(question=question_text, response=raw_llm_response)

--- a/src/karenina/benchmark/verification/evaluators/rubric_evaluator.py
+++ b/src/karenina/benchmark/verification/evaluators/rubric_evaluator.py
@@ -53,12 +53,19 @@ class RubricEvaluator:
         self.callable_registry = callable_registry or {}
 
         try:
-            self.llm = init_chat_model_unified(
-                model=model_config.model_name,
-                provider=model_config.model_provider,
-                temperature=model_config.temperature,
-                interface=model_config.interface,
-            )
+            # Build kwargs for model initialization
+            model_kwargs: dict[str, Any] = {
+                "model": model_config.model_name,
+                "provider": model_config.model_provider,
+                "temperature": model_config.temperature,
+                "interface": model_config.interface,
+            }
+
+            # Add any extra kwargs if provided (e.g., vendor-specific API keys)
+            if model_config.extra_kwargs:
+                model_kwargs.update(model_config.extra_kwargs)
+
+            self.llm = init_chat_model_unified(**model_kwargs)
         except Exception as e:
             raise RuntimeError(f"Failed to initialize LLM for rubric evaluation: {e}") from e
 

--- a/src/karenina/benchmark/verification/tools/embedding_check.py
+++ b/src/karenina/benchmark/verification/tools/embedding_check.py
@@ -213,12 +213,19 @@ def check_semantic_equivalence(
         # Note: model_name is guaranteed non-None by ModelConfig validator
         assert parsing_model.model_name is not None, "model_name must not be None"
 
-        parsing_llm = init_chat_model_unified(
-            model=parsing_model.model_name,
-            provider=parsing_model.model_provider,
-            temperature=parsing_model.temperature,
-            interface=parsing_model.interface,
-        )
+        # Build kwargs for model initialization
+        model_kwargs: dict[str, Any] = {
+            "model": parsing_model.model_name,
+            "provider": parsing_model.model_provider,
+            "temperature": parsing_model.temperature,
+            "interface": parsing_model.interface,
+        }
+
+        # Add any extra kwargs if provided (e.g., vendor-specific API keys)
+        if parsing_model.extra_kwargs:
+            model_kwargs.update(parsing_model.extra_kwargs)
+
+        parsing_llm = init_chat_model_unified(**model_kwargs)
 
         # Convert data to readable strings
         gt_text = _convert_to_comparable_string(ground_truth_data)

--- a/src/karenina/domain/answers/generator.py
+++ b/src/karenina/domain/answers/generator.py
@@ -239,7 +239,7 @@ def _build_chain(stage: str, config: "ModelConfig") -> Any:
     )
 
     # Use karenina's unified model interface
-    model_params = {
+    model_params: dict[str, Any] = {
         "model": config.model_name,
         "provider": config.model_provider,
         "interface": config.interface,
@@ -254,9 +254,13 @@ def _build_chain(stage: str, config: "ModelConfig") -> Any:
             if hasattr(config.endpoint_api_key, "get_secret_value"):
                 model_params["endpoint_api_key"] = config.endpoint_api_key.get_secret_value()
             else:
-                model_params["endpoint_api_key"] = config.endpoint_api_key  # type: ignore[assignment]
+                model_params["endpoint_api_key"] = config.endpoint_api_key
 
-    model = init_chat_model_unified(**model_params)  # type: ignore[arg-type]
+    # Add any extra kwargs if provided (e.g., vendor-specific API keys)
+    if config.extra_kwargs:
+        model_params.update(config.extra_kwargs)
+
+    model = init_chat_model_unified(**model_params)
 
     return prompt | model | parser
 
@@ -297,7 +301,7 @@ def _generate_with_retry(
                     ]
                 )
 
-                model_params = {
+                model_params: dict[str, Any] = {
                     "model": config.model_name,
                     "provider": config.model_provider,
                     "interface": config.interface,
@@ -312,9 +316,13 @@ def _generate_with_retry(
                         if hasattr(config.endpoint_api_key, "get_secret_value"):
                             model_params["endpoint_api_key"] = config.endpoint_api_key.get_secret_value()
                         else:
-                            model_params["endpoint_api_key"] = config.endpoint_api_key  # type: ignore[assignment]
+                            model_params["endpoint_api_key"] = config.endpoint_api_key
 
-                model = init_chat_model_unified(**model_params)  # type: ignore[arg-type]
+                # Add any extra kwargs if provided (e.g., vendor-specific API keys)
+                if config.extra_kwargs:
+                    model_params.update(config.extra_kwargs)
+
+                model = init_chat_model_unified(**model_params)
 
                 chain = prompt | model | parser
 

--- a/src/karenina/schemas/workflow/models.py
+++ b/src/karenina/schemas/workflow/models.py
@@ -369,6 +369,9 @@ class ModelConfig(BaseModel):
     # OpenAI Endpoint configuration (for openai_endpoint interface)
     endpoint_base_url: str | None = None  # Custom endpoint base URL
     endpoint_api_key: SecretStr | None = None  # User-provided API key
+    # Extra keyword arguments to pass to the underlying model interface
+    # Useful for passing vendor-specific API keys, custom parameters, etc.
+    extra_kwargs: dict[str, Any] | None = None
     # Manual interface configuration
     manual_traces: Any = Field(default=None, exclude=True)  # Excluded from serialization; type: ManualTraces | None
 

--- a/src/karenina/schemas/workflow/verification.py
+++ b/src/karenina/schemas/workflow/verification.py
@@ -391,6 +391,10 @@ class VerificationConfig(BaseModel):
         if "mcp_tool_filter" in model and model["mcp_tool_filter"]:
             sanitized["mcp_tool_filter"] = model["mcp_tool_filter"]
 
+        # Include extra_kwargs if present (vendor-specific API keys, custom parameters, etc.)
+        if "extra_kwargs" in model and model["extra_kwargs"]:
+            sanitized["extra_kwargs"] = model["extra_kwargs"]
+
         return sanitized
 
     @classmethod


### PR DESCRIPTION
## Summary

Adds support for passing vendor-specific API keys and custom parameters to model initialization through a new `extra_kwargs` field in `ModelConfig`. This enables users to configure provider-specific settings (e.g., Azure OpenAI API versions, custom headers) without modifying core configuration fields.

## Changes Made

**Schema Changes:**
- Added `extra_kwargs: dict[str, Any] | None` field to `ModelConfig` ([models.py:372-374](src/karenina/schemas/workflow/models.py#L372-L374))
- Updated `VerificationConfig._sanitize_model_config()` to include `extra_kwargs` in sanitized output ([verification.py:394-396](src/karenina/schemas/workflow/verification.py#L394-L396))

**Model Initialization Updates:**
Updated all model initialization sites to merge `extra_kwargs` into initialization parameters:
- [abstention_checker.py:135-147](src/karenina/benchmark/verification/evaluators/abstention_checker.py#L135-L147) - Abstention detection
- [rubric_evaluator.py:56-68](src/karenina/benchmark/verification/evaluators/rubric_evaluator.py#L56-L68) - Rubric evaluation
- [generate_answer.py:179-206](src/karenina/benchmark/verification/stages/generate_answer.py#L179-L206) - Answer generation
- [parse_template.py:129-151](src/karenina/benchmark/verification/stages/parse_template.py#L129-L151) - Template parsing
- [embedding_check.py:216-228](src/karenina/benchmark/verification/tools/embedding_check.py#L216-L228) - Semantic equivalence checking
- [generator.py:242-263](src/karenina/domain/answers/generator.py#L242-L263), [generator.py:304-325](src/karenina/domain/answers/generator.py#L304-L325) - Answer generation chains

**Implementation Pattern:**
All model initialization now follows this pattern:
```python
model_kwargs: dict[str, Any] = {
    "model": config.model_name,
    "provider": config.model_provider,
    "temperature": config.temperature,
    "interface": config.interface,
}

# Add interface-specific parameters...

# Merge extra_kwargs if provided
if config.extra_kwargs:
    model_kwargs.update(config.extra_kwargs)

model = init_chat_model_unified(**model_kwargs)
```

## Testing

- Manual testing with vendor-specific parameters (e.g., Azure OpenAI API version)
- Existing tests continue to pass (no breaking changes to default behavior)
- `extra_kwargs` is optional; existing configurations work without modification

## Related PRs

This PR adds backend support for the extra_kwargs feature:
- [ ] biocypher/karenina#56 - Adds `extra_kwargs` field to ModelConfig schema (this PR)
- [ ] biocypher/karenina-gui#52 - Adds JSON editor UI for configuring extra_kwargs

**Merge order:** karenina#56 (this PR) → karenina-gui#52

Both PRs should be merged for complete end-to-end functionality. The backend provides schema and model initialization support, while the GUI PR provides the user interface.

## Additional Context

**Non-breaking change:** The `extra_kwargs` field defaults to `None`, preserving backward compatibility with existing configurations.

**Use cases:**
- Azure OpenAI: Pass `api_version` parameter
- Custom providers: Pass authentication headers or endpoint-specific settings
- Fine-tuned models: Pass model-specific parameters
- Google Gemini: Pass `google_api_key` for authentication
- Anthropic: Pass `anthropic_api_key` for custom endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>