### PR TITLE
fix: misc config and verification improvements

### DIFF
--- a/src/karenina/adapters/claude_agent_sdk/agent.py
+++ b/src/karenina/adapters/claude_agent_sdk/agent.py
@@ -166,6 +166,17 @@ class ClaudeSDKAgentAdapter:
                 if key not in ("permission_mode", "max_turns", "mcp_servers", "allowed_tools"):
                     options_kwargs[key] = value
 
+        # Build env dict for Anthropic settings (api_key, base_url)
+        # The Claude Agent SDK reads ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL from env
+        env_vars: dict[str, str] = {}
+        if self._config.anthropic_api_key:
+            env_vars["ANTHROPIC_API_KEY"] = self._config.anthropic_api_key.get_secret_value()
+        if self._config.anthropic_base_url:
+            env_vars["ANTHROPIC_BASE_URL"] = self._config.anthropic_base_url
+
+        if env_vars:
+            options_kwargs["env"] = env_vars
+
         return ClaudeAgentOptions(**options_kwargs)
 
     def _build_raw_trace(self, messages: list[Any]) -> str:

--- a/src/karenina/adapters/claude_agent_sdk/llm.py
+++ b/src/karenina/adapters/claude_agent_sdk/llm.py
@@ -132,6 +132,17 @@ class ClaudeSDKLLMAdapter:
             # SDK uses max_turns for autonomous retry on structured output
             options_kwargs["max_turns"] = self._max_turns
 
+        # Build env dict for Anthropic settings (api_key, base_url)
+        # The Claude Agent SDK reads ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL from env
+        env_vars: dict[str, str] = {}
+        if self._config.anthropic_api_key:
+            env_vars["ANTHROPIC_API_KEY"] = self._config.anthropic_api_key.get_secret_value()
+        if self._config.anthropic_base_url:
+            env_vars["ANTHROPIC_BASE_URL"] = self._config.anthropic_base_url
+
+        if env_vars:
+            options_kwargs["env"] = env_vars
+
         return ClaudeAgentOptions(**options_kwargs)
 
     @property

--- a/src/karenina/adapters/claude_tool/agent.py
+++ b/src/karenina/adapters/claude_tool/agent.py
@@ -105,7 +105,14 @@ class ClaudeToolAgentAdapter:
         if self._async_client is None:
             from anthropic import AsyncAnthropic
 
-            self._async_client = AsyncAnthropic()
+            # Build kwargs for Anthropic client (api_key, base_url from config)
+            kwargs: dict[str, Any] = {}
+            if self._config.anthropic_api_key:
+                kwargs["api_key"] = self._config.anthropic_api_key.get_secret_value()
+            if self._config.anthropic_base_url:
+                kwargs["base_url"] = self._config.anthropic_base_url
+
+            self._async_client = AsyncAnthropic(**kwargs)
         return self._async_client
 
     def _extract_final_response(self, trace_messages: list[Message]) -> str:

--- a/src/karenina/adapters/claude_tool/llm.py
+++ b/src/karenina/adapters/claude_tool/llm.py
@@ -96,8 +96,15 @@ class ClaudeToolLLMAdapter:
         if self._client is None:
             from anthropic import Anthropic
 
+            # Build kwargs for Anthropic client (api_key, base_url from config)
+            kwargs: dict[str, Any] = {}
+            if self._config.anthropic_api_key:
+                kwargs["api_key"] = self._config.anthropic_api_key.get_secret_value()
+            if self._config.anthropic_base_url:
+                kwargs["base_url"] = self._config.anthropic_base_url
+
             # SDK handles retries automatically (default: 2 retries with exponential backoff)
-            self._client = Anthropic()
+            self._client = Anthropic(**kwargs)
         return self._client
 
     def _get_async_client(self) -> Any:
@@ -105,8 +112,15 @@ class ClaudeToolLLMAdapter:
         if self._async_client is None:
             from anthropic import AsyncAnthropic
 
+            # Build kwargs for Anthropic client (api_key, base_url from config)
+            kwargs: dict[str, Any] = {}
+            if self._config.anthropic_api_key:
+                kwargs["api_key"] = self._config.anthropic_api_key.get_secret_value()
+            if self._config.anthropic_base_url:
+                kwargs["base_url"] = self._config.anthropic_base_url
+
             # SDK handles retries automatically (default: 2 retries with exponential backoff)
-            self._async_client = AsyncAnthropic()
+            self._async_client = AsyncAnthropic(**kwargs)
         return self._async_client
 
     @property

--- a/src/karenina/benchmark/verification/utils/task_helpers.py
+++ b/src/karenina/benchmark/verification/utils/task_helpers.py
@@ -90,21 +90,23 @@ def create_preview_result(task: dict[str, Any]) -> VerificationResult:
     that the task is "starting" (not yet completed).
 
     Args:
