### PR TITLE
refactor(imports): convert deep relative imports to absolute imports

### DIFF
--- a/src/karenina/benchmark/core/base.py
+++ b/src/karenina/benchmark/core/base.py
@@ -6,8 +6,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from ...schemas.checkpoint import JsonLdCheckpoint
-from ...utils.checkpoint import (
+from karenina.schemas.checkpoint import JsonLdCheckpoint
+from karenina.utils.checkpoint import (
     create_jsonld_benchmark,
     extract_questions_from_benchmark,
     validate_jsonld_benchmark,
@@ -97,7 +97,7 @@ class BenchmarkBase:
         """
         from copy import deepcopy
 
-        from ...utils.checkpoint import strip_deep_judgment_config_from_checkpoint
+        from karenina.utils.checkpoint import strip_deep_judgment_config_from_checkpoint
 
         path = Path(path)
 
@@ -143,7 +143,7 @@ class BenchmarkBase:
         if item.id:
             return str(item.id)
         # Generate from question text if no ID
-        from ...utils.checkpoint import generate_question_id
+        from karenina.utils.checkpoint import generate_question_id
 
         return generate_question_id(item.item.text)
 
@@ -157,7 +157,7 @@ class BenchmarkBase:
 
                 # Find or create the property in additionalProperty
                 if not hasattr(item.item, "additionalProperty") or item.item.additionalProperty is None:
-                    from ...schemas.checkpoint import SchemaOrgPropertyValue
+                    from karenina.schemas.checkpoint import SchemaOrgPropertyValue
 
                     item.item.additionalProperty = []
 
@@ -170,7 +170,7 @@ class BenchmarkBase:
                         break
 
                 if not prop_found:
-                    from ...schemas.checkpoint import SchemaOrgPropertyValue
+                    from karenina.schemas.checkpoint import SchemaOrgPropertyValue
 
                     new_prop = SchemaOrgPropertyValue(name=property_name, value=value)
                     item.item.additionalProperty.append(new_prop)

--- a/src/karenina/benchmark/core/metadata.py
+++ b/src/karenina/benchmark/core/metadata.py
@@ -40,7 +40,7 @@ class MetadataManager:
             name: Property name
             value: Property value
         """
-        from ...schemas.checkpoint import SchemaOrgPropertyValue
+        from karenina.schemas.checkpoint import SchemaOrgPropertyValue
 
         if not self.base._checkpoint.additionalProperty:
             self.base._checkpoint.additionalProperty = []

--- a/src/karenina/benchmark/core/questions.py
+++ b/src/karenina/benchmark/core/questions.py
@@ -13,10 +13,12 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Union
 
 if TYPE_CHECKING:
-    from ...schemas.entities import Question
+    from karenina.schemas.entities import Question
+
     from .base import BenchmarkBase
 
-from ...utils.checkpoint import add_question_to_benchmark
+from karenina.utils.checkpoint import add_question_to_benchmark
+
 from .question_query import QuestionQueryBuilder
 
 logger = logging.getLogger(__name__)
@@ -140,7 +142,7 @@ class QuestionManager:
             q_id = manager.add_question("What is 6*7?", "42", answer_template=MyAnswer)
         """
         # Import Question class here to avoid circular imports
-        from ...schemas.entities import Question
+        from karenina.schemas.entities import Question
 
         # Track whether user provided an answer template (before we set default)
         user_provided_template = answer_template is not None
@@ -174,7 +176,7 @@ class QuestionManager:
         if answer_template is not None:
             if inspect.isclass(answer_template):
                 # Import BaseAnswer here to avoid circular imports
-                from ...schemas.entities import BaseAnswer
+                from karenina.schemas.entities import BaseAnswer
 
                 # Validate that it's an Answer class
                 if not issubclass(answer_template, BaseAnswer):
@@ -329,7 +331,7 @@ class QuestionManager:
         Raises:
             ValueError: If question not found
         """
-        from ...schemas.entities import Question
+        from karenina.schemas.entities import Question
 
         q_data = self.get_question(question_id)
         return Question(
@@ -348,7 +350,7 @@ class QuestionManager:
         """
         from typing import cast
 
-        from ...schemas.entities import Question
+        from karenina.schemas.entities import Question
 
         objects = []
         for q_data in cast(list[dict[str, Any]], self.get_all_questions()):
@@ -373,7 +375,7 @@ class QuestionManager:
         Returns:
             The question ID that was assigned
         """
-        from ...schemas.entities import Question
+        from karenina.schemas.entities import Question
 
         if not isinstance(question_obj, Question):
             raise ValueError("question_obj must be a Question instance")

--- a/src/karenina/benchmark/core/results.py
+++ b/src/karenina/benchmark/core/results.py
@@ -6,10 +6,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from ...schemas.entities import Rubric
+    from karenina.schemas.entities import Rubric
+
     from .base import BenchmarkBase
 
-from ...schemas.verification import VerificationResult
+from karenina.schemas.verification import VerificationResult
+
 from .results_io import ResultsIOManager
 
 logger = logging.getLogger(__name__)

--- a/src/karenina/benchmark/core/results_io.py
+++ b/src/karenina/benchmark/core/results_io.py
@@ -8,9 +8,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from ...schemas.entities import Rubric
+    from karenina.schemas.entities import Rubric
 
-from ...schemas.verification import VerificationResult
+from karenina.schemas.verification import VerificationResult
 
 logger = logging.getLogger(__name__)
 

--- a/src/karenina/benchmark/core/rubrics.py
+++ b/src/karenina/benchmark/core/rubrics.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from .base import BenchmarkBase
 
-from ...schemas.entities import CallableTrait, LLMRubricTrait, MetricRubricTrait, RegexTrait, Rubric
-from ...utils.checkpoint import (
+from karenina.schemas.entities import CallableTrait, LLMRubricTrait, MetricRubricTrait, RegexTrait, Rubric
+from karenina.utils.checkpoint import (
     add_global_rubric_to_benchmark,
     extract_global_rubric_from_benchmark,
 )
@@ -44,7 +44,7 @@ class RubricManager:
         Raises:
             ValueError: If question not found
         """
-        from ...utils.checkpoint import convert_rubric_trait_to_rating
+        from karenina.utils.checkpoint import convert_rubric_trait_to_rating
 
         # Find the question
         found = False

--- a/src/karenina/benchmark/core/templates.py
+++ b/src/karenina/benchmark/core/templates.py
@@ -8,7 +8,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from .base import BenchmarkBase
 
-from ...schemas.verification import FinishedTemplate
+from karenina.schemas.verification import FinishedTemplate
+
 from ..verification.utils.template_validation import validate_answer_template
 
 logger = logging.getLogger(__name__)

--- a/src/karenina/benchmark/core/verification_manager.py
+++ b/src/karenina/benchmark/core/verification_manager.py
@@ -8,12 +8,13 @@ if TYPE_CHECKING:
     from .base import BenchmarkBase
     from .rubrics import RubricManager
 
-from ...schemas.results import VerificationResultSet
-from ...schemas.verification import (
+from karenina.schemas.results import VerificationResultSet
+from karenina.schemas.verification import (
     FinishedTemplate,
     VerificationConfig,
     VerificationResult,
 )
+
 from ..verification import run_verification_batch
 from ..verification.utils.template_validation import validate_answer_template
 
@@ -81,7 +82,7 @@ class VerificationManager:
                     question_rubric_dict = question_rubric_raw
                 # If it's a list of trait objects, convert to Rubric and dump
                 elif isinstance(question_rubric_raw, list):
-                    from ...schemas.entities.rubric import (
+                    from karenina.schemas.entities.rubric import (
                         CallableTrait,
                         LLMRubricTrait,
                         MetricRubricTrait,

--- a/src/karenina/benchmark/task_eval/helpers.py
+++ b/src/karenina/benchmark/task_eval/helpers.py
@@ -5,9 +5,10 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from ...schemas.entities import Rubric
+    from karenina.schemas.entities import Rubric
 
-from ...schemas.config import ModelConfig
+from karenina.schemas.config import ModelConfig
+
 from ..verification.evaluators import RubricEvaluator
 
 logger = logging.getLogger(__name__)
@@ -123,7 +124,7 @@ def evaluate_question_with_rubric(
     if answer_template:
         question_rubric_traits = extract_traits_func(answer_template)
         if question_rubric_traits:
-            from ...schemas.entities import Rubric
+            from karenina.schemas.entities import Rubric
 
             question_rubric = Rubric(llm_traits=question_rubric_traits)
 

--- a/src/karenina/benchmark/task_eval/models.py
+++ b/src/karenina/benchmark/task_eval/models.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 # Import VerificationResult for use in StepEval
-from ...schemas.verification import VerificationResult
+from karenina.schemas.verification import VerificationResult
 
 
 class LogEvent(BaseModel):

--- a/src/karenina/benchmark/task_eval/task_eval.py
+++ b/src/karenina/benchmark/task_eval/task_eval.py
@@ -16,10 +16,11 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, Union
 
 if TYPE_CHECKING:
-    from ...schemas.entities import Question, Rubric
+    from karenina.schemas.entities import Question, Rubric
 
-from ...schemas.config import ModelConfig
-from ...schemas.verification import VerificationConfig
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification import VerificationConfig
+
 from ..verification.evaluators import RubricEvaluator
 from .models import LogEvent, StepEval, TaskEvalResult
 
@@ -319,7 +320,7 @@ class TaskEval:
 
         Handles both Question objects and dictionary objects from Benchmark.
         """
-        from ...schemas.entities import Question
+        from karenina.schemas.entities import Question
 
         if isinstance(question, Question):
             return {
@@ -753,7 +754,7 @@ class Answer(BaseAnswer):
         if not rubrics:
             return None
 
-        from ...schemas.entities import CallableTrait, LLMRubricTrait, MetricRubricTrait, RegexTrait, Rubric
+        from karenina.schemas.entities import CallableTrait, LLMRubricTrait, MetricRubricTrait, RegexTrait, Rubric
 
         # Check for trait name conflicts first (across all trait types)
         all_trait_names = []

--- a/src/karenina/benchmark/verification/batch_runner.py
+++ b/src/karenina/benchmark/verification/batch_runner.py
@@ -10,15 +10,16 @@ import time
 from collections.abc import Callable
 from typing import Any
 
-from ...schemas.entities import Rubric
-from ...schemas.results import VerificationResultSet
-from ...schemas.verification import (
+from karenina.schemas.entities import Rubric
+from karenina.schemas.results import VerificationResultSet
+from karenina.schemas.verification import (
     FinishedTemplate,
     VerificationConfig,
     VerificationResult,
 )
-from ...schemas.verification.config import DEFAULT_ASYNC_ENABLED
-from ...utils.answer_cache import AnswerTraceCache
+from karenina.schemas.verification.config import DEFAULT_ASYNC_ENABLED
+from karenina.utils.answer_cache import AnswerTraceCache
+
 from .utils.cache_helpers import (
     extract_answer_data_from_result,
     generate_answer_cache_key,

--- a/src/karenina/benchmark/verification/evaluators/rubric/deep_judgment.py
+++ b/src/karenina/benchmark/verification/evaluators/rubric/deep_judgment.py
@@ -29,15 +29,15 @@ import re
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
-from .....ports import LLMPort, Message
-from .....ports.capabilities import PortCapabilities
-from ...prompts.assembler import PromptAssembler
-from ...prompts.deep_judgment.rubric.deep_judgment import DeepJudgmentPromptBuilder
-from ...prompts.task_types import PromptTask
+from karenina.benchmark.verification.prompts.assembler import PromptAssembler
+from karenina.benchmark.verification.prompts.deep_judgment.rubric.deep_judgment import DeepJudgmentPromptBuilder
+from karenina.benchmark.verification.prompts.task_types import PromptTask
+from karenina.ports import LLMPort, Message
+from karenina.ports.capabilities import PortCapabilities
 
 if TYPE_CHECKING:
-    from .....schemas.entities import LLMRubricTrait, Rubric
-    from .....schemas.verification.prompt_config import PromptConfig
+    from karenina.schemas.entities import LLMRubricTrait, Rubric
+    from karenina.schemas.verification.prompt_config import PromptConfig
 
 logger = logging.getLogger(__name__)
 
@@ -152,7 +152,7 @@ class RubricDeepJudgmentHandler:
                 - hallucination_risks: Per-trait hallucination risk (if search enabled)
                 - traits_without_valid_excerpts: Traits that failed excerpt extraction
         """
-        from .....schemas.entities import Rubric as RubricClass
+        from karenina.schemas.entities import Rubric as RubricClass
 
         # Separate deep-judgment vs standard traits
         dj_traits = [t for t in rubric.llm_traits if t.deep_judgment_enabled]
@@ -408,7 +408,7 @@ class RubricDeepJudgmentHandler:
         # Retry loop
         for attempt in range(max_attempts + 1):  # Initial + retries
             # Build prompt (with feedback if retry)
-            from .....schemas.outputs import TraitExcerptsOutput
+            from karenina.schemas.outputs import TraitExcerptsOutput
 
             system_prompt = self._prompt_builder.build_excerpt_extraction_system_prompt()
             user_prompt = self._prompt_builder.build_excerpt_extraction_user_prompt(
@@ -512,7 +512,7 @@ class RubricDeepJudgmentHandler:
         Returns:
             Tuple of (valid_excerpts, failed_excerpts)
         """
-        from ...utils.trace_fuzzy_match import fuzzy_match_excerpt
+        from karenina.benchmark.verification.utils.trace_fuzzy_match import fuzzy_match_excerpt
 
         valid = []
         failed = []
@@ -557,7 +557,7 @@ class RubricDeepJudgmentHandler:
         Returns:
             Dictionary with: excerpts (updated with search results), risk_assessment, model_calls, usage_metadata_list
         """
-        from ...utils.search_provider import create_search_tool
+        from karenina.benchmark.verification.utils.search_provider import create_search_tool
 
         # Create search tool
         search_tool = create_search_tool(config.deep_judgment_rubric_search_tool)
@@ -580,7 +580,7 @@ class RubricDeepJudgmentHandler:
 
         for i, excerpt in enumerate(excerpts):
             # Build prompt for hallucination assessment
-            from .....schemas.outputs import HallucinationRiskOutput
+            from karenina.schemas.outputs import HallucinationRiskOutput
 
             excerpt_text = excerpt.get("text", "")
             search_result = search_results[i] if i < len(search_results) else "No results available"
@@ -604,7 +604,7 @@ class RubricDeepJudgmentHandler:
             )
 
             # Use LLMPort.with_structured_output() for parsing
-            from .....schemas.outputs import HallucinationRiskOutput
+            from karenina.schemas.outputs import HallucinationRiskOutput
 
             try:
                 structured_llm = self.llm.with_structured_output(HallucinationRiskOutput)
@@ -695,7 +695,7 @@ class RubricDeepJudgmentHandler:
         Returns:
             Dictionary with: score (int | bool), usage_metadata
         """
-        from .....schemas.outputs import SingleBooleanScore, SingleNumericScore
+        from karenina.schemas.outputs import SingleBooleanScore, SingleNumericScore
 
         schema_class = SingleBooleanScore if trait.kind == "boolean" else SingleNumericScore
 

--- a/src/karenina/benchmark/verification/evaluators/rubric/evaluator.py
+++ b/src/karenina/benchmark/verification/evaluators/rubric/evaluator.py
@@ -18,16 +18,17 @@ Evaluation is delegated to specialized handlers:
 import logging
 from typing import TYPE_CHECKING, Any
 
-from .....adapters import get_llm
-from .....ports import LLMPort
-from .....schemas.config import ModelConfig
-from .....schemas.entities import CallableTrait, MetricRubricTrait, RegexTrait, Rubric
+from karenina.adapters import get_llm
+from karenina.ports import LLMPort
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.entities import CallableTrait, MetricRubricTrait, RegexTrait, Rubric
+
 from .deep_judgment import RubricDeepJudgmentHandler
 from .llm_trait import LLMTraitEvaluator
 from .metric_trait import MetricTraitEvaluator
 
 if TYPE_CHECKING:
-    from .....schemas.verification import PromptConfig
+    from karenina.schemas.verification import PromptConfig
 
 logger = logging.getLogger(__name__)
 

--- a/src/karenina/benchmark/verification/evaluators/rubric/llm_trait.py
+++ b/src/karenina/benchmark/verification/evaluators/rubric/llm_trait.py
@@ -23,15 +23,15 @@ import re
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
-from .....ports import LLMPort, Message, PortCapabilities
-from .....schemas.entities import LLMRubricTrait
-from ...prompts import PromptAssembler, PromptTask
-from ...prompts.rubric.literal_trait import LiteralTraitPromptBuilder
-from ...prompts.rubric.llm_trait import LLMTraitPromptBuilder
+from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
+from karenina.benchmark.verification.prompts.rubric.literal_trait import LiteralTraitPromptBuilder
+from karenina.benchmark.verification.prompts.rubric.llm_trait import LLMTraitPromptBuilder
+from karenina.ports import LLMPort, Message, PortCapabilities
+from karenina.schemas.entities import LLMRubricTrait
 
 if TYPE_CHECKING:
-    from .....schemas.config import ModelConfig
-    from .....schemas.verification import PromptConfig
+    from karenina.schemas.config import ModelConfig
+    from karenina.schemas.verification import PromptConfig
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +81,7 @@ class LLMTraitEvaluator:
             model_config: Model configuration for reference.
             prompt_config: Optional per-task-type user instructions for prompt assembly.
         """
-        from .....adapters.llm_parallel import read_async_config
+        from karenina.adapters.llm_parallel import read_async_config
 
         self.llm = llm
         self._model_config = model_config
@@ -138,7 +138,7 @@ class LLMTraitEvaluator:
         Returns:
             Tuple of (results_dict, usage_metadata)
         """
-        from .....schemas.outputs import BatchRubricScores
+        from karenina.schemas.outputs import BatchRubricScores
 
         system_prompt = self._llm_prompt_builder.build_batch_system_prompt()
         user_prompt = self._llm_prompt_builder.build_batch_user_prompt(question, answer, traits)
@@ -184,7 +184,7 @@ class LLMTraitEvaluator:
         Returns:
             Tuple of (results_dict, list_of_usage_metadata)
         """
-        from .....schemas.outputs import SingleBooleanScore, SingleNumericScore
+        from karenina.schemas.outputs import SingleBooleanScore, SingleNumericScore
 
         # Build all tasks upfront
         tasks: list[tuple[list[Message], type]] = []
@@ -219,7 +219,7 @@ class LLMTraitEvaluator:
 
         Uses the LLMParallelInvoker for concurrent execution with LLMPort.
         """
-        from .....adapters import LLMParallelInvoker
+        from karenina.adapters import LLMParallelInvoker
 
         logger.debug(f"LLMParallelInvoker: Executing {len(tasks)} tasks with max_workers={self._async_max_workers}")
         invoker = LLMParallelInvoker(self.llm, max_workers=self._async_max_workers)
@@ -438,7 +438,7 @@ class LLMTraitEvaluator:
             - labels: Dict mapping trait names to class labels (or invalid value for error)
             - usage_metadata: Usage metadata from the LLM call
         """
-        from .....schemas.outputs import BatchLiteralClassifications
+        from karenina.schemas.outputs import BatchLiteralClassifications
 
         # Filter to only literal traits
         literal_traits = [t for t in traits if t.kind == "literal"]
@@ -497,7 +497,7 @@ class LLMTraitEvaluator:
             - labels: Dict mapping trait names to class labels (or invalid value for error)
             - usage_metadata_list: List of usage metadata dicts from LLM calls
         """
-        from .....schemas.outputs import SingleLiteralClassification
+        from karenina.schemas.outputs import SingleLiteralClassification
 
         # Filter to only literal traits
         literal_traits = [t for t in traits if t.kind == "literal"]
@@ -535,7 +535,7 @@ class LLMTraitEvaluator:
 
         Uses the LLMParallelInvoker for concurrent execution with LLMPort.
         """
-        from .....adapters import LLMParallelInvoker
+        from karenina.adapters import LLMParallelInvoker
 
         logger.debug(
             f"LLMParallelInvoker: Executing {len(tasks)} literal tasks with max_workers={self._async_max_workers}"

--- a/src/karenina/benchmark/verification/evaluators/rubric/metric_trait.py
+++ b/src/karenina/benchmark/verification/evaluators/rubric/metric_trait.py
@@ -20,14 +20,14 @@ import re
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
-from .....ports import LLMPort, PortCapabilities
-from .....schemas.entities import MetricRubricTrait
-from ...prompts import PromptAssembler, PromptTask
-from ...prompts.rubric.metric_trait import MetricTraitPromptBuilder
+from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
+from karenina.benchmark.verification.prompts.rubric.metric_trait import MetricTraitPromptBuilder
+from karenina.ports import LLMPort, PortCapabilities
+from karenina.schemas.entities import MetricRubricTrait
 
 if TYPE_CHECKING:
-    from .....schemas.config import ModelConfig
-    from .....schemas.verification import PromptConfig
+    from karenina.schemas.config import ModelConfig
+    from karenina.schemas.verification import PromptConfig
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +128,7 @@ class MetricTraitEvaluator:
         Returns:
             Tuple of (confusion_lists, metrics, usage_metadata)
         """
-        from .....schemas.outputs import ConfusionMatrixOutput
+        from karenina.schemas.outputs import ConfusionMatrixOutput
 
         # Build prompt
         system_prompt = self._prompt_builder.build_system_prompt()

--- a/src/karenina/benchmark/verification/evaluators/template/__init__.py
+++ b/src/karenina/benchmark/verification/evaluators/template/__init__.py
@@ -7,7 +7,8 @@ This package provides:
 - deep_judgment_parse: Multi-stage parsing with excerpt extraction
 """
 
-from ...prompts.parsing.parsing_instructions import TemplatePromptBuilder
+from karenina.benchmark.verification.prompts.parsing.parsing_instructions import TemplatePromptBuilder
+
 from .deep_judgment import deep_judgment_parse
 from .evaluator import TemplateEvaluator
 from .results import FieldVerificationResult, ParseResult, RegexVerificationResult

--- a/src/karenina/benchmark/verification/evaluators/template/deep_judgment.py
+++ b/src/karenina/benchmark/verification/evaluators/template/deep_judgment.py
@@ -25,20 +25,19 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from karenina.benchmark.verification.prompts.assembler import PromptAssembler
+from karenina.benchmark.verification.prompts.task_types import PromptTask
+from karenina.ports import LLMPort, ParserPort
+from karenina.ports.capabilities import PortCapabilities
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.entities import BaseAnswer
+from karenina.schemas.shared import SearchResultItem
+from karenina.schemas.verification import VerificationConfig
 from karenina.utils.json_extraction import strip_markdown_fences as _strip_markdown_fences
 
-from .....ports import LLMPort, ParserPort
-from .....ports.capabilities import PortCapabilities
-from .....schemas.config import ModelConfig
-from .....schemas.entities import BaseAnswer
-from .....schemas.shared import SearchResultItem
-from .....schemas.verification import VerificationConfig
-from ...prompts.assembler import PromptAssembler
-from ...prompts.task_types import PromptTask
-
 if TYPE_CHECKING:
-    from .....schemas.verification.prompt_config import PromptConfig
-from ...prompts.deep_judgment.template import (
+    from karenina.schemas.verification.prompt_config import PromptConfig
+from karenina.benchmark.verification.prompts.deep_judgment.template import (
     build_assessment_system_prompt,
     build_assessment_user_prompt,
     build_excerpt_system_prompt,
@@ -46,15 +45,15 @@ from ...prompts.deep_judgment.template import (
     build_reasoning_system_prompt,
     build_reasoning_user_prompt,
 )
-from ...utils.search_provider import create_search_tool
-from ...utils.template_parsing_helpers import (
+from karenina.benchmark.verification.utils.search_provider import create_search_tool
+from karenina.benchmark.verification.utils.template_parsing_helpers import (
     _extract_attribute_descriptions,
     _extract_attribute_names_from_class,
     _format_search_results_for_llm,
     format_excerpts_for_reasoning,
     format_reasoning_for_parsing,
 )
-from ...utils.trace_fuzzy_match import fuzzy_match_excerpt
+from karenina.benchmark.verification.utils.trace_fuzzy_match import fuzzy_match_excerpt
 
 logger = logging.getLogger(__name__)
 

--- a/src/karenina/benchmark/verification/evaluators/template/evaluator.py
+++ b/src/karenina/benchmark/verification/evaluators/template/evaluator.py
@@ -12,19 +12,20 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any
 
-from .....adapters import get_llm, get_parser
-from .....ports import LLMPort
-from .....schemas.config import ModelConfig
-from .....schemas.entities import BaseAnswer
-from .....schemas.verification.model_identity import ModelIdentity
-from ...prompts import PromptAssembler, PromptTask
-from ...prompts.parsing.parsing_instructions import TemplatePromptBuilder
-from ...utils import prepare_evaluation_input
+from karenina.adapters import get_llm, get_parser
+from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
+from karenina.benchmark.verification.prompts.parsing.parsing_instructions import TemplatePromptBuilder
+from karenina.benchmark.verification.utils import prepare_evaluation_input
+from karenina.ports import LLMPort
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.entities import BaseAnswer
+from karenina.schemas.verification.model_identity import ModelIdentity
+
 from .results import FieldVerificationResult, ParseResult, RegexVerificationResult
 
 if TYPE_CHECKING:
-    from .....ports import ParserPort
-    from .....schemas.verification import PromptConfig
+    from karenina.ports import ParserPort
+    from karenina.schemas.verification import PromptConfig
 
 logger = logging.getLogger(__name__)
 
@@ -318,7 +319,9 @@ class TemplateEvaluator:
         if not self._should_expose_ground_truth():
             return None
         try:
-            from ...utils.template_parsing_helpers import create_test_instance_from_answer_class
+            from karenina.benchmark.verification.utils.template_parsing_helpers import (
+                create_test_instance_from_answer_class,
+            )
 
             _, ground_truth = create_test_instance_from_answer_class(self.raw_answer_class)
             return ground_truth
@@ -353,7 +356,8 @@ class TemplateEvaluator:
         """
         from langchain_core.output_parsers import PydanticOutputParser
 
-        from .....schemas.verification import VerificationConfig
+        from karenina.schemas.verification import VerificationConfig
+
         from .deep_judgment import deep_judgment_parse
 
         result = ParseResult()
@@ -380,7 +384,9 @@ class TemplateEvaluator:
         ground_truth = None
         if self._should_expose_ground_truth():
             try:
-                from ...utils.template_parsing_helpers import create_test_instance_from_answer_class
+                from karenina.benchmark.verification.utils.template_parsing_helpers import (
+                    create_test_instance_from_answer_class,
+                )
 
                 _, ground_truth = create_test_instance_from_answer_class(self.raw_answer_class)
             except Exception as e:

--- a/src/karenina/benchmark/verification/evaluators/trace/abstention.py
+++ b/src/karenina/benchmark/verification/evaluators/trace/abstention.py
@@ -8,17 +8,17 @@ from typing import Any
 from pydantic import BaseModel, Field
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from .....adapters import get_llm
-from .....ports import LLMResponse
-from .....ports.capabilities import PortCapabilities
-from .....schemas.config import ModelConfig
-from .....schemas.verification.prompt_config import PromptConfig
-from .....utils.errors import is_retryable_error
-from .....utils.retry import log_retry
-from ...prompts.assembler import PromptAssembler
-from ...prompts.task_types import PromptTask
-from ...prompts.trace.abstention import ABSTENTION_DETECTION_SYS, ABSTENTION_DETECTION_USER
-from ...utils.llm_judge_helpers import extract_judge_result, fallback_json_parse
+from karenina.adapters import get_llm
+from karenina.benchmark.verification.prompts.assembler import PromptAssembler
+from karenina.benchmark.verification.prompts.task_types import PromptTask
+from karenina.benchmark.verification.prompts.trace.abstention import ABSTENTION_DETECTION_SYS, ABSTENTION_DETECTION_USER
+from karenina.benchmark.verification.utils.llm_judge_helpers import extract_judge_result, fallback_json_parse
+from karenina.ports import LLMResponse
+from karenina.ports.capabilities import PortCapabilities
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification.prompt_config import PromptConfig
+from karenina.utils.errors import is_retryable_error
+from karenina.utils.retry import log_retry
 
 # Set up logger
 logger = logging.getLogger(__name__)

--- a/src/karenina/benchmark/verification/evaluators/trace/sufficiency.py
+++ b/src/karenina/benchmark/verification/evaluators/trace/sufficiency.py
@@ -8,17 +8,20 @@ from typing import Any
 from pydantic import BaseModel, Field
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from .....adapters import get_llm
-from .....ports import LLMResponse
-from .....ports.capabilities import PortCapabilities
-from .....schemas.config import ModelConfig
-from .....schemas.verification.prompt_config import PromptConfig
-from .....utils.errors import is_retryable_error
-from .....utils.retry import log_retry
-from ...prompts.assembler import PromptAssembler
-from ...prompts.task_types import PromptTask
-from ...prompts.trace.sufficiency import SUFFICIENCY_DETECTION_SYS, SUFFICIENCY_DETECTION_USER
-from ...utils.llm_judge_helpers import extract_judge_result, fallback_json_parse
+from karenina.adapters import get_llm
+from karenina.benchmark.verification.prompts.assembler import PromptAssembler
+from karenina.benchmark.verification.prompts.task_types import PromptTask
+from karenina.benchmark.verification.prompts.trace.sufficiency import (
+    SUFFICIENCY_DETECTION_SYS,
+    SUFFICIENCY_DETECTION_USER,
+)
+from karenina.benchmark.verification.utils.llm_judge_helpers import extract_judge_result, fallback_json_parse
+from karenina.ports import LLMResponse
+from karenina.ports.capabilities import PortCapabilities
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification.prompt_config import PromptConfig
+from karenina.utils.errors import is_retryable_error
+from karenina.utils.retry import log_retry
 
 # Set up logger
 logger = logging.getLogger(__name__)

--- a/src/karenina/benchmark/verification/executor.py
+++ b/src/karenina/benchmark/verification/executor.py
@@ -25,9 +25,9 @@ from anyio.from_thread import start_blocking_portal
 if TYPE_CHECKING:
     from anyio.from_thread import BlockingPortal
 
-from ...schemas.verification import VerificationResult
-from ...schemas.verification.config import DEFAULT_ASYNC_MAX_WORKERS
-from ...utils.answer_cache import AnswerTraceCache
+from karenina.schemas.verification import VerificationResult
+from karenina.schemas.verification.config import DEFAULT_ASYNC_MAX_WORKERS
+from karenina.utils.answer_cache import AnswerTraceCache
 
 logger = logging.getLogger(__name__)
 

--- a/src/karenina/benchmark/verification/runner.py
+++ b/src/karenina/benchmark/verification/runner.py
@@ -6,16 +6,17 @@ Main entry point for running verification using the stage-based pipeline archite
 import logging
 from typing import Any
 
-from ...schemas.config import ModelConfig
-from ...schemas.entities import Rubric
-from ...schemas.verification import PromptConfig, VerificationResult
-from ...schemas.verification.config import (
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.entities import Rubric
+from karenina.schemas.verification import PromptConfig, VerificationResult
+from karenina.schemas.verification.config import (
     DEFAULT_DEEP_JUDGMENT_FUZZY_THRESHOLD,
     DEFAULT_DEEP_JUDGMENT_MAX_EXCERPTS,
     DEFAULT_DEEP_JUDGMENT_RETRY_ATTEMPTS,
     DEFAULT_RUBRIC_MAX_EXCERPTS,
 )
-from ...utils.checkpoint import generate_template_id
+from karenina.utils.checkpoint import generate_template_id
+
 from .stages import StageOrchestrator, VerificationContext
 
 logger = logging.getLogger(__name__)

--- a/src/karenina/benchmark/verification/stages/core/base.py
+++ b/src/karenina/benchmark/verification/stages/core/base.py
@@ -20,10 +20,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
-from .....schemas.config import ModelConfig
-from .....schemas.entities import Rubric
-from .....schemas.verification import PromptConfig
-from .....schemas.verification.config import (
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.entities import Rubric
+from karenina.schemas.verification import PromptConfig
+from karenina.schemas.verification.config import (
     DEFAULT_DEEP_JUDGMENT_FUZZY_THRESHOLD,
     DEFAULT_DEEP_JUDGMENT_MAX_EXCERPTS,
     DEFAULT_DEEP_JUDGMENT_RETRY_ATTEMPTS,
@@ -31,7 +31,7 @@ from .....schemas.verification.config import (
 )
 
 if TYPE_CHECKING:
-    from ...utils.trace_usage_tracker import UsageTracker
+    from karenina.benchmark.verification.utils.trace_usage_tracker import UsageTracker
 
 logger = logging.getLogger(__name__)
 
@@ -520,7 +520,7 @@ class BaseVerificationStage(ABC):
         Returns:
             UsageTracker instance (from context or newly created)
         """
-        from ...utils.trace_usage_tracker import UsageTracker
+        from karenina.benchmark.verification.utils.trace_usage_tracker import UsageTracker
 
         usage_tracker: UsageTracker | None = context.get_artifact("usage_tracker")
         if usage_tracker is None:

--- a/src/karenina/benchmark/verification/stages/core/check_stage_base.py
+++ b/src/karenina/benchmark/verification/stages/core/check_stage_base.py
@@ -9,7 +9,8 @@ import logging
 from abc import abstractmethod
 from typing import Any
 
-from .....schemas.verification.model_identity import ModelIdentity
+from karenina.schemas.verification.model_identity import ModelIdentity
+
 from .base import ArtifactKeys, BaseVerificationStage, VerificationContext
 
 logger = logging.getLogger(__name__)

--- a/src/karenina/benchmark/verification/stages/core/orchestrator.py
+++ b/src/karenina/benchmark/verification/stages/core/orchestrator.py
@@ -6,8 +6,9 @@ Manages stage execution, dependencies, and error handling.
 import logging
 import time
 
-from .....schemas.entities import Rubric
-from .....schemas.verification import VerificationResult
+from karenina.schemas.entities import Rubric
+from karenina.schemas.verification import VerificationResult
+
 from ..pipeline.abstention_check import AbstentionCheckStage
 from ..pipeline.deep_judgment_autofail import DeepJudgmentAutoFailStage
 from ..pipeline.deep_judgment_rubric_auto_fail import DeepJudgmentRubricAutoFailStage

--- a/src/karenina/benchmark/verification/stages/helpers/deep_judgment_helpers.py
+++ b/src/karenina/benchmark/verification/stages/helpers/deep_judgment_helpers.py
@@ -7,8 +7,8 @@ These are extracted from rubric_evaluation.py to reduce clutter in the stage fil
 import logging
 from typing import Any
 
-from .....schemas.entities import LLMRubricTrait
-from .....schemas.verification import DeepJudgmentTraitConfig
+from karenina.schemas.entities import LLMRubricTrait
+from karenina.schemas.verification import DeepJudgmentTraitConfig
 
 # Set up logger
 logger = logging.getLogger(__name__)

--- a/src/karenina/benchmark/verification/stages/helpers/results_exporter.py
+++ b/src/karenina/benchmark/verification/stages/helpers/results_exporter.py
@@ -28,9 +28,9 @@ import time
 from io import StringIO
 from typing import Any, Protocol
 
-from .....schemas.results import VerificationResultSet
-from .....schemas.verification import VerificationJob
-from .....utils.version import get_karenina_version
+from karenina.schemas.results import VerificationResultSet
+from karenina.schemas.verification import VerificationJob
+from karenina.utils.version import get_karenina_version
 
 
 class HasTraitNames(Protocol):

--- a/src/karenina/benchmark/verification/stages/pipeline/abstention_check.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/abstention_check.py
@@ -5,7 +5,8 @@ Detects when LLMs refuse to answer or abstain from responding.
 
 from typing import Any
 
-from ...evaluators import detect_abstention
+from karenina.benchmark.verification.evaluators import detect_abstention
+
 from ..core.base import ArtifactKeys, VerificationContext
 from ..core.check_stage_base import BaseCheckStage
 

--- a/src/karenina/benchmark/verification/stages/pipeline/embedding_check.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/embedding_check.py
@@ -5,8 +5,9 @@ Semantic similarity fallback for field verification failures.
 
 import logging
 
-from ...utils.embedding_check import perform_embedding_check
-from ...utils.llm_invocation import _split_parsed_response
+from karenina.benchmark.verification.utils.embedding_check import perform_embedding_check
+from karenina.benchmark.verification.utils.llm_invocation import _split_parsed_response
+
 from ..core.base import ArtifactKeys, BaseVerificationStage, VerificationContext
 
 # Set up logger

--- a/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
@@ -6,9 +6,9 @@ Builds the final VerificationResult from accumulated context.
 import logging
 from typing import Any
 
+from karenina.benchmark.verification.utils.llm_invocation import _split_parsed_response
 from karenina.schemas.verification import VerificationResult
 
-from ...utils.llm_invocation import _split_parsed_response
 from ..core.base import ArtifactKeys, BaseVerificationStage, VerificationContext
 
 # Set up logger

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -10,12 +10,12 @@ import traceback
 from typing import Any
 
 from karenina.adapters import get_agent, get_llm
+from karenina.benchmark.verification.utils.llm_invocation import _construct_few_shot_prompt
+from karenina.benchmark.verification.utils.trace_agent_metrics import extract_agent_metrics_from_messages
+from karenina.benchmark.verification.utils.trace_usage_tracker import UsageTracker
 from karenina.ports import AgentConfig, AgentPort, LLMPort, Message
 from karenina.schemas.verification.model_identity import ModelIdentity
 
-from ...utils.llm_invocation import _construct_few_shot_prompt
-from ...utils.trace_agent_metrics import extract_agent_metrics_from_messages
-from ...utils.trace_usage_tracker import UsageTracker
 from ..core.base import ArtifactKeys, BaseVerificationStage, VerificationContext
 
 # Set up logger

--- a/src/karenina/benchmark/verification/stages/pipeline/parse_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/parse_template.py
@@ -6,7 +6,8 @@ Parses LLM responses into Pydantic objects using standard or deep-judgment parsi
 import logging
 from typing import Any
 
-from ...evaluators import TemplateEvaluator
+from karenina.benchmark.verification.evaluators import TemplateEvaluator
+
 from ..core.base import ArtifactKeys, BaseVerificationStage, VerificationContext
 
 # Set up logger

--- a/src/karenina/benchmark/verification/stages/pipeline/rubric_evaluation.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/rubric_evaluation.py
@@ -5,10 +5,10 @@ Evaluates LLM responses against qualitative rubric criteria.
 
 import logging
 
+from karenina.benchmark.verification.evaluators import RubricEvaluator
+from karenina.benchmark.verification.utils import prepare_evaluation_input
 from karenina.schemas.verification.model_identity import ModelIdentity
 
-from ...evaluators import RubricEvaluator
-from ...utils import prepare_evaluation_input
 from ..core.base import ArtifactKeys, BaseVerificationStage, VerificationContext
 from ..helpers.deep_judgment_helpers import apply_deep_judgment_config_to_traits
 

--- a/src/karenina/benchmark/verification/stages/pipeline/sufficiency_check.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/sufficiency_check.py
@@ -6,7 +6,8 @@ Detects when LLM responses lack sufficient information to populate a template.
 import logging
 from typing import Any
 
-from ...evaluators import detect_sufficiency
+from karenina.benchmark.verification.evaluators import detect_sufficiency
+
 from ..core.base import ArtifactKeys, VerificationContext
 from ..core.check_stage_base import BaseCheckStage
 

--- a/src/karenina/benchmark/verification/stages/pipeline/trace_validation_autofail.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/trace_validation_autofail.py
@@ -5,7 +5,8 @@ Auto-fails verification when agent trace doesn't end with an AI message.
 
 import logging
 
-from ...utils import extract_final_ai_message
+from karenina.benchmark.verification.utils import extract_final_ai_message
+
 from ..core.base import ArtifactKeys, BaseVerificationStage, VerificationContext
 
 # Set up logger

--- a/src/karenina/benchmark/verification/stages/pipeline/validate_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/validate_template.py
@@ -4,8 +4,8 @@ Validates the Pydantic template syntax and injects question ID.
 """
 
 from karenina.benchmark.authoring.answers.generator import inject_question_id_into_answer_class
+from karenina.benchmark.verification.utils.template_validation import validate_answer_template
 
-from ...utils.template_validation import validate_answer_template
 from ..core.base import ArtifactKeys, BaseVerificationStage, VerificationContext
 
 

--- a/src/karenina/benchmark/verification/utils/cache_helpers.py
+++ b/src/karenina/benchmark/verification/utils/cache_helpers.py
@@ -7,8 +7,8 @@ for the AnswerTraceCache used in batch verification.
 import logging
 from typing import Any
 
-from ....schemas.verification import VerificationResult
-from ....utils.answer_cache import AnswerTraceCache
+from karenina.schemas.verification import VerificationResult
+from karenina.utils.answer_cache import AnswerTraceCache
 
 logger = logging.getLogger(__name__)
 

--- a/src/karenina/benchmark/verification/utils/embedding_check.py
+++ b/src/karenina/benchmark/verification/utils/embedding_check.py
@@ -7,10 +7,10 @@ import threading
 from collections import OrderedDict
 from typing import Any
 
-from ....adapters.factory import get_llm
-from ....ports.messages import Message
-from ....schemas.config import ModelConfig
-from ....schemas.verification.config import DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_THRESHOLD
+from karenina.adapters.factory import get_llm
+from karenina.ports.messages import Message
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification.config import DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_THRESHOLD
 
 logger = logging.getLogger(__name__)
 

--- a/src/karenina/benchmark/verification/utils/llm_judge_helpers.py
+++ b/src/karenina/benchmark/verification/utils/llm_judge_helpers.py
@@ -16,9 +16,8 @@ from typing import Any, TypeVar
 
 from pydantic import BaseModel
 
+from karenina.ports import LLMResponse
 from karenina.utils.json_extraction import strip_markdown_fences
-
-from ....ports import LLMResponse
 
 logger = logging.getLogger(__name__)
 

--- a/src/karenina/benchmark/verification/utils/search_helpers.py
+++ b/src/karenina/benchmark/verification/utils/search_helpers.py
@@ -12,7 +12,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from ....schemas import SearchResultItem
+    from karenina.schemas import SearchResultItem
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ def parse_tool_output(raw_result: Any) -> list["SearchResultItem"]:
         Returns empty list on failure rather than raising.
     """
     # Import here to avoid circular imports
-    from ....schemas import SearchResultItem
+    from karenina.schemas import SearchResultItem
 
     # Case 1: Already a list of SearchResultItem
     if isinstance(raw_result, list) and all(isinstance(item, SearchResultItem) for item in raw_result):

--- a/src/karenina/benchmark/verification/utils/search_provider.py
+++ b/src/karenina/benchmark/verification/utils/search_provider.py
@@ -52,7 +52,8 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from ....schemas import SearchResultItem
+from karenina.schemas import SearchResultItem
+
 from .search_helpers import parse_tool_output as _parse_tool_output
 
 logger = logging.getLogger(__name__)

--- a/src/karenina/benchmark/verification/utils/search_tavily.py
+++ b/src/karenina/benchmark/verification/utils/search_tavily.py
@@ -23,7 +23,7 @@ from typing import Any
 
 from pydantic import SecretStr
 
-from ....schemas import SearchResultItem
+from karenina.schemas import SearchResultItem
 
 logger = logging.getLogger(__name__)
 

--- a/src/karenina/benchmark/verification/utils/storage_helpers.py
+++ b/src/karenina/benchmark/verification/utils/storage_helpers.py
@@ -6,7 +6,7 @@ This module provides database auto-save functionality for verification results.
 import logging
 from typing import Any
 
-from ....schemas.verification import FinishedTemplate, VerificationResult
+from karenina.schemas.verification import FinishedTemplate, VerificationResult
 
 logger = logging.getLogger(__name__)
 
@@ -32,8 +32,8 @@ def auto_save_results(
         run_id: Unique identifier for this run
     """
     try:
-        from ....benchmark import Benchmark
-        from ....storage import DBConfig, get_benchmark_summary, save_benchmark, save_verification_results
+        from karenina.benchmark import Benchmark
+        from karenina.storage import DBConfig, get_benchmark_summary, save_benchmark, save_verification_results
 
         # Create database config
         db_config = DBConfig(storage_url=storage_url)

--- a/src/karenina/benchmark/verification/utils/task_helpers.py
+++ b/src/karenina/benchmark/verification/utils/task_helpers.py
@@ -7,8 +7,8 @@ few-shot resolution, and preview result creation.
 import logging
 from typing import Any
 
-from ....schemas.entities import Rubric
-from ....schemas.verification import (
+from karenina.schemas.entities import Rubric
+from karenina.schemas.verification import (
     FinishedTemplate,
     VerificationConfig,
     VerificationResult,
@@ -48,7 +48,7 @@ def merge_rubrics_for_task(
             logger.warning(f"Failed to parse question rubric for {template.question_id}: {e}")
 
     try:
-        from ....schemas import merge_rubrics
+        from karenina.schemas import merge_rubrics
 
         return merge_rubrics(global_rubric, question_rubric)
     except ValueError as e:

--- a/src/karenina/benchmark/verification/utils/template_parsing_helpers.py
+++ b/src/karenina/benchmark/verification/utils/template_parsing_helpers.py
@@ -9,12 +9,12 @@ import logging
 import re
 from typing import Any, get_args, get_origin
 
+from karenina.schemas.entities import BaseAnswer
+from karenina.schemas.shared import SearchResultItem
+
 # Re-export shared utilities for backward compatibility
 from karenina.utils.json_extraction import extract_json_from_text as _extract_json_from_text
 from karenina.utils.json_extraction import strip_markdown_fences as _strip_markdown_fences
-
-from ....schemas.entities import BaseAnswer
-from ....schemas.shared import SearchResultItem
 
 __all__ = [
     "_strip_markdown_fences",
@@ -419,7 +419,7 @@ def extract_rubric_traits_from_template(answer_template: str) -> list[Any]:
     """
     try:
         # Prepare minimal execution environment similar to template validation
-        from ....schemas.entities import CallableTrait, LLMRubricTrait, MetricRubricTrait, RegexTrait, Rubric
+        from karenina.schemas.entities import CallableTrait, LLMRubricTrait, MetricRubricTrait, RegexTrait, Rubric
 
         global_ns = {
             "__builtins__": __builtins__,

--- a/src/karenina/benchmark/verification/utils/template_validation.py
+++ b/src/karenina/benchmark/verification/utils/template_validation.py
@@ -2,7 +2,7 @@
 
 import inspect
 
-from ....schemas.entities import BaseAnswer
+from karenina.schemas.entities import BaseAnswer
 
 
 def validate_answer_template(template_code: str) -> tuple[bool, str | None, type | None]:

--- a/src/karenina/storage/operations.py
+++ b/src/karenina/storage/operations.py
@@ -12,7 +12,8 @@ from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 if TYPE_CHECKING:
-    from ...schemas.verification import VerificationResult
+    from karenina.schemas.verification import VerificationResult
+
     from ..benchmark.benchmark import Benchmark
 
 from sqlalchemy import Select, select
@@ -599,10 +600,12 @@ def _model_to_verification_result(model: VerificationResultModel) -> "Verificati
     automatically reconstruct the nested Pydantic model from the
     flat SQLAlchemy model.
     """
+    from typing import cast
+
     from karenina.schemas.verification import VerificationResult
 
     # Use auto-converter to reconstruct nested Pydantic model from flat ORM
-    return orm_to_pydantic(model, VerificationResult, FLATTEN_CONFIG)
+    return cast(VerificationResult, orm_to_pydantic(model, VerificationResult, FLATTEN_CONFIG))
 
 
 def import_verification_results(


### PR DESCRIPTION
## Summary

Converts all 3–5 dot deep relative imports to absolute `karenina.*` paths across 48 files, enforcing CLAUDE.md §3 (max 2-dot relative imports). No logic changes — import paths only.

## Changes Made

- **48 files modified** across `benchmark/`, `storage/`
- **190 deep relative imports** replaced with absolute equivalents:
  - 5-dot (`from .....X`) → `from karenina.X` (evaluators, stages at depth 4)
  - 4-dot (`from ....X`) → `from karenina.X` (verification/utils at depth 3)
  - 3-dot (`from ...X`) → `from karenina.X` or `from karenina.benchmark.verification.X` (benchmark/core, task_eval, verification root, stages/pipeline)
- All 1-dot and 2-dot relative imports preserved unchanged
- Ruff auto-sorted imports in 37 files as part of pre-commit
- Added `cast()` in `storage/operations.py` to resolve mypy error exposed by the import change

### Files by area

| Area | Files |
|------|-------|
| `benchmark/verification/evaluators/` | 8 (rubric, template, trace) |
| `benchmark/verification/stages/` | 12 (core, helpers, pipeline) |
| `benchmark/verification/utils/` | 10 |
| `benchmark/verification/` (root) | 3 (executor, batch_runner, runner) |
| `benchmark/core/` | 8 |
| `benchmark/task_eval/` | 3 |
| `storage/` | 1 |

## Testing

- Full test suite: **2692 passed, 5 skipped, 0 failures** (unchanged from baseline)
- Pre-commit hooks all pass (ruff, ruff-format, mypy, vulture)
- Grep confirms zero 3+ dot relative imports remain in `src/karenina/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>