-        task: Task dictionary with question_id, question_text, and model info
+        task: Task dictionary with question_id, question_text, model info, and optional replicate
 
     Returns:
-        VerificationResult with preview metadata
+        VerificationResult with preview metadata including replicate info
     """
     from karenina.schemas.verification.model_identity import ModelIdentity
 
     answering_identity = ModelIdentity.from_model_config(task["answering_model"], role="answering")
     parsing_identity = ModelIdentity.from_model_config(task["parsing_model"], role="parsing")
+    replicate = task.get("replicate")  # May be None for single-replicate runs
 
     preview_result_id = VerificationResultMetadata.compute_result_id(
         question_id=task["question_id"],
         answering=answering_identity,
         parsing=parsing_identity,
         timestamp="",  # Empty timestamp indicates "starting" event
+        replicate=replicate,
     )
     return VerificationResult(
         metadata=VerificationResultMetadata(
@@ -117,6 +119,7 @@ def create_preview_result(task: dict[str, Any]) -> VerificationResult:
             execution_time=0.0,
             timestamp="",  # Empty timestamp indicates "starting" event
             result_id=preview_result_id,
+            replicate=replicate,
         )
     )
 

--- a/src/karenina/schemas/config/models.py
+++ b/src/karenina/schemas/config/models.py
@@ -559,6 +559,9 @@ class ModelConfig(BaseModel):
     # OpenAI Endpoint configuration (for openai_endpoint interface)
     endpoint_base_url: str | None = None  # Custom endpoint base URL
     endpoint_api_key: SecretStr | None = None  # User-provided API key
+    # Anthropic-specific configuration (for claude_tool and claude_agent_sdk interfaces)
+    anthropic_base_url: str | None = None  # Custom Anthropic API endpoint (for proxies, self-hosted)
+    anthropic_api_key: SecretStr | None = None  # Override ANTHROPIC_API_KEY env var
     # Extra keyword arguments to pass to the underlying model interface
     # Useful for passing vendor-specific API keys, custom parameters, etc.
     extra_kwargs: dict[str, Any] | None = None

--- a/src/karenina/schemas/verification/config_presets.py
+++ b/src/karenina/schemas/verification/config_presets.py
@@ -155,6 +155,13 @@ def sanitize_model_config(model: dict[str, Any]) -> dict[str, Any]:
         if "endpoint_api_key" in model and model["endpoint_api_key"]:
             sanitized["endpoint_api_key"] = model["endpoint_api_key"]
 
+    # Only include Anthropic fields for claude_tool and claude_agent_sdk interfaces
+    if model["interface"] in ("claude_tool", "claude_agent_sdk"):
+        if "anthropic_base_url" in model and model["anthropic_base_url"]:
+            sanitized["anthropic_base_url"] = model["anthropic_base_url"]
+        if "anthropic_api_key" in model and model["anthropic_api_key"]:
+            sanitized["anthropic_api_key"] = model["anthropic_api_key"]
+
     # Only include MCP fields if they have values
     if "mcp_urls_dict" in model and model["mcp_urls_dict"]:
         sanitized["mcp_urls_dict"] = model["mcp_urls_dict"]


### PR DESCRIPTION
## Summary

- **Anthropic API configuration**: Add `anthropic_base_url` and `anthropic_api_key` fields to `ModelConfig` for custom Anthropic API endpoints and authentication. Updated both `claude_tool` and `claude_agent_sdk` adapters to use these settings.

- **OpenAI endpoint URL normalization**: Add automatic `/v1` suffix normalization for OpenAI-compatible endpoints to ensure consistent API paths regardless of user input format.

- **Replicate progress tracking fix**: Fix progress tracking for multi-replicate verification runs by using unique task keys (`question_id_rep{N}`) instead of just question IDs.

## Changes

| File | Change |
|------|--------|
| `schemas/config/models.py` | Add `anthropic_base_url`, `anthropic_api_key` to ModelConfig |
| `schemas/verification/config_presets.py` | Preserve Anthropic fields in preset sanitization |
| `adapters/claude_tool/llm.py` | Use Anthropic config when initializing clients |
| `adapters/claude_tool/agent.py` | Use Anthropic config when initializing clients |
| `adapters/claude_agent_sdk/llm.py` | Pass Anthropic settings via env vars |
| `adapters/claude_agent_sdk/agent.py` | Pass Anthropic settings via env vars |
| `adapters/langchain/models.py` | Add `_normalize_openai_endpoint_url()` helper |
| `schemas/verification/job.py` | Add `_make_task_key()` for unique replicate keys |
| `benchmark/verification/utils/task_helpers.py` | Include replicate in preview result metadata |

## Test plan

- [ ] Verify Anthropic API configuration is passed to clients correctly
- [ ] Test OpenAI endpoint URL normalization with various URL formats
- [ ] Run multi-replicate verification and confirm progress tracking works

🤖 Generated with [Claude Code](https://claude.com/claude-code)