### PR TITLE
Add langchain_deep_agents adapter with conformance test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,10 @@ embeddings = [
 gepa = [
     "gepa>=0.0.24",  # For GEPA prompt optimization integration
 ]
+deep-agents = [
+    "deepagents>=0.4.0",
+    "langchain-mcp-adapters>=0.1.0",
+]
 
 [project.scripts]
 karenina = "karenina.cli:app"

--- a/src/karenina/adapters/factory.py
+++ b/src/karenina/adapters/factory.py
@@ -57,7 +57,7 @@ from karenina.schemas.config import INTERFACES_NO_PROVIDER_REQUIRED
 
 # Type alias for interface values
 InterfaceType: TypeAlias = Literal[
-    "langchain", "openrouter", "manual", "openai_endpoint", "claude_agent_sdk", "claude_tool"
+    "langchain", "openrouter", "manual", "openai_endpoint", "claude_agent_sdk", "claude_tool", "langchain_deep_agents"
 ]
 
 logger = logging.getLogger(__name__)

--- a/src/karenina/adapters/langchain_deep_agents/__init__.py
+++ b/src/karenina/adapters/langchain_deep_agents/__init__.py
@@ -1,0 +1,69 @@
+"""LangChain Deep Agents adapter for natively agentic evaluation.
+
+This adapter provides AgentPort, LLMPort, and ParserPort implementations
+using LangChain Deep Agents (create_deep_agent). It enables provider-agnostic
+agentic evaluation with built-in planning, context management, and subagent
+orchestration.
+
+Requires: pip install deepagents langchain-mcp-adapters
+
+Adapter classes:
+    - DeepAgentsAgentAdapter: Agent loops via create_deep_agent with MCP support
+    - DeepAgentsLLMAdapter: Simple LLM invocation via single-turn agent
+    - DeepAgentsParserAdapter: Structured output parsing
+
+Utilities:
+    - DeepAgentsMessageConverter: Convert between unified Message and LangGraph types
+    - check_deep_agents_available: Check if deepagents is installed
+    - convert_mcp_to_tools: Convert MCPServerConfig to LangChain tools
+    - extract_deep_agents_usage: Extract UsageMetadata from agent results
+    - deep_agents_messages_to_raw_trace: Format messages as raw trace string
+"""
+
+from typing import TYPE_CHECKING, Any
+
+__all__ = [
+    "DeepAgentsAgentAdapter",
+    "DeepAgentsLLMAdapter",
+    "DeepAgentsParserAdapter",
+    "DeepAgentsMessageConverter",
+    "check_deep_agents_available",
+    "convert_mcp_to_tools",
+    "extract_deep_agents_usage",
+    "deep_agents_messages_to_raw_trace",
+    "wrap_deep_agents_error",
+]
+
+if TYPE_CHECKING:
+    from karenina.adapters.langchain_deep_agents.agent import DeepAgentsAgentAdapter
+    from karenina.adapters.langchain_deep_agents.availability import check_deep_agents_available
+    from karenina.adapters.langchain_deep_agents.errors import wrap_deep_agents_error
+    from karenina.adapters.langchain_deep_agents.llm import DeepAgentsLLMAdapter
+    from karenina.adapters.langchain_deep_agents.mcp import convert_mcp_to_tools
+    from karenina.adapters.langchain_deep_agents.messages import DeepAgentsMessageConverter
+    from karenina.adapters.langchain_deep_agents.parser import DeepAgentsParserAdapter
+    from karenina.adapters.langchain_deep_agents.trace import deep_agents_messages_to_raw_trace
+    from karenina.adapters.langchain_deep_agents.usage import extract_deep_agents_usage
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy import adapter classes to avoid circular imports."""
+    _imports = {
+        "DeepAgentsAgentAdapter": "karenina.adapters.langchain_deep_agents.agent",
+        "DeepAgentsLLMAdapter": "karenina.adapters.langchain_deep_agents.llm",
+        "DeepAgentsParserAdapter": "karenina.adapters.langchain_deep_agents.parser",
+        "DeepAgentsMessageConverter": "karenina.adapters.langchain_deep_agents.messages",
+        "check_deep_agents_available": "karenina.adapters.langchain_deep_agents.availability",
+        "convert_mcp_to_tools": "karenina.adapters.langchain_deep_agents.mcp",
+        "extract_deep_agents_usage": "karenina.adapters.langchain_deep_agents.usage",
+        "deep_agents_messages_to_raw_trace": "karenina.adapters.langchain_deep_agents.trace",
+        "wrap_deep_agents_error": "karenina.adapters.langchain_deep_agents.errors",
+    }
+
+    if name in _imports:
+        import importlib
+
+        module = importlib.import_module(_imports[name])
+        return getattr(module, name)
+
+    raise AttributeError(f"module 'karenina.adapters.langchain_deep_agents' has no attribute '{name}'")

--- a/src/karenina/adapters/langchain_deep_agents/agent.py
+++ b/src/karenina/adapters/langchain_deep_agents/agent.py
@@ -1,0 +1,315 @@
+"""LangChain Deep Agents adapter implementing the AgentPort interface.
+
+This module provides the DeepAgentsAgentAdapter class that implements AgentPort
+using Deep Agents' create_deep_agent() for agent loops with built-in planning,
+context management, and subagent orchestration.
+
+Key differences from the Claude Agent SDK adapter:
+- Deep Agents uses LangGraph's compiled graph API (.ainvoke/.invoke)
+- Messages are LangGraph BaseMessage instances in the result state
+- System prompts go to the create_deep_agent() system_prompt parameter
+- Recursion limit controls max agent steps via LangGraph config
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+from typing import TYPE_CHECKING, Any
+
+from karenina.ports import (
+    AgentConfig,
+    AgentResponseError,
+    AgentResult,
+    AgentTimeoutError,
+    MCPServerConfig,
+    Message,
+    Tool,
+)
+
+from .errors import wrap_deep_agents_error
+from .initialization import create_chat_model
+from .messages import DeepAgentsMessageConverter
+from .trace import deep_agents_messages_to_raw_trace
+from .usage import extract_actual_model, extract_deep_agents_usage
+
+if TYPE_CHECKING:
+    from karenina.schemas.config import ModelConfig
+
+# Lazy import: resolved at first arun() call. Allows module to load
+# without deepagents installed (availability check gates actual use).
+_create_deep_agent = None
+
+logger = logging.getLogger(__name__)
+
+
+class DeepAgentsAgentAdapter:
+    """Agent adapter using LangChain Deep Agents' create_deep_agent.
+
+    This adapter implements the AgentPort Protocol for agent execution with
+    built-in planning tools, filesystem operations, subagent delegation,
+    and context management. Uses create_deep_agent() which returns a
+    compiled LangGraph graph.
+
+    The adapter handles:
+    - Message conversion from unified Message to prompt string
+    - Model initialization via init_chat_model
+    - Agent creation and invocation via LangGraph
+    - Dual trace output (raw_trace string and trace_messages list)
+    - Usage metadata extraction from AIMessage response_metadata
+    - Recursion limit detection from LangGraph state
+
+    Example:
+        >>> config = ModelConfig(
+        ...     id="test",
+        ...     model_name="claude-sonnet-4-20250514",
+        ...     model_provider="anthropic",
+        ...     interface="langchain_deep_agents",
+        ... )
+        >>> adapter = DeepAgentsAgentAdapter(config)
+        >>> result = await adapter.arun(
+        ...     messages=[Message.user("What files are in /tmp?")],
+        ...     config=AgentConfig(max_turns=10),
+        ... )
+        >>> print(result.final_response)
+    """
+
+    def __init__(self, model_config: ModelConfig) -> None:
+        """Initialize the Deep Agents adapter.
+
+        Args:
+            model_config: Configuration specifying model, provider, and interface.
+        """
+        self._config = model_config
+        self._converter = DeepAgentsMessageConverter()
+
+    def _extract_final_response(self, lc_messages: list[Any]) -> str:
+        """Extract final text response from the last AIMessage.
+
+        Args:
+            lc_messages: List of LangGraph BaseMessage objects.
+
+        Returns:
+            The final text response string.
+        """
+        from langchain_core.messages import AIMessage
+
+        for msg in reversed(lc_messages):
+            if isinstance(msg, AIMessage):
+                if isinstance(msg.content, str) and msg.content:
+                    return msg.content
+                if isinstance(msg.content, list):
+                    text_parts = []
+                    for block in msg.content:
+                        if isinstance(block, str):
+                            text_parts.append(block)
+                        elif isinstance(block, dict) and block.get("type") == "text":
+                            text_parts.append(block["text"])
+                    if text_parts:
+                        return "\n".join(text_parts)
+
+        return "[No final response extracted]"
+
+    def _count_turns(self, lc_messages: list[Any]) -> int:
+        """Count the number of agent turns (AIMessage instances).
+
+        Args:
+            lc_messages: List of LangGraph BaseMessage objects.
+
+        Returns:
+            Number of AIMessage instances in the conversation.
+        """
+        from langchain_core.messages import AIMessage
+
+        return sum(1 for msg in lc_messages if isinstance(msg, AIMessage))
+
+    async def arun(
+        self,
+        messages: list[Message],
+        tools: list[Tool] | None = None,  # noqa: ARG002 - required by AgentPort protocol
+        mcp_servers: dict[str, MCPServerConfig] | None = None,  # noqa: ARG002 - required by AgentPort protocol
+        config: AgentConfig | None = None,
+    ) -> AgentResult:
+        """Execute an agent loop with optional tools and MCP servers.
+
+        Args:
+            messages: Initial conversation messages.
+            tools: Optional list of Tool definitions the agent can invoke.
+            mcp_servers: Optional dict of MCP server configurations.
+            config: Optional AgentConfig for execution parameters.
+
+        Returns:
+            AgentResult with final response, traces, usage, and metadata.
+
+        Raises:
+            AgentExecutionError: If the agent fails during execution.
+            AgentTimeoutError: If execution exceeds the timeout.
+            AgentResponseError: If the response is malformed or invalid.
+        """
+        global _create_deep_agent  # noqa: PLW0603
+        if _create_deep_agent is None:
+            from deepagents import create_deep_agent as _cda
+
+            _create_deep_agent = _cda
+
+        config = config or AgentConfig()
+
+        # Convert messages to prompt string and extract system prompt
+        prompt_string = self._converter.to_prompt_string(messages)
+        system_prompt = self._converter.extract_system_prompt(messages)
+
+        # Use config system_prompt as fallback
+        if not system_prompt and config.system_prompt:
+            system_prompt = config.system_prompt
+        elif not system_prompt and self._config.system_prompt:
+            system_prompt = self._config.system_prompt
+
+        # Initialize model
+        chat_model = create_chat_model(self._config)
+
+        # Build agent kwargs
+        agent_kwargs: dict[str, Any] = {"model": chat_model}
+        if system_prompt:
+            agent_kwargs["system_prompt"] = system_prompt
+
+        # Pass through extra config to create_deep_agent
+        if config.extra:
+            for key, value in config.extra.items():
+                if key not in ("model", "system_prompt"):
+                    agent_kwargs[key] = value
+
+        # Create the agent
+        agent = _create_deep_agent(**agent_kwargs)
+
+        # Build invocation input
+        invoke_input: dict[str, Any] = {
+            "messages": [{"role": "user", "content": prompt_string}],
+        }
+
+        # LangGraph config for recursion limit
+        # Each tool call + response = 2 steps, so double max_turns
+        langgraph_config: dict[str, Any] = {
+            "recursion_limit": config.max_turns * 2,
+        }
+
+        # Execute agent
+        result: dict[str, Any] = {}
+        limit_reached = False
+
+        async def execute_agent() -> None:
+            nonlocal result, limit_reached
+
+            result = await agent.ainvoke(invoke_input, config=langgraph_config)
+
+            # Check if limit was reached via state
+            if result.get("is_last_step", False):
+                limit_reached = True
+
+        try:
+            if config.timeout:
+                await asyncio.wait_for(execute_agent(), timeout=config.timeout)
+            else:
+                await execute_agent()
+
+        except TimeoutError as e:
+            raise AgentTimeoutError(f"Agent execution timed out after {config.timeout}s") from e
+        except Exception as e:
+            mapped_error, was_limit = wrap_deep_agents_error(e)
+            if was_limit:
+                limit_reached = True
+                logger.warning("Agent hit turn limit: %s", e)
+            else:
+                raise mapped_error from e
+
+        # Extract messages from result
+        lc_messages: list[Any] = result.get("messages", [])
+
+        if not lc_messages:
+            raise AgentResponseError("No messages received from Deep Agents")
+
+        # Build raw_trace (legacy string format)
+        raw_trace = deep_agents_messages_to_raw_trace(lc_messages)
+        if limit_reached:
+            raw_trace += "\n\n[Note: Recursion limit reached, partial response shown]"
+
+        # Build trace_messages (structured format)
+        trace_messages = self._converter.from_provider(lc_messages)
+
+        # Extract final response
+        final_response = self._extract_final_response(lc_messages)
+
+        # Extract usage
+        usage = extract_deep_agents_usage(lc_messages, model=self._config.model_name)
+
+        # Count turns
+        turns = self._count_turns(lc_messages)
+
+        # Extract actual model
+        actual_model = extract_actual_model(lc_messages) or self._config.model_name
+
+        return AgentResult(
+            final_response=final_response,
+            raw_trace=raw_trace,
+            trace_messages=trace_messages,
+            usage=usage,
+            turns=turns,
+            limit_reached=limit_reached,
+            session_id=None,
+            actual_model=actual_model,
+        )
+
+    def run(
+        self,
+        messages: list[Message],
+        tools: list[Tool] | None = None,
+        mcp_servers: dict[str, MCPServerConfig] | None = None,
+        config: AgentConfig | None = None,
+    ) -> AgentResult:
+        """Synchronous wrapper for arun().
+
+        Args:
+            messages: Initial conversation messages.
+            tools: Optional list of Tool definitions.
+            mcp_servers: Optional MCP server configurations.
+            config: Optional AgentConfig for execution parameters.
+
+        Returns:
+            AgentResult from the agent execution.
+
+        Raises:
+            AgentExecutionError: If the agent fails during execution.
+            AgentTimeoutError: If execution exceeds the timeout.
+            AgentResponseError: If the response is malformed or invalid.
+        """
+        from karenina.benchmark.verification.executor import get_async_portal
+
+        portal = get_async_portal()
+
+        if portal is not None:
+            return portal.call(self.arun, messages, tools, mcp_servers, config)
+
+        # No portal: check if we're in an async context
+        try:
+            asyncio.get_running_loop()
+            # We're in an async context: use ThreadPoolExecutor
+
+            def run_in_thread() -> AgentResult:
+                return asyncio.run(self.arun(messages, tools, mcp_servers, config))
+
+            timeout = config.timeout if config and config.timeout else 600
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future = executor.submit(run_in_thread)
+                return future.result(timeout=timeout)
+
+        except RuntimeError:
+            # No event loop running, safe to use asyncio.run
+            return asyncio.run(self.arun(messages, tools, mcp_servers, config))
+
+    async def aclose(self) -> None:
+        """Close underlying resources.
+
+        Deep Agents manages its own cleanup via LangGraph's compiled graph,
+        so this is a no-op. Provided for interface consistency with other
+        adapters that do require cleanup.
+        """

--- a/src/karenina/adapters/langchain_deep_agents/agent.py
+++ b/src/karenina/adapters/langchain_deep_agents/agent.py
@@ -173,10 +173,26 @@ class DeepAgentsAgentAdapter:
         if system_prompt:
             agent_kwargs["system_prompt"] = system_prompt
 
+        # Configure backend for real filesystem access when workspace is available
+        workspace_path = config.workspace_path
+        if workspace_path:
+            from deepagents.backends import FilesystemBackend
+
+            agent_kwargs["backend"] = FilesystemBackend(root_dir=str(workspace_path))
+            logger.info("Using FilesystemBackend with root_dir=%s", workspace_path)
+        else:
+            # Default: use FilesystemBackend rooted at cwd for real filesystem access.
+            # StateBackend (virtual/in-memory) is NOT suitable for benchmarking because
+            # the agent cannot see real files on disk.
+            from deepagents.backends import FilesystemBackend
+
+            agent_kwargs["backend"] = FilesystemBackend()
+            logger.info("Using FilesystemBackend with default root (cwd)")
+
         # Pass through extra config to create_deep_agent
         if config.extra:
             for key, value in config.extra.items():
-                if key not in ("model", "system_prompt"):
+                if key not in ("model", "system_prompt", "backend"):
                     agent_kwargs[key] = value
 
         # Create the agent

--- a/src/karenina/adapters/langchain_deep_agents/agent.py
+++ b/src/karenina/adapters/langchain_deep_agents/agent.py
@@ -26,6 +26,7 @@ from karenina.ports import (
     MCPServerConfig,
     Message,
     Tool,
+    UsageMetadata,
 )
 
 from .errors import wrap_deep_agents_error
@@ -241,8 +242,21 @@ class DeepAgentsAgentAdapter:
         # Extract messages from result
         lc_messages: list[Any] = result.get("messages", [])
 
-        if not lc_messages:
+        if not lc_messages and not limit_reached:
             raise AgentResponseError("No messages received from Deep Agents")
+
+        # If limit was reached but no messages, return a partial result
+        if not lc_messages and limit_reached:
+            return AgentResult(
+                final_response="[Agent hit recursion limit before producing a response]",
+                raw_trace="[Note: Recursion limit reached, no response produced]",
+                trace_messages=[],
+                usage=UsageMetadata(model=self._config.model_name),
+                turns=0,
+                limit_reached=True,
+                session_id=None,
+                actual_model=self._config.model_name,
+            )
 
         # Build raw_trace (legacy string format)
         raw_trace = deep_agents_messages_to_raw_trace(lc_messages)

--- a/src/karenina/adapters/langchain_deep_agents/availability.py
+++ b/src/karenina/adapters/langchain_deep_agents/availability.py
@@ -1,0 +1,31 @@
+"""Availability check for LangChain Deep Agents adapter.
+
+Verifies that the deepagents package is installed. No fallback interface
+is provided because Deep Agents' natively agentic behavior cannot be
+meaningfully approximated by the scaffolded LangChain adapter.
+"""
+
+from __future__ import annotations
+
+from karenina.adapters.registry import AdapterAvailability
+
+
+def check_deep_agents_available() -> AdapterAvailability:
+    """Check if the deepagents package is installed.
+
+    Returns:
+        AdapterAvailability with status and installation instructions.
+    """
+    try:
+        import deepagents  # noqa: F401
+
+        return AdapterAvailability(
+            available=True,
+            reason="deepagents package is installed",
+        )
+    except ImportError:
+        return AdapterAvailability(
+            available=False,
+            reason=("deepagents package not installed. Install with: pip install deepagents or: uv add deepagents"),
+            fallback_interface=None,
+        )

--- a/src/karenina/adapters/langchain_deep_agents/errors.py
+++ b/src/karenina/adapters/langchain_deep_agents/errors.py
@@ -1,0 +1,56 @@
+"""Error mapping for LangChain Deep Agents adapter.
+
+Maps Deep Agents and LangGraph exceptions to karenina's exception hierarchy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from karenina.ports import AgentExecutionError, AgentResponseError, AgentTimeoutError
+
+logger = logging.getLogger(__name__)
+
+
+def wrap_deep_agents_error(error: Exception) -> tuple[Exception, bool]:
+    """Map a Deep Agents / LangGraph exception to a karenina exception.
+
+    Args:
+        error: The original exception from Deep Agents or LangGraph.
+
+    Returns:
+        Tuple of (mapped_exception, limit_reached). The limit_reached flag
+        is True when the error indicates the agent hit a recursion or turn limit.
+    """
+    error_str = str(error).lower()
+
+    # Check for recursion / turn limit errors
+    if "recursion" in error_str or "limit" in error_str or "max_turns" in error_str:
+        return (
+            AgentExecutionError(f"Agent hit turn limit: {error}"),
+            True,
+        )
+
+    # Timeout errors
+    if isinstance(error, TimeoutError | asyncio.TimeoutError):
+        return AgentTimeoutError(f"Agent execution timed out: {error}"), False
+
+    # Output parsing errors
+    if "parse" in error_str or "output" in error_str and "format" in error_str:
+        return AgentResponseError(f"Failed to parse agent response: {error}"), False
+
+    # GraphRecursionError from LangGraph
+    try:
+        from langgraph.errors import GraphRecursionError
+
+        if isinstance(error, GraphRecursionError):
+            return (
+                AgentExecutionError(f"Agent hit recursion limit: {error}"),
+                True,
+            )
+    except ImportError:
+        pass
+
+    # Default: general execution error
+    return AgentExecutionError(f"Agent execution failed: {error}"), False

--- a/src/karenina/adapters/langchain_deep_agents/initialization.py
+++ b/src/karenina/adapters/langchain_deep_agents/initialization.py
@@ -1,0 +1,60 @@
+"""Model initialization for the Deep Agents adapter.
+
+Adapted from the LangChain adapter's init_chat_model_unified. Creates a
+BaseChatModel instance that can be passed to create_deep_agent(model=...).
+
+This is a separate copy (not a cross-adapter import) to maintain adapter
+isolation per karenina conventions.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from langchain.chat_models import init_chat_model
+
+from karenina.ports import AdapterUnavailableError
+
+if TYPE_CHECKING:
+    from karenina.schemas.config import ModelConfig
+
+logger = logging.getLogger(__name__)
+
+
+def create_chat_model(model_config: ModelConfig, **kwargs: Any) -> Any:
+    """Create a LangChain BaseChatModel from a karenina ModelConfig.
+
+    Args:
+        model_config: Configuration specifying model name and provider.
+        **kwargs: Additional arguments passed to init_chat_model.
+
+    Returns:
+        Initialized BaseChatModel instance.
+
+    Raises:
+        AdapterUnavailableError: If required configuration is missing.
+    """
+    if not model_config.model_name:
+        raise AdapterUnavailableError(
+            "model_name is required for langchain_deep_agents interface",
+            reason="missing_model_name",
+        )
+
+    if not model_config.model_provider:
+        raise AdapterUnavailableError(
+            "model_provider is required for langchain_deep_agents interface",
+            reason="missing_model_provider",
+        )
+
+    model_kwargs: dict[str, Any] = {}
+    if model_config.temperature is not None:
+        model_kwargs["temperature"] = model_config.temperature
+
+    model_kwargs.update(kwargs)
+
+    return init_chat_model(
+        model=model_config.model_name,
+        model_provider=model_config.model_provider,
+        **model_kwargs,
+    )

--- a/src/karenina/adapters/langchain_deep_agents/llm.py
+++ b/src/karenina/adapters/langchain_deep_agents/llm.py
@@ -1,0 +1,189 @@
+"""LangChain Deep Agents LLM adapter implementing the LLMPort interface.
+
+This module provides the DeepAgentsLLMAdapter class that implements LLMPort
+using LangChain's init_chat_model for simple single-turn LLM calls.
+
+For single-turn calls, the adapter uses the LangChain model directly (not
+create_deep_agent), since no agent loop or tool calling is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+from karenina.ports import LLMResponse, Message
+from karenina.ports.capabilities import PortCapabilities
+from karenina.ports.usage import UsageMetadata
+
+from .initialization import create_chat_model
+from .messages import DeepAgentsMessageConverter
+
+if TYPE_CHECKING:
+    from karenina.schemas.config import ModelConfig
+
+logger = logging.getLogger(__name__)
+
+
+class DeepAgentsLLMAdapter:
+    """LLM adapter using LangChain's init_chat_model for single-turn calls.
+
+    This adapter implements the LLMPort Protocol for simple LLM invocation
+    without agent loops. Uses the LangChain model directly for efficiency.
+
+    Example:
+        >>> config = ModelConfig(
+        ...     id="test",
+        ...     model_name="claude-sonnet-4-20250514",
+        ...     model_provider="anthropic",
+        ...     interface="langchain_deep_agents",
+        ... )
+        >>> adapter = DeepAgentsLLMAdapter(config)
+        >>> response = await adapter.ainvoke([Message.user("Hello!")])
+        >>> print(response.content)
+    """
+
+    def __init__(
+        self,
+        model_config: ModelConfig,
+        *,
+        _structured_schema: type[BaseModel] | None = None,
+    ) -> None:
+        """Initialize the Deep Agents LLM adapter.
+
+        Args:
+            model_config: Configuration specifying model, provider, and interface.
+            _structured_schema: Internal; schema for structured output mode.
+        """
+        self._config = model_config
+        self._converter = DeepAgentsMessageConverter()
+        self._structured_schema = _structured_schema
+
+    @property
+    def capabilities(self) -> PortCapabilities:
+        """Declare adapter capabilities.
+
+        Returns:
+            PortCapabilities with system_prompt=True and structured_output=True.
+        """
+        return PortCapabilities(
+            supports_system_prompt=True,
+            supports_structured_output=True,
+        )
+
+    async def ainvoke(self, messages: list[Message]) -> LLMResponse:
+        """Invoke the LLM asynchronously.
+
+        Converts karenina Messages to LangChain format, invokes the model,
+        and converts the response back.
+
+        Args:
+            messages: List of messages forming the conversation.
+
+        Returns:
+            LLMResponse containing the generated content and usage metadata.
+        """
+        from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+        # Build LangChain message list
+        lc_messages: list[Any] = []
+        for msg in messages:
+            text = msg.text or ""
+            if msg.role.value == "system":
+                lc_messages.append(SystemMessage(content=text))
+            elif msg.role.value == "user":
+                lc_messages.append(HumanMessage(content=text))
+            elif msg.role.value == "assistant":
+                lc_messages.append(AIMessage(content=text))
+
+        # Create model
+        chat_model = create_chat_model(self._config)
+
+        # Apply structured output if configured
+        if self._structured_schema is not None:
+            chat_model = chat_model.with_structured_output(self._structured_schema)
+
+        # Invoke
+        response = await chat_model.ainvoke(lc_messages)
+
+        # Extract content
+        if self._structured_schema is not None:
+            # Structured output returns a Pydantic model or dict
+            if isinstance(response, BaseModel):
+                content = response.model_dump_json()
+            elif isinstance(response, dict):
+                import json
+
+                content = json.dumps(response)
+            else:
+                content = str(response)
+        elif isinstance(response, AIMessage):
+            content = response.content if isinstance(response.content, str) else str(response.content)
+        else:
+            content = str(response)
+
+        # Extract usage
+        usage = UsageMetadata(model=self._config.model_name)
+        if isinstance(response, AIMessage):
+            usage_meta = getattr(response, "usage_metadata", None)
+            if usage_meta and isinstance(usage_meta, dict):
+                usage = UsageMetadata(
+                    input_tokens=usage_meta.get("input_tokens", 0),
+                    output_tokens=usage_meta.get("output_tokens", 0),
+                    total_tokens=usage_meta.get("input_tokens", 0) + usage_meta.get("output_tokens", 0),
+                    model=self._config.model_name,
+                )
+
+        return LLMResponse(content=content, usage=usage, raw=response)
+
+    def invoke(self, messages: list[Message]) -> LLMResponse:
+        """Invoke the LLM synchronously.
+
+        Args:
+            messages: List of messages forming the conversation.
+
+        Returns:
+            LLMResponse containing the generated content and usage metadata.
+        """
+        from karenina.benchmark.verification.executor import get_async_portal
+
+        portal = get_async_portal()
+        if portal is not None:
+            return portal.call(self.ainvoke, messages)
+
+        try:
+            asyncio.get_running_loop()
+
+            def run_in_thread() -> LLMResponse:
+                return asyncio.run(self.ainvoke(messages))
+
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future = executor.submit(run_in_thread)
+                return future.result(timeout=600)
+
+        except RuntimeError:
+            return asyncio.run(self.ainvoke(messages))
+
+    def with_structured_output(
+        self,
+        schema: type[BaseModel],
+        *,
+        max_retries: int | None = None,  # noqa: ARG002
+    ) -> DeepAgentsLLMAdapter:
+        """Return a new adapter configured for structured output.
+
+        Args:
+            schema: A Pydantic model class defining the output structure.
+            max_retries: Ignored (LangChain handles retries internally).
+
+        Returns:
+            A new DeepAgentsLLMAdapter configured with the schema.
+        """
+        return DeepAgentsLLMAdapter(
+            self._config,
+            _structured_schema=schema,
+        )

--- a/src/karenina/adapters/langchain_deep_agents/mcp.py
+++ b/src/karenina/adapters/langchain_deep_agents/mcp.py
@@ -1,0 +1,94 @@
+"""MCP server configuration conversion for Deep Agents adapter.
+
+Converts karenina's MCPServerConfig (TypedDict union) to parameters
+compatible with langchain-mcp-adapters' MultiServerMCPClient.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def build_mcp_server_params(
+    mcp_servers: dict[str, Any] | None,
+) -> dict[str, dict[str, Any]]:
+    """Convert MCPServerConfig dict to langchain-mcp-adapters parameters.
+
+    Discriminates stdio vs HTTP/SSE transports using the 'type' field
+    from MCPServerConfig TypedDicts.
+
+    Args:
+        mcp_servers: Dict mapping server names to MCPServerConfig.
+
+    Returns:
+        Dict of server parameters for MultiServerMCPClient.
+    """
+    if not mcp_servers:
+        return {}
+
+    server_params: dict[str, dict[str, Any]] = {}
+
+    for name, config in mcp_servers.items():
+        if not isinstance(config, dict):
+            logger.warning("Skipping non-dict MCP config for server %s", name)
+            continue
+
+        transport_type = config.get("type", "stdio")
+
+        if transport_type == "stdio":
+            params: dict[str, Any] = {
+                "transport": "stdio",
+                "command": config["command"],
+                "args": config.get("args", []),
+            }
+            env = config.get("env")
+            if env:
+                params["env"] = env
+            server_params[name] = params
+
+        elif transport_type in ("http", "sse"):
+            # Map karenina's "http" type to the library's "sse" transport
+            params = {
+                "transport": "sse" if transport_type == "http" else transport_type,
+                "url": config["url"],
+            }
+            headers = config.get("headers")
+            if headers:
+                params["headers"] = headers
+            server_params[name] = params
+
+        else:
+            logger.warning(
+                "Unknown MCP transport type '%s' for server %s",
+                transport_type,
+                name,
+            )
+
+    return server_params
+
+
+async def convert_mcp_to_tools(
+    mcp_servers: dict[str, Any] | None,
+) -> list[Any]:
+    """Convert MCP server configs to LangChain tools via langchain-mcp-adapters.
+
+    Creates a MultiServerMCPClient, connects to all servers, and returns
+    their tools as LangChain BaseTool instances.
+
+    Args:
+        mcp_servers: Dict mapping server names to MCPServerConfig.
+
+    Returns:
+        List of LangChain BaseTool instances from all MCP servers.
+    """
+    server_params = build_mcp_server_params(mcp_servers)
+    if not server_params:
+        return []
+
+    from langchain_mcp_adapters.client import MultiServerMCPClient
+
+    async with MultiServerMCPClient(server_params) as client:  # type: ignore[arg-type,misc]
+        return await client.get_tools()

--- a/src/karenina/adapters/langchain_deep_agents/messages.py
+++ b/src/karenina/adapters/langchain_deep_agents/messages.py
@@ -1,0 +1,165 @@
+"""Message conversion between karenina's unified Message and LangGraph types.
+
+Handles bidirectional conversion:
+- To Deep Agents: karenina Message -> prompt string (system extracted separately)
+- From Deep Agents: LangGraph BaseMessage -> karenina Message
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from karenina.ports import Content, Message, Role, TextContent, ToolResultContent, ToolUseContent
+
+logger = logging.getLogger(__name__)
+
+
+class DeepAgentsMessageConverter:
+    """Convert between karenina's unified Message and LangGraph message types.
+
+    Deep Agents accepts messages as dicts with role/content keys for invocation,
+    and returns LangGraph BaseMessage subclasses in results.
+    """
+
+    def to_prompt_string(self, messages: list[Message]) -> str:
+        """Convert user/assistant messages to a prompt string.
+
+        System messages are excluded (use extract_system_prompt instead).
+
+        Args:
+            messages: List of karenina Message objects.
+
+        Returns:
+            Concatenated prompt string from non-system messages.
+        """
+        parts = []
+        for msg in messages:
+            if msg.role == Role.SYSTEM:
+                continue
+            text = msg.text
+            if text:
+                parts.append(text)
+        return "\n\n".join(parts)
+
+    def extract_system_prompt(self, messages: list[Message]) -> str | None:
+        """Extract system prompt from messages.
+
+        Args:
+            messages: List of karenina Message objects.
+
+        Returns:
+            Combined system prompt text, or None if no system messages.
+        """
+        system_parts = []
+        for msg in messages:
+            if msg.role == Role.SYSTEM:
+                text = msg.text
+                if text:
+                    system_parts.append(text)
+        return "\n\n".join(system_parts) if system_parts else None
+
+    def to_langchain_messages(self, messages: list[Message]) -> list[dict[str, str]]:
+        """Convert karenina messages to LangGraph-compatible dicts.
+
+        Args:
+            messages: List of karenina Message objects.
+
+        Returns:
+            List of message dicts with role and content keys.
+        """
+        result = []
+        for msg in messages:
+            if msg.role == Role.SYSTEM:
+                continue
+            role_map = {
+                Role.USER: "user",
+                Role.ASSISTANT: "assistant",
+                Role.TOOL: "tool",
+            }
+            role = role_map.get(msg.role, "user")
+            result.append({"role": role, "content": msg.text or ""})
+        return result
+
+    def from_provider(self, lc_messages: list[Any]) -> list[Message]:
+        """Convert LangGraph BaseMessage list to karenina Messages.
+
+        Args:
+            lc_messages: List of LangGraph message objects.
+
+        Returns:
+            List of karenina Message objects.
+        """
+        from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+        result: list[Message] = []
+
+        for msg in lc_messages:
+            if isinstance(msg, SystemMessage):
+                result.append(Message.system(msg.content if isinstance(msg.content, str) else str(msg.content)))
+
+            elif isinstance(msg, HumanMessage):
+                result.append(Message.user(msg.content if isinstance(msg.content, str) else str(msg.content)))
+
+            elif isinstance(msg, AIMessage):
+                result.append(self._convert_ai_message(msg))
+
+            elif isinstance(msg, ToolMessage):
+                content = msg.content if isinstance(msg.content, str) else str(msg.content)
+                tool_call_id = getattr(msg, "tool_call_id", "") or ""
+                result.append(
+                    Message(
+                        role=Role.TOOL,
+                        content=[ToolResultContent(tool_use_id=tool_call_id, content=content)],
+                    )
+                )
+
+            else:
+                logger.debug("Skipping unknown message type: %s", type(msg).__name__)
+
+        return result
+
+    def _convert_ai_message(self, msg: Any) -> Message:
+        """Convert a LangGraph AIMessage to a karenina Message.
+
+        Handles text content, structured content blocks, and tool calls.
+
+        Args:
+            msg: LangGraph AIMessage instance.
+
+        Returns:
+            Karenina Message with Role.ASSISTANT.
+        """
+        content_blocks: list[Content] = []
+
+        if isinstance(msg.content, str) and msg.content:
+            content_blocks.append(TextContent(text=msg.content))
+        elif isinstance(msg.content, list):
+            for block in msg.content:
+                if isinstance(block, str):
+                    content_blocks.append(TextContent(text=block))
+                elif isinstance(block, dict):
+                    if block.get("type") == "text":
+                        content_blocks.append(TextContent(text=block["text"]))
+                    elif block.get("type") == "tool_use":
+                        content_blocks.append(
+                            ToolUseContent(
+                                id=block.get("id", ""),
+                                name=block.get("name", ""),
+                                input=block.get("input", {}),
+                            )
+                        )
+
+        if hasattr(msg, "tool_calls") and msg.tool_calls:
+            for tc in msg.tool_calls:
+                content_blocks.append(
+                    ToolUseContent(
+                        id=tc.get("id", ""),
+                        name=tc.get("name", ""),
+                        input=tc.get("args", {}),
+                    )
+                )
+
+        if content_blocks:
+            return Message(role=Role.ASSISTANT, content=content_blocks)
+        return Message.assistant("")

--- a/src/karenina/adapters/langchain_deep_agents/parser.py
+++ b/src/karenina/adapters/langchain_deep_agents/parser.py
@@ -1,0 +1,228 @@
+"""LangChain Deep Agents Parser adapter implementing the ParserPort interface.
+
+This module provides the DeepAgentsParserAdapter class that implements
+ParserPort using LangChain's with_structured_output() for extracting
+structured data from LLM responses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import json
+import logging
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from pydantic import BaseModel
+
+from karenina.ports import ParseError
+from karenina.ports.capabilities import PortCapabilities
+from karenina.ports.parser import ParsePortResult
+from karenina.ports.usage import UsageMetadata
+
+from .initialization import create_chat_model
+from .messages import DeepAgentsMessageConverter
+
+if TYPE_CHECKING:
+    from karenina.schemas.config import ModelConfig
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class DeepAgentsParserAdapter:
+    """Parser adapter using LangChain's structured output for data extraction.
+
+    Implements the ParserPort Protocol by using with_structured_output()
+    on the LangChain model. Falls back to JSON extraction from text if
+    structured output is not available.
+
+    Example:
+        >>> from pydantic import BaseModel, Field
+        >>> class Answer(BaseModel):
+        ...     gene: str = Field(description="Gene name")
+        >>> parser = DeepAgentsParserAdapter(config)
+        >>> result = await parser.aparse_to_pydantic(messages, Answer)
+        >>> print(result.parsed.gene)
+    """
+
+    def __init__(self, model_config: ModelConfig) -> None:
+        """Initialize the Deep Agents Parser adapter.
+
+        Args:
+            model_config: Configuration specifying model, provider, and interface.
+        """
+        self._config = model_config
+        self._converter = DeepAgentsMessageConverter()
+
+    @property
+    def capabilities(self) -> PortCapabilities:
+        """Declare adapter capabilities.
+
+        Returns:
+            PortCapabilities with system_prompt=True and structured_output=True.
+        """
+        return PortCapabilities(
+            supports_system_prompt=True,
+            supports_structured_output=True,
+        )
+
+    async def aparse_to_pydantic(
+        self,
+        messages: list[Any],
+        schema: type[T],
+    ) -> ParsePortResult[T]:
+        """Parse pre-assembled prompt messages into a Pydantic model.
+
+        Uses LangChain's with_structured_output() to constrain the LLM.
+        Falls back to JSON extraction if structured output fails.
+
+        Args:
+            messages: Pre-assembled prompt messages (system + user).
+            schema: A Pydantic model class defining the expected structure.
+
+        Returns:
+            ParsePortResult containing the parsed model and usage metadata.
+
+        Raises:
+            ParseError: If the LLM fails to produce valid structured data.
+        """
+        from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+        # Build LangChain message list
+        lc_messages: list[Any] = []
+        for msg in messages:
+            text = msg.text or ""
+            if msg.role.value == "system":
+                lc_messages.append(SystemMessage(content=text))
+            elif msg.role.value == "user":
+                lc_messages.append(HumanMessage(content=text))
+            elif msg.role.value == "assistant":
+                lc_messages.append(AIMessage(content=text))
+
+        # Create model with structured output
+        chat_model = create_chat_model(self._config)
+
+        try:
+            structured_model = chat_model.with_structured_output(schema)
+            response = await structured_model.ainvoke(lc_messages)
+        except Exception as e:
+            logger.warning("Structured output failed, falling back to text extraction: %s", e)
+            response = await chat_model.ainvoke(lc_messages)
+            return self._extract_from_text(response, schema)
+
+        # Response should be a Pydantic model or dict
+        usage = self._extract_usage_from_response(response)
+
+        if isinstance(response, schema):
+            return ParsePortResult(parsed=response, usage=usage)
+
+        if isinstance(response, dict):
+            try:
+                parsed = schema.model_validate(response)
+                return ParsePortResult(parsed=parsed, usage=usage)
+            except Exception as e:
+                raise ParseError(f"Failed to validate structured output: {e}") from e
+
+        if isinstance(response, BaseModel):
+            try:
+                parsed = schema.model_validate(response.model_dump())
+                return ParsePortResult(parsed=parsed, usage=usage)
+            except Exception as e:
+                raise ParseError(f"Failed to convert structured output to target schema: {e}") from e
+
+        raise ParseError(f"Unexpected response type from structured output: {type(response).__name__}")
+
+    def _extract_from_text(self, response: Any, schema: type[T]) -> ParsePortResult[T]:
+        """Extract structured data from a text response (fallback path).
+
+        Args:
+            response: The AIMessage response from the LLM.
+            schema: The target Pydantic schema.
+
+        Returns:
+            ParsePortResult with the parsed model.
+
+        Raises:
+            ParseError: If JSON extraction or validation fails.
+        """
+        from langchain_core.messages import AIMessage
+
+        content = ""
+        if isinstance(response, AIMessage):
+            content = response.content if isinstance(response.content, str) else str(response.content)
+        else:
+            content = str(response)
+
+        usage = self._extract_usage_from_response(response)
+
+        # Try to extract JSON from the text
+        try:
+            # Look for JSON in code blocks or raw JSON
+            json_str = content
+            if "```json" in content:
+                json_str = content.split("```json")[1].split("```")[0].strip()
+            elif "```" in content:
+                json_str = content.split("```")[1].split("```")[0].strip()
+
+            data = json.loads(json_str)
+            parsed = schema.model_validate(data)
+            return ParsePortResult(parsed=parsed, usage=usage)
+        except (json.JSONDecodeError, Exception) as e:
+            raise ParseError(f"Failed to extract structured data from text response: {e}") from e
+
+    def _extract_usage_from_response(self, response: Any) -> UsageMetadata:
+        """Extract usage metadata from a LangChain response.
+
+        Args:
+            response: The response object (AIMessage or other).
+
+        Returns:
+            UsageMetadata with token counts if available.
+        """
+        from langchain_core.messages import AIMessage
+
+        if isinstance(response, AIMessage):
+            usage_meta = getattr(response, "usage_metadata", None)
+            if usage_meta and isinstance(usage_meta, dict):
+                return UsageMetadata(
+                    input_tokens=usage_meta.get("input_tokens", 0),
+                    output_tokens=usage_meta.get("output_tokens", 0),
+                    total_tokens=usage_meta.get("input_tokens", 0) + usage_meta.get("output_tokens", 0),
+                    model=self._config.model_name,
+                )
+        return UsageMetadata(model=self._config.model_name)
+
+    def parse_to_pydantic(
+        self,
+        messages: list[Any],
+        schema: type[T],
+    ) -> ParsePortResult[T]:
+        """Parse pre-assembled prompt messages (sync wrapper).
+
+        Args:
+            messages: Pre-assembled prompt messages.
+            schema: A Pydantic model class defining the expected structure.
+
+        Returns:
+            ParsePortResult containing the parsed model and usage metadata.
+        """
+        from karenina.benchmark.verification.executor import get_async_portal
+
+        portal = get_async_portal()
+        if portal is not None:
+            return portal.call(self.aparse_to_pydantic, messages, schema)
+
+        try:
+            asyncio.get_running_loop()
+
+            def run_in_thread() -> ParsePortResult[T]:
+                return asyncio.run(self.aparse_to_pydantic(messages, schema))
+
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future = executor.submit(run_in_thread)
+                return future.result(timeout=600)
+
+        except RuntimeError:
+            return asyncio.run(self.aparse_to_pydantic(messages, schema))

--- a/src/karenina/adapters/langchain_deep_agents/parser.py
+++ b/src/karenina/adapters/langchain_deep_agents/parser.py
@@ -105,34 +105,40 @@ class DeepAgentsParserAdapter:
         chat_model = create_chat_model(self._config)
 
         try:
-            structured_model = chat_model.with_structured_output(schema)
-            response = await structured_model.ainvoke(lc_messages)
+            # Use include_raw=True to get the AIMessage alongside the parsed output.
+            # This is critical for usage tracking: without it, with_structured_output
+            # returns only the parsed dict/model, losing the AIMessage.response_metadata
+            # where token counts live.
+            structured_model = chat_model.with_structured_output(schema, include_raw=True)
+            raw_response = await structured_model.ainvoke(lc_messages)
         except Exception as e:
             logger.warning("Structured output failed, falling back to text extraction: %s", e)
             response = await chat_model.ainvoke(lc_messages)
             return self._extract_from_text(response, schema)
 
-        # Response should be a Pydantic model or dict
-        usage = self._extract_usage_from_response(response)
+        # include_raw=True returns {"raw": AIMessage, "parsed": dict/model, "parsing_error": ...}
+        parsed_output = raw_response.get("parsed") if isinstance(raw_response, dict) else raw_response
+        raw_msg = raw_response.get("raw") if isinstance(raw_response, dict) else None
+        usage = self._extract_usage_from_response(raw_msg) if raw_msg else UsageMetadata(model=self._config.model_name)
 
-        if isinstance(response, schema):
-            return ParsePortResult(parsed=response, usage=usage)
+        if isinstance(parsed_output, schema):
+            return ParsePortResult(parsed=parsed_output, usage=usage)
 
-        if isinstance(response, dict):
+        if isinstance(parsed_output, dict):
             try:
-                parsed = schema.model_validate(response)
+                parsed = schema.model_validate(parsed_output)
                 return ParsePortResult(parsed=parsed, usage=usage)
             except Exception as e:
                 raise ParseError(f"Failed to validate structured output: {e}") from e
 
-        if isinstance(response, BaseModel):
+        if isinstance(parsed_output, BaseModel):
             try:
-                parsed = schema.model_validate(response.model_dump())
+                parsed = schema.model_validate(parsed_output.model_dump())
                 return ParsePortResult(parsed=parsed, usage=usage)
             except Exception as e:
                 raise ParseError(f"Failed to convert structured output to target schema: {e}") from e
 
-        raise ParseError(f"Unexpected response type from structured output: {type(response).__name__}")
+        raise ParseError(f"Unexpected response type from structured output: {type(parsed_output).__name__}")
 
     def _extract_from_text(self, response: Any, schema: type[T]) -> ParsePortResult[T]:
         """Extract structured data from a text response (fallback path).

--- a/src/karenina/adapters/langchain_deep_agents/prompts/__init__.py
+++ b/src/karenina/adapters/langchain_deep_agents/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Prompt instruction modules for LangChain Deep Agents adapter."""

--- a/src/karenina/adapters/langchain_deep_agents/prompts/deep_judgment.py
+++ b/src/karenina/adapters/langchain_deep_agents/prompts/deep_judgment.py
@@ -1,0 +1,43 @@
+"""Deep judgment instruction for LangChain Deep Agents adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from karenina.ports.adapter_instruction import AdapterInstructionRegistry
+
+SYSTEM_ADDITION = "If uncertain, use your best interpretation based on the text."
+
+USER_ADDITION = ""
+
+
+@dataclass
+class _DeepAgentsDJInstruction:
+    """Minimal deep judgment directives for Deep Agents adapter.
+
+    The adapter uses LangChain's structured output, so no format/schema
+    sections are needed. Only interpretation guidance is appended.
+    """
+
+    @property
+    def system_addition(self) -> str:
+        return SYSTEM_ADDITION
+
+    @property
+    def user_addition(self) -> str:
+        return USER_ADDITION
+
+
+def _deep_agents_dj_factory(**kwargs: object) -> _DeepAgentsDJInstruction:  # noqa: ARG001
+    return _DeepAgentsDJInstruction()
+
+
+_DJ_STRUCTURED_TASKS = [
+    "dj_rubric_excerpt_extraction",
+    "dj_rubric_hallucination",
+    "dj_rubric_score_extraction",
+    "dj_template_excerpt_extraction",
+    "dj_template_hallucination",
+]
+for _task in _DJ_STRUCTURED_TASKS:
+    AdapterInstructionRegistry.register("langchain_deep_agents", _task, _deep_agents_dj_factory)

--- a/src/karenina/adapters/langchain_deep_agents/prompts/parsing.py
+++ b/src/karenina/adapters/langchain_deep_agents/prompts/parsing.py
@@ -1,0 +1,36 @@
+"""Parsing instruction for LangChain Deep Agents adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from karenina.ports.adapter_instruction import AdapterInstructionRegistry
+
+SYSTEM_ADDITION = "If uncertain, use your best interpretation based on the text."
+
+USER_ADDITION = ""
+
+
+@dataclass
+class _DeepAgentsParsingInstruction:
+    """Append best-interpretation directive for Deep Agents parsing.
+
+    The Deep Agents adapter uses LangChain's with_structured_output(),
+    so no format/schema sections are needed. Only a best-interpretation
+    directive is appended.
+    """
+
+    @property
+    def system_addition(self) -> str:
+        return SYSTEM_ADDITION
+
+    @property
+    def user_addition(self) -> str:
+        return USER_ADDITION
+
+
+def _deep_agents_parsing_factory(**kwargs: object) -> _DeepAgentsParsingInstruction:  # noqa: ARG001
+    return _DeepAgentsParsingInstruction()
+
+
+AdapterInstructionRegistry.register("langchain_deep_agents", "parsing", _deep_agents_parsing_factory)

--- a/src/karenina/adapters/langchain_deep_agents/prompts/rubric.py
+++ b/src/karenina/adapters/langchain_deep_agents/prompts/rubric.py
@@ -1,0 +1,43 @@
+"""Rubric instruction for LangChain Deep Agents adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from karenina.ports.adapter_instruction import AdapterInstructionRegistry
+
+SYSTEM_ADDITION = "If uncertain, use your best interpretation based on the response."
+
+USER_ADDITION = ""
+
+
+@dataclass
+class _DeepAgentsRubricInstruction:
+    """Minimal rubric evaluation directives for Deep Agents adapter.
+
+    The adapter uses LangChain's structured output, so no format/schema
+    sections are needed. Only interpretation guidance is appended.
+    """
+
+    @property
+    def system_addition(self) -> str:
+        return SYSTEM_ADDITION
+
+    @property
+    def user_addition(self) -> str:
+        return USER_ADDITION
+
+
+def _deep_agents_rubric_factory(**kwargs: object) -> _DeepAgentsRubricInstruction:  # noqa: ARG001
+    return _DeepAgentsRubricInstruction()
+
+
+_RUBRIC_TASKS = [
+    "rubric_llm_trait_batch",
+    "rubric_llm_trait_single",
+    "rubric_literal_trait_batch",
+    "rubric_literal_trait_single",
+    "rubric_metric_trait",
+]
+for _task in _RUBRIC_TASKS:
+    AdapterInstructionRegistry.register("langchain_deep_agents", _task, _deep_agents_rubric_factory)

--- a/src/karenina/adapters/langchain_deep_agents/registration.py
+++ b/src/karenina/adapters/langchain_deep_agents/registration.py
@@ -1,0 +1,69 @@
+"""Registration module for LangChain Deep Agents adapters.
+
+This module registers the langchain_deep_agents interface with the AdapterRegistry.
+The Deep Agents adapter requires the deepagents package to be installed.
+
+Adapter instructions for PARSING, RUBRIC, and DEEP JUDGMENT tasks are
+registered via the prompts subpackage (imported at the bottom of this module).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from karenina.adapters.registry import AdapterAvailability, AdapterRegistry, AdapterSpec
+
+if TYPE_CHECKING:
+    from karenina.ports import AgentPort, LLMPort, ParserPort
+    from karenina.schemas.config import ModelConfig
+
+
+def _check_availability() -> AdapterAvailability:
+    """Check availability via dedicated module."""
+    from karenina.adapters.langchain_deep_agents.availability import check_deep_agents_available
+
+    return check_deep_agents_available()
+
+
+def _create_agent(config: ModelConfig) -> AgentPort:
+    """Factory function to create Deep Agents agent adapter."""
+    from karenina.adapters.langchain_deep_agents.agent import DeepAgentsAgentAdapter
+
+    return DeepAgentsAgentAdapter(config)
+
+
+def _create_llm(config: ModelConfig) -> LLMPort:
+    """Factory function to create Deep Agents LLM adapter."""
+    from karenina.adapters.langchain_deep_agents.llm import DeepAgentsLLMAdapter
+
+    return DeepAgentsLLMAdapter(config)
+
+
+def _create_parser(config: ModelConfig) -> ParserPort:
+    """Factory function to create Deep Agents parser adapter."""
+    from karenina.adapters.langchain_deep_agents.parser import DeepAgentsParserAdapter
+
+    return DeepAgentsParserAdapter(config)
+
+
+# Register the LangChain Deep Agents adapter
+_deep_agents_spec = AdapterSpec(
+    interface="langchain_deep_agents",
+    description="LangChain Deep Agents for autonomous task execution",
+    agent_factory=_create_agent,
+    llm_factory=_create_llm,
+    parser_factory=_create_parser,
+    availability_checker=_check_availability,
+    fallback_interface=None,  # No fallback: explicit install required
+    routes_to=None,
+    supports_mcp=True,
+    supports_tools=True,
+    natively_agentic=True,
+)
+
+AdapterRegistry.register(_deep_agents_spec)
+
+# Import prompt modules to trigger adapter instruction registration
+import karenina.adapters.langchain_deep_agents.prompts.deep_judgment  # noqa: E402, F401
+import karenina.adapters.langchain_deep_agents.prompts.parsing  # noqa: E402, F401
+import karenina.adapters.langchain_deep_agents.prompts.rubric  # noqa: E402, F401

--- a/src/karenina/adapters/langchain_deep_agents/trace.py
+++ b/src/karenina/adapters/langchain_deep_agents/trace.py
@@ -1,0 +1,92 @@
+"""Trace extraction from LangGraph agent results.
+
+Converts LangGraph BaseMessage lists into karenina's raw trace format:
+a delimited string for backward compatibility with existing infrastructure
+(regex highlighting, database storage, trace validation).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def deep_agents_messages_to_raw_trace(
+    messages: list[Any],
+    include_user_messages: bool = False,
+) -> str:
+    """Convert LangGraph messages to raw trace string format.
+
+    Produces delimited trace compatible with existing karenina infrastructure
+    (regex highlighting, database storage, backward compatibility).
+
+    Args:
+        messages: List of LangGraph BaseMessage objects.
+        include_user_messages: If True, include HumanMessage in trace.
+
+    Returns:
+        Formatted trace string with --- delimiters.
+    """
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+    if not messages:
+        return ""
+
+    parts: list[str] = []
+
+    for msg in messages:
+        if isinstance(msg, SystemMessage):
+            continue
+
+        if isinstance(msg, HumanMessage):
+            if include_user_messages:
+                parts.append(f"--- Human Message ---\n{msg.content}")
+            continue
+
+        if isinstance(msg, AIMessage):
+            text = _extract_ai_text(msg)
+
+            if text:
+                parts.append(f"--- AI Message ---\n{text}")
+
+            if hasattr(msg, "tool_calls") and msg.tool_calls:
+                for tc in msg.tool_calls:
+                    tool_name = tc.get("name", "unknown")
+                    tool_input = tc.get("args", {})
+                    input_str = json.dumps(tool_input, indent=2) if tool_input else "{}"
+                    parts.append(f"--- Tool Call ---\nTool: {tool_name}\nInput: {input_str}")
+
+        elif isinstance(msg, ToolMessage):
+            content = msg.content if isinstance(msg.content, str) else str(msg.content)
+            parts.append(f"--- Tool Result ---\n{content}")
+
+    return "\n\n".join(parts)
+
+
+def _extract_ai_text(msg: Any) -> str:
+    """Extract text content from an AIMessage.
+
+    Handles both simple string content and list content (mixed text/tool_use blocks).
+
+    Args:
+        msg: A LangGraph AIMessage instance.
+
+    Returns:
+        Concatenated text content from the message.
+    """
+    if isinstance(msg.content, str):
+        return msg.content
+
+    if isinstance(msg.content, list):
+        text_parts = []
+        for block in msg.content:
+            if isinstance(block, str):
+                text_parts.append(block)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                text_parts.append(block["text"])
+        return "\n".join(text_parts)
+
+    return ""

--- a/src/karenina/adapters/langchain_deep_agents/usage.py
+++ b/src/karenina/adapters/langchain_deep_agents/usage.py
@@ -1,0 +1,85 @@
+"""Usage metadata extraction from LangGraph agent results.
+
+Extracts token counts from AIMessage.response_metadata, which is populated
+by LangChain's LLM integrations for most providers.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from karenina.ports.usage import UsageMetadata
+
+logger = logging.getLogger(__name__)
+
+
+def extract_deep_agents_usage(
+    messages: list[Any],
+    model: str | None = None,
+) -> UsageMetadata:
+    """Extract aggregated usage metadata from LangGraph messages.
+
+    Sums token counts across all AIMessage instances in the conversation.
+    Token counts come from AIMessage.usage_metadata (preferred) or
+    AIMessage.response_metadata.token_usage (fallback).
+
+    Args:
+        messages: List of LangGraph BaseMessage objects.
+        model: Model name to include in usage metadata.
+
+    Returns:
+        Aggregated UsageMetadata for the entire agent run.
+    """
+    from langchain_core.messages import AIMessage
+
+    total_input = 0
+    total_output = 0
+
+    for msg in messages:
+        if not isinstance(msg, AIMessage):
+            continue
+
+        usage_meta = getattr(msg, "usage_metadata", None)
+        if usage_meta and isinstance(usage_meta, dict):
+            total_input += usage_meta.get("input_tokens", 0)
+            total_output += usage_meta.get("output_tokens", 0)
+            continue
+
+        resp_meta = getattr(msg, "response_metadata", None)
+        if resp_meta and isinstance(resp_meta, dict):
+            token_usage = resp_meta.get("token_usage", {})
+            if isinstance(token_usage, dict):
+                total_input += token_usage.get("prompt_tokens", 0)
+                total_output += token_usage.get("completion_tokens", 0)
+
+    return UsageMetadata(
+        input_tokens=total_input,
+        output_tokens=total_output,
+        total_tokens=total_input + total_output,
+        model=model,
+    )
+
+
+def extract_actual_model(messages: list[Any]) -> str | None:
+    """Extract actual model name from the last AIMessage.
+
+    Checks response_metadata for model_name or model fields,
+    searching from the end of the message list (most recent first).
+
+    Args:
+        messages: List of LangGraph BaseMessage objects.
+
+    Returns:
+        Model name string, or None if not found.
+    """
+    from langchain_core.messages import AIMessage
+
+    for msg in reversed(messages):
+        if isinstance(msg, AIMessage):
+            resp_meta = getattr(msg, "response_metadata", None)
+            if resp_meta and isinstance(resp_meta, dict):
+                model_name = resp_meta.get("model_name") or resp_meta.get("model")
+                if model_name:
+                    return str(model_name)
+    return None

--- a/src/karenina/adapters/registry.py
+++ b/src/karenina/adapters/registry.py
@@ -345,6 +345,11 @@ class AdapterRegistry:
             except ImportError:
                 logger.debug("Claude Tool registration module not available")
 
+            try:
+                from karenina.adapters.langchain_deep_agents import registration as _da  # noqa: F401
+            except ImportError:
+                logger.debug("LangChain Deep Agents registration module not available")
+
             cls._initialized = True
 
     @classmethod

--- a/src/karenina/schemas/config/models.py
+++ b/src/karenina/schemas/config/models.py
@@ -202,6 +202,7 @@ INTERFACE_LANGCHAIN = "langchain"
 INTERFACE_OPENAI_ENDPOINT = "openai_endpoint"
 INTERFACE_CLAUDE_AGENT_SDK = "claude_agent_sdk"
 INTERFACE_CLAUDE_TOOL = "claude_tool"
+INTERFACE_LANGCHAIN_DEEP_AGENTS = "langchain_deep_agents"
 INTERFACES_NO_PROVIDER_REQUIRED = [
     INTERFACE_OPENROUTER,
     INTERFACE_MANUAL,
@@ -564,9 +565,15 @@ class ModelConfig(BaseModel):
     model_name: str | None = None  # Optional - defaults to "manual" for manual interface
     temperature: float = 0.1
     max_tokens: int = 8192  # Maximum tokens for model response
-    interface: Literal["langchain", "openrouter", "manual", "openai_endpoint", "claude_agent_sdk", "claude_tool"] = (
-        "langchain"
-    )
+    interface: Literal[
+        "langchain",
+        "openrouter",
+        "manual",
+        "openai_endpoint",
+        "claude_agent_sdk",
+        "claude_tool",
+        "langchain_deep_agents",
+    ] = "langchain"
     system_prompt: str | None = None  # Optional - defaults applied based on context (answering/parsing)
     max_retries: int = 2  # Optional max retries for template generation
     mcp_urls_dict: dict[str, str] | None = None  # Optional MCP server URLs

--- a/tests/unit/adapters/conformance/__init__.py
+++ b/tests/unit/adapters/conformance/__init__.py
@@ -1,0 +1,7 @@
+"""Shared adapter conformance tests.
+
+These tests validate that any adapter implementation correctly satisfies
+the port protocols (AgentPort, LLMPort, ParserPort). Each adapter provides
+its own conftest.py with fixtures; the conformance tests are parametrized
+across all available adapters.
+"""

--- a/tests/unit/adapters/conformance/conftest.py
+++ b/tests/unit/adapters/conformance/conftest.py
@@ -1,0 +1,117 @@
+"""Shared fixtures for adapter conformance tests.
+
+Provides fixtures that create adapter instances for each registered interface.
+Conformance tests use these to validate protocol compliance across all adapters.
+
+Adapters that are unavailable (e.g., missing SDK) are skipped automatically.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from karenina.adapters.registry import AdapterRegistry
+from karenina.schemas.config import ModelConfig
+
+
+@pytest.fixture
+def all_registered_interfaces() -> list[str]:
+    """Return all registered interface names."""
+    return sorted(AdapterRegistry.get_interfaces())
+
+
+@pytest.fixture
+def mock_model_config_for_interface():
+    """Factory fixture: create a ModelConfig for a given interface."""
+
+    def _factory(interface: str) -> ModelConfig:
+        return ModelConfig(
+            id=f"test-{interface}",
+            model_name="claude-sonnet-4-20250514",
+            model_provider="anthropic",
+            interface=interface,
+            temperature=0.0,
+        )
+
+    return _factory
+
+
+# --- Deep Agents adapter fixtures (mocked) ---
+
+
+@pytest.fixture
+def deep_agents_agent_adapter():
+    """DeepAgentsAgentAdapter with mocked create_deep_agent."""
+    from karenina.adapters.langchain_deep_agents.agent import DeepAgentsAgentAdapter
+
+    config = ModelConfig(
+        id="test-da",
+        model_name="claude-sonnet-4-20250514",
+        model_provider="anthropic",
+        interface="langchain_deep_agents",
+        temperature=0.0,
+    )
+    return DeepAgentsAgentAdapter(config)
+
+
+@pytest.fixture
+def deep_agents_llm_adapter():
+    """DeepAgentsLLMAdapter instance."""
+    from karenina.adapters.langchain_deep_agents.llm import DeepAgentsLLMAdapter
+
+    config = ModelConfig(
+        id="test-da",
+        model_name="claude-sonnet-4-20250514",
+        model_provider="anthropic",
+        interface="langchain_deep_agents",
+        temperature=0.0,
+    )
+    return DeepAgentsLLMAdapter(config)
+
+
+@pytest.fixture
+def deep_agents_parser_adapter():
+    """DeepAgentsParserAdapter instance."""
+    from karenina.adapters.langchain_deep_agents.parser import DeepAgentsParserAdapter
+
+    config = ModelConfig(
+        id="test-da",
+        model_name="claude-sonnet-4-20250514",
+        model_provider="anthropic",
+        interface="langchain_deep_agents",
+        temperature=0.0,
+    )
+    return DeepAgentsParserAdapter(config)
+
+
+@pytest.fixture
+def deep_agents_message_converter():
+    """DeepAgentsMessageConverter instance."""
+    from karenina.adapters.langchain_deep_agents.messages import DeepAgentsMessageConverter
+
+    return DeepAgentsMessageConverter()
+
+
+@pytest.fixture
+def mock_deep_agents_agent_result(monkeypatch):
+    """Monkeypatch create_deep_agent and create_chat_model for mocked arun()."""
+    from langchain_core.messages import AIMessage
+
+    mock_result = {
+        "messages": [AIMessage(content="The answer is Paris.")],
+        "is_last_step": False,
+    }
+    mock_agent = MagicMock()
+    mock_agent.ainvoke = AsyncMock(return_value=mock_result)
+
+    monkeypatch.setattr(
+        "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+        lambda **_kwargs: mock_agent,
+    )
+    monkeypatch.setattr(
+        "karenina.adapters.langchain_deep_agents.agent.create_chat_model",
+        lambda _config, **_kw: MagicMock(),
+    )
+    return mock_result

--- a/tests/unit/adapters/conformance/conftest.py
+++ b/tests/unit/adapters/conformance/conftest.py
@@ -39,11 +39,20 @@ def mock_model_config_for_interface():
 
 
 # --- Deep Agents adapter fixtures (mocked) ---
+# These fixtures require deepagents and langchain_core to be installed.
+# Tests that use them will be skipped if the packages are missing.
+
+
+def _skip_if_no_deep_agents():
+    """Skip if deepagents or langchain_core are not installed."""
+    pytest.importorskip("deepagents", reason="deepagents not installed")
+    pytest.importorskip("langchain_core", reason="langchain-core not installed")
 
 
 @pytest.fixture
 def deep_agents_agent_adapter():
     """DeepAgentsAgentAdapter with mocked create_deep_agent."""
+    _skip_if_no_deep_agents()
     from karenina.adapters.langchain_deep_agents.agent import DeepAgentsAgentAdapter
 
     config = ModelConfig(
@@ -59,6 +68,7 @@ def deep_agents_agent_adapter():
 @pytest.fixture
 def deep_agents_llm_adapter():
     """DeepAgentsLLMAdapter instance."""
+    _skip_if_no_deep_agents()
     from karenina.adapters.langchain_deep_agents.llm import DeepAgentsLLMAdapter
 
     config = ModelConfig(
@@ -74,6 +84,7 @@ def deep_agents_llm_adapter():
 @pytest.fixture
 def deep_agents_parser_adapter():
     """DeepAgentsParserAdapter instance."""
+    _skip_if_no_deep_agents()
     from karenina.adapters.langchain_deep_agents.parser import DeepAgentsParserAdapter
 
     config = ModelConfig(
@@ -89,6 +100,7 @@ def deep_agents_parser_adapter():
 @pytest.fixture
 def deep_agents_message_converter():
     """DeepAgentsMessageConverter instance."""
+    _skip_if_no_deep_agents()
     from karenina.adapters.langchain_deep_agents.messages import DeepAgentsMessageConverter
 
     return DeepAgentsMessageConverter()
@@ -97,6 +109,7 @@ def deep_agents_message_converter():
 @pytest.fixture
 def mock_deep_agents_agent_result(monkeypatch):
     """Monkeypatch create_deep_agent and create_chat_model for mocked arun()."""
+    _skip_if_no_deep_agents()
     from langchain_core.messages import AIMessage
 
     mock_result = {

--- a/tests/unit/adapters/conformance/test_agent_port.py
+++ b/tests/unit/adapters/conformance/test_agent_port.py
@@ -1,0 +1,82 @@
+"""Conformance tests for AgentPort implementations.
+
+Validates that AgentPort adapters correctly satisfy the protocol,
+produce valid AgentResult objects, and handle the aclose() lifecycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import pytest
+
+from karenina.ports import AgentConfig, AgentPort, AgentResult, Message
+
+
+@pytest.mark.unit
+class TestAgentPortConformance:
+    """Verify AgentPort protocol compliance for Deep Agents adapter."""
+
+    def test_isinstance_check(self, deep_agents_agent_adapter):
+        """Adapter must pass runtime_checkable isinstance."""
+        assert isinstance(deep_agents_agent_adapter, AgentPort)
+
+    def test_arun_signature(self, deep_agents_agent_adapter):
+        """arun() must accept messages, tools, mcp_servers, config."""
+        sig = inspect.signature(deep_agents_agent_adapter.arun)
+        params = list(sig.parameters.keys())
+        assert "messages" in params
+        assert "tools" in params
+        assert "mcp_servers" in params
+        assert "config" in params
+
+    def test_run_signature(self, deep_agents_agent_adapter):
+        """run() must have the same parameters as arun()."""
+        sig = inspect.signature(deep_agents_agent_adapter.run)
+        params = list(sig.parameters.keys())
+        assert "messages" in params
+        assert "tools" in params
+        assert "mcp_servers" in params
+        assert "config" in params
+
+    def test_aclose_does_not_raise(self, deep_agents_agent_adapter):
+        """aclose() must be callable without error."""
+        asyncio.run(deep_agents_agent_adapter.aclose())
+
+    @pytest.mark.asyncio
+    async def test_arun_returns_agent_result(
+        self,
+        deep_agents_agent_adapter,
+        mock_deep_agents_agent_result,  # noqa: ARG002
+    ):
+        """arun() must return a valid AgentResult with all required fields."""
+        result = await deep_agents_agent_adapter.arun(
+            messages=[Message.user("What is the capital of France?")],
+            config=AgentConfig(max_turns=5),
+        )
+
+        assert isinstance(result, AgentResult)
+        assert isinstance(result.final_response, str)
+        assert len(result.final_response) > 0
+        assert isinstance(result.raw_trace, str)
+        assert isinstance(result.trace_messages, list)
+        assert isinstance(result.turns, int)
+        assert result.turns >= 0
+        assert isinstance(result.limit_reached, bool)
+
+    @pytest.mark.asyncio
+    async def test_agent_result_usage_valid(
+        self,
+        deep_agents_agent_adapter,
+        mock_deep_agents_agent_result,  # noqa: ARG002
+    ):
+        """AgentResult.usage must have non-negative token counts."""
+        result = await deep_agents_agent_adapter.arun(
+            messages=[Message.user("Hello")],
+            config=AgentConfig(max_turns=5),
+        )
+
+        assert result.usage.input_tokens >= 0
+        assert result.usage.output_tokens >= 0
+        assert result.usage.total_tokens >= 0

--- a/tests/unit/adapters/conformance/test_llm_port.py
+++ b/tests/unit/adapters/conformance/test_llm_port.py
@@ -1,0 +1,62 @@
+"""Conformance tests for LLMPort implementations.
+
+Validates that LLMPort adapters correctly satisfy the protocol,
+support structured output, and declare capabilities properly.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from pydantic import BaseModel, Field
+
+from karenina.ports import LLMPort
+from karenina.ports.capabilities import PortCapabilities
+
+
+@pytest.mark.unit
+class TestLLMPortConformance:
+    """Verify LLMPort protocol compliance for Deep Agents adapter."""
+
+    def test_isinstance_check(self, deep_agents_llm_adapter):
+        """Adapter must pass runtime_checkable isinstance."""
+        assert isinstance(deep_agents_llm_adapter, LLMPort)
+
+    def test_ainvoke_signature(self, deep_agents_llm_adapter):
+        """ainvoke() must accept messages parameter."""
+        sig = inspect.signature(deep_agents_llm_adapter.ainvoke)
+        params = list(sig.parameters.keys())
+        assert "messages" in params
+
+    def test_invoke_signature(self, deep_agents_llm_adapter):
+        """invoke() must accept messages parameter."""
+        sig = inspect.signature(deep_agents_llm_adapter.invoke)
+        params = list(sig.parameters.keys())
+        assert "messages" in params
+
+    def test_capabilities_returns_port_capabilities(self, deep_agents_llm_adapter):
+        """capabilities property must return PortCapabilities."""
+        caps = deep_agents_llm_adapter.capabilities
+        assert isinstance(caps, PortCapabilities)
+        assert isinstance(caps.supports_system_prompt, bool)
+        assert isinstance(caps.supports_structured_output, bool)
+
+    def test_with_structured_output_returns_llm_port(self, deep_agents_llm_adapter):
+        """with_structured_output() must return a new LLMPort instance."""
+
+        class TestSchema(BaseModel):
+            value: str = Field(description="test value")
+
+        structured = deep_agents_llm_adapter.with_structured_output(TestSchema)
+        assert isinstance(structured, LLMPort)
+
+    def test_with_structured_output_preserves_original(self, deep_agents_llm_adapter):
+        """with_structured_output() must not mutate the original adapter."""
+
+        class TestSchema(BaseModel):
+            value: str = Field(description="test value")
+
+        original_schema = getattr(deep_agents_llm_adapter, "_structured_schema", None)
+        deep_agents_llm_adapter.with_structured_output(TestSchema)
+        assert getattr(deep_agents_llm_adapter, "_structured_schema", None) == original_schema

--- a/tests/unit/adapters/conformance/test_message_converter.py
+++ b/tests/unit/adapters/conformance/test_message_converter.py
@@ -1,0 +1,69 @@
+"""Conformance tests for message converter roundtrip correctness.
+
+Validates that converting karenina Message -> provider format -> karenina Message
+preserves content and role for all message types.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.ports import Message
+
+
+@pytest.mark.unit
+class TestMessageConverterConformance:
+    """Verify message conversion roundtrip for Deep Agents adapter."""
+
+    def test_user_message_roundtrip(self, deep_agents_message_converter):
+        """User message survives to_prompt_string and back via from_provider."""
+        from langchain_core.messages import HumanMessage
+
+        original = Message.user("Hello, world!")
+        prompt = deep_agents_message_converter.to_prompt_string([original])
+        assert "Hello, world!" in prompt
+
+        # Simulate round-trip via provider
+        lc_msg = HumanMessage(content="Hello, world!")
+        restored = deep_agents_message_converter.from_provider([lc_msg])
+        assert len(restored) == 1
+        assert restored[0].role.value == "user"
+        assert restored[0].text == "Hello, world!"
+
+    def test_assistant_message_roundtrip(self, deep_agents_message_converter):
+        """Assistant message preserves content through from_provider."""
+        from langchain_core.messages import AIMessage
+
+        lc_msg = AIMessage(content="The answer is 42.")
+        restored = deep_agents_message_converter.from_provider([lc_msg])
+        assert len(restored) == 1
+        assert restored[0].role.value == "assistant"
+        assert "42" in restored[0].text
+
+    def test_system_message_extracted_separately(self, deep_agents_message_converter):
+        """System messages should be extracted via extract_system_prompt, not in prompt string."""
+        messages = [Message.system("Be helpful."), Message.user("Hi")]
+
+        system = deep_agents_message_converter.extract_system_prompt(messages)
+        prompt = deep_agents_message_converter.to_prompt_string(messages)
+
+        assert system == "Be helpful."
+        assert "Be helpful." not in prompt
+        assert "Hi" in prompt
+
+    def test_tool_message_roundtrip(self, deep_agents_message_converter):
+        """Tool messages preserve content through from_provider."""
+        from langchain_core.messages import ToolMessage
+
+        lc_msg = ToolMessage(content="tool output data", tool_call_id="call_123")
+        restored = deep_agents_message_converter.from_provider([lc_msg])
+        assert len(restored) == 1
+        assert restored[0].role.value == "tool"
+
+    def test_empty_messages_produce_empty_prompt(self, deep_agents_message_converter):
+        """Empty message list should produce empty prompt string."""
+        assert deep_agents_message_converter.to_prompt_string([]) == ""
+
+    def test_empty_messages_produce_no_system_prompt(self, deep_agents_message_converter):
+        """Empty message list should produce None system prompt."""
+        assert deep_agents_message_converter.extract_system_prompt([]) is None

--- a/tests/unit/adapters/conformance/test_parser_port.py
+++ b/tests/unit/adapters/conformance/test_parser_port.py
@@ -1,0 +1,44 @@
+"""Conformance tests for ParserPort implementations.
+
+Validates that ParserPort adapters correctly satisfy the protocol
+and declare capabilities properly.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from karenina.ports import ParserPort
+from karenina.ports.capabilities import PortCapabilities
+
+
+@pytest.mark.unit
+class TestParserPortConformance:
+    """Verify ParserPort protocol compliance for Deep Agents adapter."""
+
+    def test_isinstance_check(self, deep_agents_parser_adapter):
+        """Adapter must pass runtime_checkable isinstance."""
+        assert isinstance(deep_agents_parser_adapter, ParserPort)
+
+    def test_aparse_to_pydantic_signature(self, deep_agents_parser_adapter):
+        """aparse_to_pydantic() must accept messages and schema parameters."""
+        sig = inspect.signature(deep_agents_parser_adapter.aparse_to_pydantic)
+        params = list(sig.parameters.keys())
+        assert "messages" in params
+        assert "schema" in params
+
+    def test_parse_to_pydantic_signature(self, deep_agents_parser_adapter):
+        """parse_to_pydantic() must accept messages and schema parameters."""
+        sig = inspect.signature(deep_agents_parser_adapter.parse_to_pydantic)
+        params = list(sig.parameters.keys())
+        assert "messages" in params
+        assert "schema" in params
+
+    def test_capabilities_returns_port_capabilities(self, deep_agents_parser_adapter):
+        """capabilities property must return PortCapabilities."""
+        caps = deep_agents_parser_adapter.capabilities
+        assert isinstance(caps, PortCapabilities)
+        assert isinstance(caps.supports_system_prompt, bool)
+        assert isinstance(caps.supports_structured_output, bool)

--- a/tests/unit/adapters/conformance/test_registration.py
+++ b/tests/unit/adapters/conformance/test_registration.py
@@ -1,0 +1,69 @@
+"""Conformance tests for adapter registration.
+
+Validates that all registered adapters have properly configured specs
+in the AdapterRegistry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.adapters.registry import AdapterRegistry
+
+
+@pytest.mark.unit
+class TestAdapterRegistrationConformance:
+    """Verify all registered adapters have valid specs."""
+
+    def test_all_interfaces_have_specs(self, all_registered_interfaces):
+        """Every registered interface must have a non-None spec."""
+        for interface in all_registered_interfaces:
+            spec = AdapterRegistry.get_spec(interface)
+            assert spec is not None, f"No spec for interface: {interface}"
+
+    def test_all_specs_have_at_least_one_factory(self, all_registered_interfaces):
+        """Each spec must provide at least one factory (agent, llm, or parser)."""
+        for interface in all_registered_interfaces:
+            spec = AdapterRegistry.get_spec(interface)
+            has_factory = (
+                spec.agent_factory is not None or spec.llm_factory is not None or spec.parser_factory is not None
+            )
+            assert has_factory, f"Interface {interface} has no factories"
+
+    def test_supports_flags_are_booleans(self, all_registered_interfaces):
+        """Feature flags must be boolean values."""
+        for interface in all_registered_interfaces:
+            spec = AdapterRegistry.get_spec(interface)
+            assert isinstance(spec.supports_mcp, bool), f"{interface}: supports_mcp not bool"
+            assert isinstance(spec.supports_tools, bool), f"{interface}: supports_tools not bool"
+            assert isinstance(spec.natively_agentic, bool), f"{interface}: natively_agentic not bool"
+
+    def test_natively_agentic_adapters_support_tools(self, all_registered_interfaces):
+        """Natively agentic adapters should support tools (they handle tool loops internally)."""
+        for interface in all_registered_interfaces:
+            spec = AdapterRegistry.get_spec(interface)
+            if spec.natively_agentic:
+                assert spec.supports_tools, f"{interface} is natively_agentic but doesn't support tools"
+
+    def test_fallback_interface_is_registered_or_none(self, all_registered_interfaces):
+        """If a fallback is specified, it must be a registered interface."""
+        registered = set(all_registered_interfaces)
+        for interface in all_registered_interfaces:
+            spec = AdapterRegistry.get_spec(interface)
+            if spec.fallback_interface is not None:
+                assert spec.fallback_interface in registered, (
+                    f"{interface} fallback '{spec.fallback_interface}' not registered"
+                )
+
+    def test_langchain_deep_agents_spec(self):
+        """Specific validation for the langchain_deep_agents adapter."""
+        spec = AdapterRegistry.get_spec("langchain_deep_agents")
+        if spec is None:
+            pytest.skip("langchain_deep_agents not registered")
+        assert spec.natively_agentic is True
+        assert spec.supports_mcp is True
+        assert spec.supports_tools is True
+        assert spec.fallback_interface is None
+        assert spec.agent_factory is not None
+        assert spec.llm_factory is not None
+        assert spec.parser_factory is not None

--- a/tests/unit/adapters/conformance/test_trace_format.py
+++ b/tests/unit/adapters/conformance/test_trace_format.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import pytest
 
+pytest.importorskip("langchain_core", reason="langchain-core not installed")
+
 from karenina.adapters.langchain_deep_agents.trace import deep_agents_messages_to_raw_trace
 
 

--- a/tests/unit/adapters/conformance/test_trace_format.py
+++ b/tests/unit/adapters/conformance/test_trace_format.py
@@ -1,0 +1,90 @@
+"""Conformance tests for trace format validation.
+
+Validates that trace output from any adapter uses the correct delimiters
+and structure expected by the karenina infrastructure (regex highlighting,
+database storage, frontend display).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.adapters.langchain_deep_agents.trace import deep_agents_messages_to_raw_trace
+
+
+@pytest.mark.unit
+class TestTraceFormatConformance:
+    """Verify trace format correctness for Deep Agents adapter."""
+
+    def test_ai_message_uses_standard_delimiter(self):
+        """raw_trace must use '--- AI Message ---' for assistant responses."""
+        from langchain_core.messages import AIMessage
+
+        messages = [AIMessage(content="Hello")]
+        trace = deep_agents_messages_to_raw_trace(messages)
+        assert "--- AI Message ---" in trace
+
+    def test_tool_call_uses_standard_delimiter(self):
+        """raw_trace must use '--- Tool Call ---' for tool invocations."""
+        from langchain_core.messages import AIMessage
+
+        messages = [
+            AIMessage(
+                content="Searching...",
+                tool_calls=[{"name": "search", "args": {"q": "test"}, "id": "c1"}],
+            ),
+        ]
+        trace = deep_agents_messages_to_raw_trace(messages)
+        assert "--- Tool Call ---" in trace
+
+    def test_tool_result_uses_standard_delimiter(self):
+        """raw_trace must use '--- Tool Result ---' for tool outputs."""
+        from langchain_core.messages import ToolMessage
+
+        messages = [ToolMessage(content="result data", tool_call_id="c1")]
+        trace = deep_agents_messages_to_raw_trace(messages)
+        assert "--- Tool Result ---" in trace
+
+    def test_empty_messages_produce_empty_trace(self):
+        """Empty message list must produce empty string, not an error."""
+        assert deep_agents_messages_to_raw_trace([]) == ""
+
+    def test_trace_preserves_message_content(self):
+        """Content from messages must appear in the trace string."""
+        from langchain_core.messages import AIMessage
+
+        messages = [AIMessage(content="The capital of France is Paris.")]
+        trace = deep_agents_messages_to_raw_trace(messages)
+        assert "Paris" in trace
+
+    def test_tool_call_includes_tool_name(self):
+        """Tool call sections must include the tool name."""
+        from langchain_core.messages import AIMessage
+
+        messages = [
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "web_search", "args": {"q": "test"}, "id": "c1"}],
+            ),
+        ]
+        trace = deep_agents_messages_to_raw_trace(messages)
+        assert "web_search" in trace
+
+    def test_multi_turn_trace_ordering(self):
+        """Multiple messages should appear in order in the trace."""
+        from langchain_core.messages import AIMessage, ToolMessage
+
+        messages = [
+            AIMessage(
+                content="First response",
+                tool_calls=[{"name": "tool1", "args": {}, "id": "c1"}],
+            ),
+            ToolMessage(content="tool result", tool_call_id="c1"),
+            AIMessage(content="Second response"),
+        ]
+        trace = deep_agents_messages_to_raw_trace(messages)
+
+        first_pos = trace.index("First response")
+        tool_pos = trace.index("tool result")
+        second_pos = trace.index("Second response")
+        assert first_pos < tool_pos < second_pos

--- a/tests/unit/adapters/conformance/test_workspace_access.py
+++ b/tests/unit/adapters/conformance/test_workspace_access.py
@@ -1,0 +1,114 @@
+"""Conformance tests for workspace filesystem access.
+
+Validates that adapters marked as natively_agentic correctly configure
+real filesystem access when workspace_path is provided. This catches
+the critical bug where a virtual/in-memory backend makes the agent
+unable to see real files on disk.
+
+This test exists because:
+- Natively agentic adapters have built-in filesystem tools (ls, glob, read_file)
+- If these tools use a virtual backend, they return empty results for real paths
+- Simple tests ("What is the capital of France?") pass fine without filesystem
+- The bug only surfaces when the agent needs to read workspace files
+- This is a silent failure: the agent generates synthetic data instead of erroring
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.adapters.registry import AdapterRegistry
+
+
+@pytest.mark.unit
+class TestWorkspaceAccessConformance:
+    """Verify that natively agentic adapters can access real workspace files."""
+
+    def test_natively_agentic_adapters_must_not_use_virtual_backend(
+        self, all_registered_interfaces, mock_model_config_for_interface
+    ):
+        """Natively agentic adapters must configure real filesystem access.
+
+        This test verifies that the adapter does not use a virtual/in-memory
+        backend that would make the agent blind to real files on disk.
+
+        The test is necessarily adapter-specific because different SDKs use
+        different backend abstractions. We check the known problematic ones.
+        """
+        for interface in all_registered_interfaces:
+            spec = AdapterRegistry.get_spec(interface)
+            if not spec.natively_agentic:
+                continue
+
+            # For langchain_deep_agents: verify FilesystemBackend is used
+            if interface == "langchain_deep_agents":
+                self._verify_deep_agents_backend(mock_model_config_for_interface(interface))
+
+    def _verify_deep_agents_backend(self, model_config):
+        """Verify Deep Agents adapter uses FilesystemBackend, not StateBackend.
+
+        Captures the kwargs passed to create_deep_agent to inspect the backend.
+        """
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        try:
+            from deepagents.backends import FilesystemBackend, StateBackend
+        except ImportError:
+            pytest.skip("deepagents not installed")
+
+        from langchain_core.messages import AIMessage
+
+        from karenina.adapters.langchain_deep_agents import agent as agent_module
+        from karenina.adapters.langchain_deep_agents.agent import DeepAgentsAgentAdapter
+        from karenina.ports import AgentConfig, Message
+
+        captured_kwargs: dict = {}
+        original_create = agent_module._create_deep_agent
+
+        def capture_create(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_agent = MagicMock()
+            mock_agent.ainvoke = AsyncMock(
+                return_value={
+                    "messages": [AIMessage(content="ok")],
+                    "is_last_step": False,
+                }
+            )
+            return mock_agent
+
+        agent_module._create_deep_agent = capture_create
+        try:
+            adapter = DeepAgentsAgentAdapter(model_config)
+            asyncio.run(
+                adapter.arun(
+                    messages=[Message.user("test")],
+                    config=AgentConfig(max_turns=2),
+                )
+            )
+
+            backend = captured_kwargs.get("backend")
+            assert backend is not None, "create_deep_agent must receive a 'backend' kwarg"
+            assert isinstance(backend, FilesystemBackend), (
+                f"Expected FilesystemBackend, got {type(backend).__name__}. "
+                "StateBackend would make the agent unable to see real files."
+            )
+            assert not isinstance(backend, StateBackend), "StateBackend (virtual/in-memory) must never be used."
+        finally:
+            agent_module._create_deep_agent = original_create
+
+    def test_workspace_path_is_accepted_by_agent_config(self):
+        """AgentConfig must accept workspace_path parameter."""
+        from pathlib import Path
+
+        from karenina.ports import AgentConfig
+
+        config = AgentConfig(workspace_path=Path("/tmp/test_workspace"))
+        assert config.workspace_path == Path("/tmp/test_workspace")
+
+    def test_workspace_path_none_is_valid(self):
+        """AgentConfig with no workspace_path must also work."""
+        from karenina.ports import AgentConfig
+
+        config = AgentConfig()
+        assert config.workspace_path is None

--- a/tests/unit/adapters/langchain_deep_agents/conftest.py
+++ b/tests/unit/adapters/langchain_deep_agents/conftest.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import pytest
 
+pytest.importorskip("deepagents", reason="deepagents not installed")
+pytest.importorskip("langchain_core", reason="langchain-core not installed")
+
 from karenina.schemas.config import ModelConfig
 
 

--- a/tests/unit/adapters/langchain_deep_agents/conftest.py
+++ b/tests/unit/adapters/langchain_deep_agents/conftest.py
@@ -1,0 +1,19 @@
+"""Shared fixtures for LangChain Deep Agents adapter tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.schemas.config import ModelConfig
+
+
+@pytest.fixture
+def deep_agents_model_config() -> ModelConfig:
+    """ModelConfig configured for langchain_deep_agents interface."""
+    return ModelConfig(
+        id="test-deep-agents",
+        model_name="claude-sonnet-4-20250514",
+        model_provider="anthropic",
+        interface="langchain_deep_agents",
+        temperature=0.0,
+    )

--- a/tests/unit/adapters/langchain_deep_agents/test_agent.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_agent.py
@@ -11,6 +11,135 @@ from karenina.ports import AgentConfig, AgentResult, Message
 
 
 @pytest.mark.unit
+class TestDeepAgentsBackendConfiguration:
+    """Verify the adapter configures a real filesystem backend, not virtual state.
+
+    This test class exists because a virtual/in-memory backend (StateBackend)
+    causes the agent to see an empty filesystem: all ls/glob/read_file calls
+    return empty results even when real files exist on disk. This is a critical
+    correctness issue for benchmarking with workspace files.
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_uses_filesystem_backend(self, deep_agents_model_config, monkeypatch):
+        """Without workspace_path, adapter must use FilesystemBackend (not StateBackend)."""
+        from deepagents.backends import FilesystemBackend
+        from langchain_core.messages import AIMessage
+
+        captured_kwargs: dict = {}
+
+        def capture_create(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_agent = MagicMock()
+            mock_agent.ainvoke = AsyncMock(
+                return_value={
+                    "messages": [AIMessage(content="ok")],
+                    "is_last_step": False,
+                }
+            )
+            return mock_agent
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+            capture_create,
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.create_chat_model",
+            lambda _config, **_kw: MagicMock(),
+        )
+
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        await adapter.arun(messages=[Message.user("test")], config=AgentConfig(max_turns=2))
+
+        assert "backend" in captured_kwargs, "backend kwarg must be passed to create_deep_agent"
+        backend = captured_kwargs["backend"]
+        assert isinstance(backend, FilesystemBackend), (
+            f"Expected FilesystemBackend, got {type(backend).__name__}. "
+            "StateBackend would make the agent unable to see real files on disk."
+        )
+
+    @pytest.mark.asyncio
+    async def test_workspace_path_configures_rooted_backend(self, deep_agents_model_config, tmp_path, monkeypatch):
+        """When workspace_path is set, FilesystemBackend must be rooted at that path."""
+        from deepagents.backends import FilesystemBackend
+        from langchain_core.messages import AIMessage
+
+        captured_kwargs: dict = {}
+
+        def capture_create(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_agent = MagicMock()
+            mock_agent.ainvoke = AsyncMock(
+                return_value={
+                    "messages": [AIMessage(content="ok")],
+                    "is_last_step": False,
+                }
+            )
+            return mock_agent
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+            capture_create,
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.create_chat_model",
+            lambda _config, **_kw: MagicMock(),
+        )
+
+        workspace = tmp_path / "my_workspace"
+        workspace.mkdir()
+        (workspace / "data.xlsx").write_text("fake data")
+
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        await adapter.arun(
+            messages=[Message.user("analyze data.xlsx")],
+            config=AgentConfig(max_turns=2, workspace_path=workspace),
+        )
+
+        backend = captured_kwargs["backend"]
+        assert isinstance(backend, FilesystemBackend)
+        # FilesystemBackend stores root_dir as 'cwd' attribute
+        assert backend.cwd == workspace
+
+    @pytest.mark.asyncio
+    async def test_backend_is_never_state_backend(self, deep_agents_model_config, monkeypatch):
+        """StateBackend must never be used; it makes the agent blind to real files."""
+        from deepagents.backends import StateBackend
+        from langchain_core.messages import AIMessage
+
+        captured_kwargs: dict = {}
+
+        def capture_create(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_agent = MagicMock()
+            mock_agent.ainvoke = AsyncMock(
+                return_value={
+                    "messages": [AIMessage(content="ok")],
+                    "is_last_step": False,
+                }
+            )
+            return mock_agent
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+            capture_create,
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.create_chat_model",
+            lambda _config, **_kw: MagicMock(),
+        )
+
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        await adapter.arun(messages=[Message.user("test")], config=AgentConfig(max_turns=2))
+
+        backend = captured_kwargs.get("backend")
+        assert not isinstance(backend, StateBackend), (
+            "StateBackend (virtual/in-memory) must never be used. "
+            "The agent would see empty results for all filesystem operations."
+        )
+
+
+@pytest.mark.unit
 class TestDeepAgentsAgentAdapter:
     def test_init_stores_config(self, deep_agents_model_config):
         adapter = DeepAgentsAgentAdapter(deep_agents_model_config)

--- a/tests/unit/adapters/langchain_deep_agents/test_agent.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_agent.py
@@ -1,0 +1,129 @@
+"""Tests for DeepAgentsAgentAdapter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from karenina.adapters.langchain_deep_agents.agent import DeepAgentsAgentAdapter
+from karenina.ports import AgentConfig, AgentResult, Message
+
+
+@pytest.mark.unit
+class TestDeepAgentsAgentAdapter:
+    def test_init_stores_config(self, deep_agents_model_config):
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        assert adapter._config == deep_agents_model_config
+
+    @pytest.mark.asyncio
+    async def test_arun_returns_agent_result(self, deep_agents_model_config, monkeypatch):
+        """Test that arun produces a valid AgentResult with mocked Deep Agents."""
+        from langchain_core.messages import AIMessage
+
+        mock_result = {
+            "messages": [AIMessage(content="The answer is 42.")],
+            "is_last_step": False,
+        }
+
+        mock_agent = MagicMock()
+        mock_agent.ainvoke = AsyncMock(return_value=mock_result)
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+            lambda **_kwargs: mock_agent,
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.create_chat_model",
+            lambda _config, **_kw: MagicMock(),
+        )
+
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        result = await adapter.arun(
+            messages=[Message.user("What is the meaning of life?")],
+            config=AgentConfig(max_turns=5),
+        )
+
+        assert isinstance(result, AgentResult)
+        assert "42" in result.final_response
+        assert "--- AI Message ---" in result.raw_trace
+        assert len(result.trace_messages) >= 1
+        assert result.usage.input_tokens >= 0
+        assert result.limit_reached is False
+        assert result.turns == 1
+
+    @pytest.mark.asyncio
+    async def test_arun_detects_limit_reached(self, deep_agents_model_config, monkeypatch):
+        """Test that is_last_step=True in result sets limit_reached."""
+        from langchain_core.messages import AIMessage
+
+        mock_result = {
+            "messages": [AIMessage(content="Partial answer.")],
+            "is_last_step": True,
+        }
+
+        mock_agent = MagicMock()
+        mock_agent.ainvoke = AsyncMock(return_value=mock_result)
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+            lambda **_kwargs: mock_agent,
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.create_chat_model",
+            lambda _config, **_kw: MagicMock(),
+        )
+
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        result = await adapter.arun(
+            messages=[Message.user("Complex question")],
+            config=AgentConfig(max_turns=2),
+        )
+
+        assert result.limit_reached is True
+
+    @pytest.mark.asyncio
+    async def test_arun_with_tool_calls(self, deep_agents_model_config, monkeypatch):
+        """Test trace extraction with tool calls in the conversation."""
+        from langchain_core.messages import AIMessage, ToolMessage
+
+        mock_result = {
+            "messages": [
+                AIMessage(
+                    content="Let me search.",
+                    tool_calls=[{"name": "search", "args": {"q": "test"}, "id": "call_1"}],
+                ),
+                ToolMessage(content="search result", tool_call_id="call_1"),
+                AIMessage(content="Based on the search, the answer is X."),
+            ],
+            "is_last_step": False,
+        }
+
+        mock_agent = MagicMock()
+        mock_agent.ainvoke = AsyncMock(return_value=mock_result)
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+            lambda **_kwargs: mock_agent,
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.create_chat_model",
+            lambda _config, **_kw: MagicMock(),
+        )
+
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        result = await adapter.arun(
+            messages=[Message.user("Search for something")],
+            config=AgentConfig(max_turns=10),
+        )
+
+        assert "answer is X" in result.final_response
+        assert "--- Tool Call ---" in result.raw_trace
+        assert "--- Tool Result ---" in result.raw_trace
+        assert result.turns == 2  # Two AIMessages
+
+    @pytest.mark.asyncio
+    async def test_aclose_is_noop(self, deep_agents_model_config):
+        """aclose() should not raise."""
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        await adapter.aclose()

--- a/tests/unit/adapters/langchain_deep_agents/test_availability.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_availability.py
@@ -1,0 +1,33 @@
+"""Tests for Deep Agents availability checking."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.adapters.langchain_deep_agents.availability import check_deep_agents_available
+
+
+@pytest.mark.unit
+class TestDeepAgentsAvailability:
+    def test_returns_availability_result(self):
+        result = check_deep_agents_available()
+        assert hasattr(result, "available")
+        assert hasattr(result, "reason")
+        assert isinstance(result.available, bool)
+        assert isinstance(result.reason, str)
+
+    def test_unavailable_when_import_fails(self, monkeypatch):
+        import builtins
+
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "deepagents":
+                raise ImportError("No module named 'deepagents'")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        result = check_deep_agents_available()
+        assert result.available is False
+        assert "deepagents" in result.reason.lower()
+        assert result.fallback_interface is None

--- a/tests/unit/adapters/langchain_deep_agents/test_llm.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_llm.py
@@ -1,0 +1,54 @@
+"""Tests for DeepAgentsLLMAdapter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from karenina.adapters.langchain_deep_agents.llm import DeepAgentsLLMAdapter
+from karenina.ports import LLMResponse, Message
+
+
+@pytest.mark.unit
+class TestDeepAgentsLLMAdapter:
+    @pytest.mark.asyncio
+    async def test_ainvoke_returns_llm_response(self, deep_agents_model_config, monkeypatch):
+        """Test that ainvoke produces a valid LLMResponse."""
+        from langchain_core.messages import AIMessage
+
+        mock_response = AIMessage(content="Response text.")
+        mock_model = MagicMock()
+        mock_model.ainvoke = AsyncMock(return_value=mock_response)
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.llm.create_chat_model",
+            lambda _config, **_kw: mock_model,
+        )
+
+        adapter = DeepAgentsLLMAdapter(deep_agents_model_config)
+        result = await adapter.ainvoke([Message.user("Hello")])
+
+        assert isinstance(result, LLMResponse)
+        assert "Response text" in result.content
+
+    def test_capabilities_include_system_prompt(self, deep_agents_model_config):
+        """Capabilities should declare system prompt and structured output support."""
+        adapter = DeepAgentsLLMAdapter(deep_agents_model_config)
+        caps = adapter.capabilities
+        assert caps.supports_system_prompt is True
+        assert caps.supports_structured_output is True
+
+    def test_with_structured_output_returns_new_adapter(self, deep_agents_model_config):
+        """with_structured_output should return a new adapter with the schema set."""
+        from pydantic import BaseModel, Field
+
+        class Answer(BaseModel):
+            value: str = Field(description="The answer")
+
+        adapter = DeepAgentsLLMAdapter(deep_agents_model_config)
+        structured = adapter.with_structured_output(Answer)
+
+        assert isinstance(structured, DeepAgentsLLMAdapter)
+        assert structured._structured_schema == Answer
+        assert adapter._structured_schema is None  # Original unchanged

--- a/tests/unit/adapters/langchain_deep_agents/test_mcp.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_mcp.py
@@ -1,0 +1,41 @@
+"""Tests for MCP config conversion."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+class TestMCPConfigConversion:
+    def test_stdio_config_produces_valid_params(self):
+        from karenina.adapters.langchain_deep_agents.mcp import build_mcp_server_params
+
+        config = {
+            "filesystem": {
+                "type": "stdio",
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+            }
+        }
+        result = build_mcp_server_params(config)
+        assert "filesystem" in result
+        assert result["filesystem"]["command"] == "npx"
+
+    def test_http_config_produces_valid_params(self):
+        from karenina.adapters.langchain_deep_agents.mcp import build_mcp_server_params
+
+        config = {
+            "api": {
+                "type": "http",
+                "url": "https://mcp.example.com/api",
+            }
+        }
+        result = build_mcp_server_params(config)
+        assert "api" in result
+        assert result["api"]["url"] == "https://mcp.example.com/api"
+
+    def test_empty_config_returns_empty(self):
+        from karenina.adapters.langchain_deep_agents.mcp import build_mcp_server_params
+
+        assert build_mcp_server_params({}) == {}
+        assert build_mcp_server_params(None) == {}

--- a/tests/unit/adapters/langchain_deep_agents/test_messages.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_messages.py
@@ -1,0 +1,74 @@
+"""Tests for DeepAgentsMessageConverter."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.adapters.langchain_deep_agents.messages import DeepAgentsMessageConverter
+from karenina.ports.messages import Message
+
+
+@pytest.mark.unit
+class TestDeepAgentsMessageConverter:
+    def setup_method(self):
+        self.converter = DeepAgentsMessageConverter()
+
+    def test_user_message_to_prompt_string(self):
+        messages = [Message.user("What is 2 + 2?")]
+        result = self.converter.to_prompt_string(messages)
+        assert "What is 2 + 2?" in result
+
+    def test_system_message_extracted_separately(self):
+        messages = [Message.system("You are helpful."), Message.user("Hello")]
+        system = self.converter.extract_system_prompt(messages)
+        prompt = self.converter.to_prompt_string(messages)
+        assert system == "You are helpful."
+        assert "You are helpful." not in prompt
+        assert "Hello" in prompt
+
+    def test_multiple_user_messages_concatenated(self):
+        messages = [Message.user("First"), Message.user("Second")]
+        result = self.converter.to_prompt_string(messages)
+        assert "First" in result
+        assert "Second" in result
+
+    def test_no_system_message_returns_none(self):
+        messages = [Message.user("Hello")]
+        assert self.converter.extract_system_prompt(messages) is None
+
+    def test_from_provider_human_message(self):
+        from langchain_core.messages import HumanMessage
+
+        lc_messages = [HumanMessage(content="Hello")]
+        result = self.converter.from_provider(lc_messages)
+        assert len(result) == 1
+        assert result[0].role.value == "user"
+
+    def test_from_provider_ai_message(self):
+        from langchain_core.messages import AIMessage
+
+        lc_messages = [AIMessage(content="The answer is 42.")]
+        result = self.converter.from_provider(lc_messages)
+        assert len(result) == 1
+        assert result[0].role.value == "assistant"
+
+    def test_from_provider_tool_message(self):
+        from langchain_core.messages import ToolMessage
+
+        lc_messages = [ToolMessage(content="result data", tool_call_id="call_1")]
+        result = self.converter.from_provider(lc_messages)
+        assert len(result) == 1
+        assert result[0].role.value == "tool"
+
+    def test_from_provider_ai_with_tool_calls(self):
+        from langchain_core.messages import AIMessage
+
+        lc_messages = [
+            AIMessage(
+                content="Let me search.",
+                tool_calls=[{"name": "search", "args": {"q": "test"}, "id": "call_1"}],
+            )
+        ]
+        result = self.converter.from_provider(lc_messages)
+        assert len(result) == 1
+        assert result[0].role.value == "assistant"

--- a/tests/unit/adapters/langchain_deep_agents/test_parser.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_parser.py
@@ -21,9 +21,18 @@ class SimpleAnswer(BaseModel):
 class TestDeepAgentsParserAdapter:
     @pytest.mark.asyncio
     async def test_aparse_to_pydantic_with_structured_output(self, deep_agents_model_config, monkeypatch):
-        """Test parsing with structured output returning a dict."""
+        """Test parsing with structured output returning a dict (include_raw=True format)."""
+        from langchain_core.messages import AIMessage
+
+        # include_raw=True returns {"raw": AIMessage, "parsed": dict, "parsing_error": None}
         mock_structured_model = MagicMock()
-        mock_structured_model.ainvoke = AsyncMock(return_value={"value": "42"})
+        mock_structured_model.ainvoke = AsyncMock(
+            return_value={
+                "raw": AIMessage(content='{"value": "42"}'),
+                "parsed": {"value": "42"},
+                "parsing_error": None,
+            }
+        )
 
         mock_model = MagicMock()
         mock_model.with_structured_output = MagicMock(return_value=mock_structured_model)
@@ -46,9 +55,17 @@ class TestDeepAgentsParserAdapter:
     @pytest.mark.asyncio
     async def test_aparse_to_pydantic_with_pydantic_response(self, deep_agents_model_config, monkeypatch):
         """Test parsing when structured output returns a Pydantic model directly."""
+        from langchain_core.messages import AIMessage
+
         answer = SimpleAnswer(value="hello")
         mock_structured_model = MagicMock()
-        mock_structured_model.ainvoke = AsyncMock(return_value=answer)
+        mock_structured_model.ainvoke = AsyncMock(
+            return_value={
+                "raw": AIMessage(content='{"value": "hello"}'),
+                "parsed": answer,
+                "parsing_error": None,
+            }
+        )
 
         mock_model = MagicMock()
         mock_model.with_structured_output = MagicMock(return_value=mock_structured_model)

--- a/tests/unit/adapters/langchain_deep_agents/test_parser.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_parser.py
@@ -1,0 +1,98 @@
+"""Tests for DeepAgentsParserAdapter."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import BaseModel, Field
+
+from karenina.adapters.langchain_deep_agents.parser import DeepAgentsParserAdapter
+from karenina.ports import Message
+from karenina.ports.parser import ParsePortResult
+
+
+class SimpleAnswer(BaseModel):
+    value: str = Field(description="The answer")
+
+
+@pytest.mark.unit
+class TestDeepAgentsParserAdapter:
+    @pytest.mark.asyncio
+    async def test_aparse_to_pydantic_with_structured_output(self, deep_agents_model_config, monkeypatch):
+        """Test parsing with structured output returning a dict."""
+        mock_structured_model = MagicMock()
+        mock_structured_model.ainvoke = AsyncMock(return_value={"value": "42"})
+
+        mock_model = MagicMock()
+        mock_model.with_structured_output = MagicMock(return_value=mock_structured_model)
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.parser.create_chat_model",
+            lambda _config, **_kw: mock_model,
+        )
+
+        adapter = DeepAgentsParserAdapter(deep_agents_model_config)
+        result = await adapter.aparse_to_pydantic(
+            [Message.user("Parse this")],
+            SimpleAnswer,
+        )
+
+        assert isinstance(result, ParsePortResult)
+        assert isinstance(result.parsed, SimpleAnswer)
+        assert result.parsed.value == "42"
+
+    @pytest.mark.asyncio
+    async def test_aparse_to_pydantic_with_pydantic_response(self, deep_agents_model_config, monkeypatch):
+        """Test parsing when structured output returns a Pydantic model directly."""
+        answer = SimpleAnswer(value="hello")
+        mock_structured_model = MagicMock()
+        mock_structured_model.ainvoke = AsyncMock(return_value=answer)
+
+        mock_model = MagicMock()
+        mock_model.with_structured_output = MagicMock(return_value=mock_structured_model)
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.parser.create_chat_model",
+            lambda _config, **_kw: mock_model,
+        )
+
+        adapter = DeepAgentsParserAdapter(deep_agents_model_config)
+        result = await adapter.aparse_to_pydantic(
+            [Message.user("Parse this")],
+            SimpleAnswer,
+        )
+
+        assert result.parsed.value == "hello"
+
+    @pytest.mark.asyncio
+    async def test_aparse_fallback_to_text_extraction(self, deep_agents_model_config, monkeypatch):
+        """Test fallback to text JSON extraction when structured output fails."""
+        from langchain_core.messages import AIMessage
+
+        answer_json = json.dumps({"value": "fallback"})
+        mock_text_response = AIMessage(content=answer_json)
+
+        mock_model = MagicMock()
+        mock_model.with_structured_output = MagicMock(side_effect=Exception("Not supported"))
+        mock_model.ainvoke = AsyncMock(return_value=mock_text_response)
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.parser.create_chat_model",
+            lambda _config, **_kw: mock_model,
+        )
+
+        adapter = DeepAgentsParserAdapter(deep_agents_model_config)
+        result = await adapter.aparse_to_pydantic(
+            [Message.user("Parse this")],
+            SimpleAnswer,
+        )
+
+        assert result.parsed.value == "fallback"
+
+    def test_capabilities_supports_structured_output(self, deep_agents_model_config):
+        """Capabilities should declare structured output support."""
+        adapter = DeepAgentsParserAdapter(deep_agents_model_config)
+        caps = adapter.capabilities
+        assert caps.supports_structured_output is True

--- a/tests/unit/adapters/langchain_deep_agents/test_trace.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_trace.py
@@ -1,0 +1,45 @@
+"""Tests for trace extraction from Deep Agents results."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.adapters.langchain_deep_agents.trace import deep_agents_messages_to_raw_trace
+
+
+@pytest.mark.unit
+class TestDeepAgentsTraceExtraction:
+    def test_ai_message_produces_ai_delimiter(self):
+        from langchain_core.messages import AIMessage
+
+        messages = [AIMessage(content="Hello world")]
+        trace = deep_agents_messages_to_raw_trace(messages)
+        assert "--- AI Message ---" in trace
+        assert "Hello world" in trace
+
+    def test_tool_call_produces_tool_delimiter(self):
+        from langchain_core.messages import AIMessage, ToolMessage
+
+        messages = [
+            AIMessage(
+                content="Let me search.",
+                tool_calls=[{"name": "search", "args": {"q": "test"}, "id": "call_1"}],
+            ),
+            ToolMessage(content="search result", tool_call_id="call_1"),
+        ]
+        trace = deep_agents_messages_to_raw_trace(messages)
+        assert "--- AI Message ---" in trace
+        assert "--- Tool Call ---" in trace
+        assert "--- Tool Result ---" in trace
+        assert "search" in trace
+
+    def test_empty_messages_returns_empty_string(self):
+        trace = deep_agents_messages_to_raw_trace([])
+        assert trace == ""
+
+    def test_multiple_ai_messages(self):
+        from langchain_core.messages import AIMessage
+
+        messages = [AIMessage(content="First"), AIMessage(content="Second")]
+        trace = deep_agents_messages_to_raw_trace(messages)
+        assert trace.count("--- AI Message ---") == 2

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.77.0"
+version = "0.85.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -134,9 +134,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/85/6cb5da3cf91de2eeea89726316e8c5c8c31e2d61ee7cb1233d7e95512c31/anthropic-0.77.0.tar.gz", hash = "sha256:ce36efeb80cb1e25430a88440dc0f9aa5c87f10d080ab70a1bdfd5c2c5fbedb4", size = 504575 }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/08/c620a0eb8625539a8ea9f5a6e06f13d131be0bc8b5b714c235d4b25dd1b5/anthropic-0.85.0.tar.gz", hash = "sha256:d45b2f38a1efb1a5d15515a426b272179a0d18783efa2bb4c3925fa773eb50b9", size = 542034 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/27/9df785d3f94df9ac72f43ee9e14b8120b37d992b18f4952774ed46145022/anthropic-0.77.0-py3-none-any.whl", hash = "sha256:65cc83a3c82ce622d5c677d0d7706c77d29dc83958c6b10286e12fda6ffb2651", size = 397867 },
+    { url = "https://files.pythonhosted.org/packages/e1/5a/9d85b85686d5cdd79f5488c8667e668d7920d06a0a1a1beb454a5b77b2db/anthropic-0.85.0-py3-none-any.whl", hash = "sha256:b4f54d632877ed7b7b29c6d9ba7299d5e21c4c92ae8de38947e9d862bff74adf", size = 458237 },
 ]
 
 [[package]]
@@ -339,6 +339,15 @@ css = [
 ]
 
 [[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508 },
+]
+
+[[package]]
 name = "build"
 version = "1.2.2.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -350,15 +359,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/46/aeab111f8e06793e4f0e421fcad593d547fb8313b50990f31681ee2fb1ad/build-1.2.2.post1.tar.gz", hash = "sha256:b36993e92ca9375a219c99e606a122ff365a760a2d4bba0caa09bd5278b608b7", size = 46701 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/c2/80633736cd183ee4a62107413def345f7e6e3c01563dbca1417363cf957e/build-1.2.2.post1-py3-none-any.whl", hash = "sha256:1d61c0887fa860c01971625baae8bdd338e517b836a2f70dd1f7aa3a6b2fc5b5", size = 22950 },
-]
-
-[[package]]
-name = "cachetools"
-version = "5.5.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080 },
 ]
 
 [[package]]
@@ -668,6 +668,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190 },
+]
+
+[[package]]
+name = "deepagents"
+version = "0.4.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain" },
+    { name = "langchain-anthropic" },
+    { name = "langchain-core" },
+    { name = "langchain-google-genai" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/e5/1dcb9e466d887bc42ddad66faa769d1c06b11ca751d1c43b4f2e5da3b1c8/deepagents-0.4.11.tar.gz", hash = "sha256:6ada9bd3b136bae294aa1520575bf85e806c0514807d6e3bf43c7b3d08b44306", size = 90529 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/45/4d78759b991535f7ef7461ac25aad79c423f5ab3cb53ef75dbeff4e9617b/deepagents-0.4.11-py3-none-any.whl", hash = "sha256:bc5b973696f5e9f9ccea1c095a4b4af6bd057b99befa76a596fc3c02380ea7cb", size = 102588 },
 ]
 
 [[package]]
@@ -987,70 +1003,42 @@ wheels = [
 ]
 
 [[package]]
-name = "google-ai-generativelanguage"
-version = "0.9.0"
+name = "google-auth"
+version = "2.49.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", extra = ["grpc"] },
-    { name = "google-auth" },
-    { name = "grpcio", version = "1.67.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/7e/67fdc46187541ead599e77f259d915f129c2f49568ebf5cadb322130712b/google_ai_generativelanguage-0.9.0.tar.gz", hash = "sha256:2524748f413917446febc8e0879dc0d4f026a064f89f17c42b81bea77ab76c84", size = 1481662 }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64", size = 333825 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/91/c2d39ad5d77813afadb0f0b8789d882d15c191710b6b6f7cb158376342ff/google_ai_generativelanguage-0.9.0-py3-none-any.whl", hash = "sha256:59f61e54cb341e602073098389876594c4d12e458617727558bb2628a86f3eb2", size = 1401288 },
-]
-
-[[package]]
-name = "google-api-core"
-version = "2.25.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-auth" },
-    { name = "googleapis-common-protos" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/21/e9d043e88222317afdbdb567165fdbc3b0aad90064c7e0c9eb0ad9955ad8/google_api_core-2.25.1.tar.gz", hash = "sha256:d2aaa0b13c78c61cb3f4282c464c046e45fbd75755683c9c525e6e8f7ed0a5e8", size = 165443 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/4b/ead00905132820b623732b175d66354e9d3e69fcf2a5dcdab780664e7896/google_api_core-2.25.1-py3-none-any.whl", hash = "sha256:8a2a56c1fef82987a524371f99f3bd0143702fecc670c72e600c1cda6bf8dbb7", size = 160807 },
+    { url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7", size = 240737 },
 ]
 
 [package.optional-dependencies]
-grpc = [
-    { name = "grpcio", version = "1.67.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "grpcio-status", version = "1.67.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "grpcio-status", version = "1.71.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+requests = [
+    { name = "requests" },
 ]
 
 [[package]]
-name = "google-auth"
-version = "2.40.3"
+name = "google-genai"
+version = "1.68.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cachetools" },
-    { name = "pyasn1-modules" },
-    { name = "rsa" },
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/9b/e92ef23b84fa10a64ce4831390b7a4c2e53c0132568d99d4ae61d04c8855/google_auth-2.40.3.tar.gz", hash = "sha256:500c3a29adedeb36ea9cf24b8d10858e152f2412e3ca37829b3fa18e33d63b77", size = 281029 }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/2c/f059982dbcb658cc535c81bbcbe7e2c040d675f4b563b03cdb01018a4bc3/google_genai-1.68.0.tar.gz", hash = "sha256:ac30c0b8bc630f9372993a97e4a11dae0e36f2e10d7c55eacdca95a9fa14ca96", size = 511285 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/63/b19553b658a1692443c62bd07e5868adaa0ad746a0751ba62c59568cd45b/google_auth-2.40.3-py2.py3-none-any.whl", hash = "sha256:1370d4593e86213563547f97a92752fc658456fe4514c809544f330fed45a7ca", size = 216137 },
-]
-
-[[package]]
-name = "googleapis-common-protos"
-version = "1.70.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/39/24/33db22342cf4a2ea27c9955e6713140fedd51e8b141b5ce5260897020f1a/googleapis_common_protos-1.70.0.tar.gz", hash = "sha256:0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257", size = 145903 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/f1/62a193f0227cf15a920390abe675f386dec35f7ae3ffe6da582d3ade42c7/googleapis_common_protos-1.70.0-py3-none-any.whl", hash = "sha256:b8bfcca8c25a2bb253e0e0b0adaf8c00773e5e6af6fd92397576680b807e0fd8", size = 294530 },
+    { url = "https://files.pythonhosted.org/packages/84/de/7d3ee9c94b74c3578ea4f88d45e8de9405902f857932334d81e89bce3dfa/google_genai-1.68.0-py3-none-any.whl", hash = "sha256:a1bc9919c0e2ea2907d1e319b65471d3d6d58c54822039a249fe1323e4178d15", size = 750912 },
 ]
 
 [[package]]
@@ -1200,43 +1188,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/45/122df922d05655f63930cf42c9e3f72ba20aadb26c100ee105cad4ce4257/grpcio-1.76.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1c9b93f79f48b03ada57ea24725d83a30284a012ec27eab2cf7e50a550cbbbcc", size = 7592214 },
     { url = "https://files.pythonhosted.org/packages/4a/6e/0b899b7f6b66e5af39e377055fb4a6675c9ee28431df5708139df2e93233/grpcio-1.76.0-cp314-cp314-win32.whl", hash = "sha256:747fa73efa9b8b1488a95d0ba1039c8e2dca0f741612d80415b1e1c560febf4e", size = 4062961 },
     { url = "https://files.pythonhosted.org/packages/19/41/0b430b01a2eb38ee887f88c1f07644a1df8e289353b78e82b37ef988fb64/grpcio-1.76.0-cp314-cp314-win_amd64.whl", hash = "sha256:922fa70ba549fce362d2e2871ab542082d66e2aaf0c19480ea453905b01f384e", size = 4834462 },
-]
-
-[[package]]
-name = "grpcio-status"
-version = "1.67.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*'",
-    "python_full_version >= '3.12.4' and python_full_version < '3.13'",
-    "python_full_version >= '3.12' and python_full_version < '3.12.4'",
-    "python_full_version < '3.12'",
-]
-dependencies = [
-    { name = "googleapis-common-protos", marker = "python_full_version < '3.14'" },
-    { name = "grpcio", version = "1.67.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "protobuf", marker = "python_full_version < '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/be/c7/fe0e79a80ac6346e0c6c0a24e9e3cbc3ae1c2a009acffb59eab484a6f69b/grpcio_status-1.67.1.tar.gz", hash = "sha256:2bf38395e028ceeecfd8866b081f61628114b384da7d51ae064ddc8d766a5d11", size = 13673 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/18/56999a1da3577d8ccc8698a575d6638e15fe25650cc88b2ce0a087f180b9/grpcio_status-1.67.1-py3-none-any.whl", hash = "sha256:16e6c085950bdacac97c779e6a502ea671232385e6e37f258884d6883392c2bd", size = 14427 },
-]
-
-[[package]]
-name = "grpcio-status"
-version = "1.71.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-]
-dependencies = [
-    { name = "googleapis-common-protos", marker = "python_full_version >= '3.14'" },
-    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "protobuf", marker = "python_full_version >= '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/53/a911467bece076020456401f55a27415d2d70d3bc2c37af06b44ea41fc5c/grpcio_status-1.71.0.tar.gz", hash = "sha256:11405fed67b68f406b3f3c7c5ae5104a79d2d309666d10d61b152e91d28fb968", size = 13669 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/d6/31fbc43ff097d8c4c9fc3df741431b8018f67bf8dfbe6553a555f6e5f675/grpcio_status-1.71.0-py3-none-any.whl", hash = "sha256:843934ef8c09e3e858952887467f8256aac3910c55f077a359a65b2b3cde3e68", size = 14424 },
 ]
 
 [[package]]
@@ -1934,6 +1885,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+deep-agents = [
+    { name = "deepagents" },
+    { name = "langchain-mcp-adapters" },
+]
 dev = [
     { name = "ipython" },
     { name = "mkdocs" },
@@ -1995,6 +1950,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.12.0" },
     { name = "anthropic", specifier = ">=0.76.0" },
     { name = "cloudpickle", specifier = ">=3.0.0" },
+    { name = "deepagents", marker = "extra == 'deep-agents'", specifier = ">=0.4.0" },
     { name = "gepa", specifier = ">=0.0.24" },
     { name = "gepa", marker = "extra == 'gepa'", specifier = ">=0.0.24" },
     { name = "httpx", specifier = ">=0.24.0" },
@@ -2009,6 +1965,7 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=0.3.66" },
     { name = "langchain-google-genai", specifier = ">=2.1.6" },
     { name = "langchain-mcp-adapters", specifier = ">=0.1.0" },
+    { name = "langchain-mcp-adapters", marker = "extra == 'deep-agents'", specifier = ">=0.1.0" },
     { name = "langchain-openai", specifier = ">=0.3.25" },
     { name = "langgraph", specifier = ">=0.5.4" },
     { name = "litellm", specifier = ">=1.80.11" },
@@ -2086,30 +2043,30 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.1.0"
+version = "1.2.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/06/be7273c6c15f5a7e64788ed2aa6329dd019170a176977acff7bcde2cdea2/langchain-1.1.0.tar.gz", hash = "sha256:583c892f59873c0329dbe04169fb3234ac794c50780e7c6fb62a61c7b86a981b", size = 528416 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/1d/1af2fc0ac084d4781778b7846b1aed62e05006bf2d73fdf84ac3a8f5225c/langchain-1.2.12.tar.gz", hash = "sha256:ed705b5b293799f7e3e394387f398a1b71707542758283206c8c21415759d991", size = 566444 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/6f/889c01d22c84934615fa3f2dcf94c2fe76fd0afa7a7d01f9b798059f0ecc/langchain-1.1.0-py3-none-any.whl", hash = "sha256:af080f3a4a779bfa5925de7aacb6dfab83249d4aab9a08f7aa7b9bec3766d8ea", size = 101797 },
+    { url = "https://files.pythonhosted.org/packages/ca/51/09bb1cfb0b57ae9440ca56cc576e4dc792f83d030eef7637d2c516dcb0a0/langchain-1.2.12-py3-none-any.whl", hash = "sha256:60eff184b8f92c2610f5a4c9a97ad339a891adb01901e83e4df8e6c9c69cf852", size = 112373 },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.2.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/f2/717dcadf0c96960154594409b68bdd5953ab95439e0b65de13cdd5c08785/langchain_anthropic-1.2.0.tar.gz", hash = "sha256:3f3cfad8c519ead2deb21c30dc538b18f4c094704c7874784320cbed7a199453", size = 688803 }
+sdist = { url = "https://files.pythonhosted.org/packages/98/c7/259d4d805c6ac90c8695714fc15498a4557bb515eb24f692fd611966e383/langchain_anthropic-1.4.0.tar.gz", hash = "sha256:bbf64e99f9149a34ba67813e9582b2160a0968de9e9f54f7ba8d1658f253c2e5", size = 674360 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/f4/f684725bd375208130ff3e9878ff3e671d888eec89a834617f3d7bcc14c9/langchain_anthropic-1.2.0-py3-none-any.whl", hash = "sha256:f489df97833e12ca0360a098eb9d04e410752840416be87ab60b0a3e120a99fe", size = 49512 },
+    { url = "https://files.pythonhosted.org/packages/2e/c0/77f99373276d4f06c38a887ef6023f101cfc7ba3b2bf9af37064cdbadde5/langchain_anthropic-1.4.0-py3-none-any.whl", hash = "sha256:c84f55722336935f7574d5771598e674f3959fdca0b51de14c9788dbf52761be", size = 48463 },
 ]
 
 [[package]]
@@ -2155,7 +2112,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.1.0"
+version = "1.2.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2165,25 +2122,26 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tenacity" },
     { name = "typing-extensions" },
+    { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/17/67c1cc2ace919e2b02dd9d783154d7fb3f1495a4ef835d9cd163b7855ac2/langchain_core-1.1.0.tar.gz", hash = "sha256:2b76a82d427922c8bc51c08404af4fc2a29e9f161dfe2297cb05091e810201e7", size = 781995 }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/da/075720d37ebc668f48743bd540b047b2b08b8ba22b46d8f61166c5ad1d1c/langchain_core-1.2.19.tar.gz", hash = "sha256:87fa82c3eb4cc3d7a65f574cb447b5df09ec2131c8c2a0a02d4737ad02685438", size = 836647 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/1e/e129fc471a2d2a7b3804480a937b5ab9319cab9f4142624fcb115f925501/langchain_core-1.1.0-py3-none-any.whl", hash = "sha256:2c9f27dadc6d21ed4aa46506a37a56e6a7e2d2f9141922dc5c251ba921822ee6", size = 473752 },
+    { url = "https://files.pythonhosted.org/packages/aa/cb/8704b2a22c0987627ed29464d23a45fb15e10a28fb482f4d84c3bddcbf27/langchain_core-1.2.19-py3-none-any.whl", hash = "sha256:6e74cb0fb443a8046ee298c05c99b67abe54cc57fcbc6d1cd3b0f2485ee47574", size = 503456 },
 ]
 
 [[package]]
 name = "langchain-google-genai"
-version = "3.2.0"
+version = "4.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filetype" },
-    { name = "google-ai-generativelanguage" },
+    { name = "google-genai" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/27/f3c8f47b7c194c42a7ea38e5b91b412c4bd45f97e702a96edad659312437/langchain_google_genai-3.2.0.tar.gz", hash = "sha256:1fa620ea9c655a37537e95438857c423e1a3599b5a665b8dd87064c76ee95b72", size = 242146 }
+sdist = { url = "https://files.pythonhosted.org/packages/14/63/e7d148f903cebfef50109da71378f411166f068d66f79b9e16a62dbacf41/langchain_google_genai-4.2.1.tar.gz", hash = "sha256:7f44487a0337535897e3bba9a1d6605d722629e034f757ffa8755af0aa85daa8", size = 278288 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/9d/c79a367e3379cf6b7d0cc43d558a411a5097d55291f2ce2f573420adb523/langchain_google_genai-3.2.0-py3-none-any.whl", hash = "sha256:689fc159d4623a184678e24771f6d52373e983a8fc8d342e44352aaf28e9445d", size = 57604 },
+    { url = "https://files.pythonhosted.org/packages/ec/7e/46c5973bd8b10a5c4c8a77136cf536e658796380a17c740246074901b038/langchain_google_genai-4.2.1-py3-none-any.whl", hash = "sha256:a7735289cf94ca3a684d830e09196aac8f6e75e647e3a0a1c3c9dc534ceb985e", size = 66500 },
 ]
 
 [[package]]
@@ -2228,7 +2186,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.0.4"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2238,9 +2196,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/3c/af87902d300c1f467165558c8966d8b1e1f896dace271d3f35a410a5c26a/langgraph-1.0.4.tar.gz", hash = "sha256:86d08e25d7244340f59c5200fa69fdd11066aa999b3164b531e2a20036fac156", size = 484397 }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/a8/8494057db9149eb850258e5d4ae961a8dbda9a283e56e1b957393d9df0cd/langgraph-1.1.2.tar.gz", hash = "sha256:c4385ce349823a590891b3f6b1c46b54f51d0134164056866e95034985f047c9", size = 544288 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/52/4eb25a3f60399da34ba34adff1b3e324cf0d87eb7a08cebf1882a9b5e0d5/langgraph-1.0.4-py3-none-any.whl", hash = "sha256:b1a835ceb0a8d69b9db48075e1939e28b1ad70ee23fa3fa8f90149904778bacf", size = 157271 },
+    { url = "https://files.pythonhosted.org/packages/52/38/3117cd90325635893a76132cdae74f5b1f53c93c33b3dc6124521cec9825/langgraph-1.1.2-py3-none-any.whl", hash = "sha256:5fd43c839ec2b5af564e9ae2d2d4f22ce0a006a0b58e800cc4e8de4dd9cbb643", size = 167543 },
 ]
 
 [[package]]
@@ -2258,28 +2216,28 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.5"
+version = "1.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/f9/54f8891b32159e4542236817aea2ee83de0de18bce28e9bdba08c7f93001/langgraph_prebuilt-1.0.5.tar.gz", hash = "sha256:85802675ad778cc7240fd02d47db1e0b59c0c86d8369447d77ce47623845db2d", size = 144453 }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/06/dd61a5c2dce009d1b03b1d56f2a85b3127659fdddf5b3be5d8f1d60820fb/langgraph_prebuilt-1.0.8.tar.gz", hash = "sha256:0cd3cf5473ced8a6cd687cc5294e08d3de57529d8dd14fdc6ae4899549efcf69", size = 164442 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/5e/aeba4a5b39fe6e874e0dd003a82da71c7153e671312671a8dacc5cb7c1af/langgraph_prebuilt-1.0.5-py3-none-any.whl", hash = "sha256:22369563e1848862ace53fbc11b027c28dd04a9ac39314633bb95f2a7e258496", size = 35072 },
+    { url = "https://files.pythonhosted.org/packages/dc/41/ec966424ad3f2ed3996d24079d3342c8cd6c0bd0653c12b2a917a685ec6c/langgraph_prebuilt-1.0.8-py3-none-any.whl", hash = "sha256:d16a731e591ba4470f3e313a319c7eee7dbc40895bcf15c821f985a3522a7ce0", size = 35648 },
 ]
 
 [[package]]
 name = "langgraph-sdk"
-version = "0.2.10"
+version = "0.3.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "orjson" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/0f/88772be3301cc5ad495e77705538edbcbf7f2ccf38d21555fa26131203aa/langgraph_sdk-0.2.10.tar.gz", hash = "sha256:ab58331504fbea28e6322037aa362929799b4e9106663ac1dbd7c5ac44558933", size = 113432 }
+sdist = { url = "https://files.pythonhosted.org/packages/35/cd/a019f1b1e97c519f2425593f9bccd3ac463a18fb5d2111cff59ce1ef62fe/langgraph_sdk-0.3.11.tar.gz", hash = "sha256:3640134835d89d2c7c8bb7de73bd10673d4b282db3ff0e2fdaf1cee9e50cb1eb", size = 190387 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/cc/ff4ba17253d31981b047f4be52cc51a19fa28dd2dd16a880c0c595bd66bd/langgraph_sdk-0.2.10-py3-none-any.whl", hash = "sha256:9aef403663726085de6851e4e50459df9562069bd316dd0261eb359f776fd0ef", size = 58430 },
+    { url = "https://files.pythonhosted.org/packages/13/c8/b8d15d4b9a320a3f57a851030a371066b91dbd1420f097d3d0338da9adc9/langgraph_sdk-0.3.11-py3-none-any.whl", hash = "sha256:18905fd6248ade98b0995d859a98672d57c811fbfffc0d63d1c107a512351b26", size = 94887 },
 ]
 
 [[package]]
@@ -3143,55 +3101,70 @@ wheels = [
 
 [[package]]
 name = "orjson"
-version = "3.10.18"
+version = "3.11.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/0b/fea456a3ffe74e70ba30e01ec183a9b26bec4d497f61dcfce1b601059c60/orjson-3.10.18.tar.gz", hash = "sha256:e8da3947d92123eda795b68228cafe2724815621fe35e8e320a9e9593a4bcd53", size = 5422810 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/45/b268004f745ede84e5798b48ee12b05129d19235d0e15267aa57dcdb400b/orjson-3.11.7.tar.gz", hash = "sha256:9b1a67243945819ce55d24a30b59d6a168e86220452d2c96f4d1f093e71c0c49", size = 6144992 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/c7/c54a948ce9a4278794f669a353551ce7db4ffb656c69a6e1f2264d563e50/orjson-3.10.18-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:e0a183ac3b8e40471e8d843105da6fbe7c070faab023be3b08188ee3f85719b8", size = 248929 },
-    { url = "https://files.pythonhosted.org/packages/9e/60/a9c674ef1dd8ab22b5b10f9300e7e70444d4e3cda4b8258d6c2488c32143/orjson-3.10.18-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:5ef7c164d9174362f85238d0cd4afdeeb89d9e523e4651add6a5d458d6f7d42d", size = 133364 },
-    { url = "https://files.pythonhosted.org/packages/c1/4e/f7d1bdd983082216e414e6d7ef897b0c2957f99c545826c06f371d52337e/orjson-3.10.18-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd14c5d99cdc7bf93f22b12ec3b294931518aa019e2a147e8aa2f31fd3240f7", size = 136995 },
-    { url = "https://files.pythonhosted.org/packages/17/89/46b9181ba0ea251c9243b0c8ce29ff7c9796fa943806a9c8b02592fce8ea/orjson-3.10.18-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7b672502323b6cd133c4af6b79e3bea36bad2d16bca6c1f645903fce83909a7a", size = 132894 },
-    { url = "https://files.pythonhosted.org/packages/ca/dd/7bce6fcc5b8c21aef59ba3c67f2166f0a1a9b0317dcca4a9d5bd7934ecfd/orjson-3.10.18-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:51f8c63be6e070ec894c629186b1c0fe798662b8687f3d9fdfa5e401c6bd7679", size = 137016 },
-    { url = "https://files.pythonhosted.org/packages/1c/4a/b8aea1c83af805dcd31c1f03c95aabb3e19a016b2a4645dd822c5686e94d/orjson-3.10.18-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f9478ade5313d724e0495d167083c6f3be0dd2f1c9c8a38db9a9e912cdaf947", size = 138290 },
-    { url = "https://files.pythonhosted.org/packages/36/d6/7eb05c85d987b688707f45dcf83c91abc2251e0dd9fb4f7be96514f838b1/orjson-3.10.18-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:187aefa562300a9d382b4b4eb9694806e5848b0cedf52037bb5c228c61bb66d4", size = 142829 },
-    { url = "https://files.pythonhosted.org/packages/d2/78/ddd3ee7873f2b5f90f016bc04062713d567435c53ecc8783aab3a4d34915/orjson-3.10.18-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9da552683bc9da222379c7a01779bddd0ad39dd699dd6300abaf43eadee38334", size = 132805 },
-    { url = "https://files.pythonhosted.org/packages/8c/09/c8e047f73d2c5d21ead9c180203e111cddeffc0848d5f0f974e346e21c8e/orjson-3.10.18-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e450885f7b47a0231979d9c49b567ed1c4e9f69240804621be87c40bc9d3cf17", size = 135008 },
-    { url = "https://files.pythonhosted.org/packages/0c/4b/dccbf5055ef8fb6eda542ab271955fc1f9bf0b941a058490293f8811122b/orjson-3.10.18-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:5e3c9cc2ba324187cd06287ca24f65528f16dfc80add48dc99fa6c836bb3137e", size = 413419 },
-    { url = "https://files.pythonhosted.org/packages/8a/f3/1eac0c5e2d6d6790bd2025ebfbefcbd37f0d097103d76f9b3f9302af5a17/orjson-3.10.18-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:50ce016233ac4bfd843ac5471e232b865271d7d9d44cf9d33773bcd883ce442b", size = 153292 },
-    { url = "https://files.pythonhosted.org/packages/1f/b4/ef0abf64c8f1fabf98791819ab502c2c8c1dc48b786646533a93637d8999/orjson-3.10.18-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b3ceff74a8f7ffde0b2785ca749fc4e80e4315c0fd887561144059fb1c138aa7", size = 137182 },
-    { url = "https://files.pythonhosted.org/packages/a9/a3/6ea878e7b4a0dc5c888d0370d7752dcb23f402747d10e2257478d69b5e63/orjson-3.10.18-cp311-cp311-win32.whl", hash = "sha256:fdba703c722bd868c04702cac4cb8c6b8ff137af2623bc0ddb3b3e6a2c8996c1", size = 142695 },
-    { url = "https://files.pythonhosted.org/packages/79/2a/4048700a3233d562f0e90d5572a849baa18ae4e5ce4c3ba6247e4ece57b0/orjson-3.10.18-cp311-cp311-win_amd64.whl", hash = "sha256:c28082933c71ff4bc6ccc82a454a2bffcef6e1d7379756ca567c772e4fb3278a", size = 134603 },
-    { url = "https://files.pythonhosted.org/packages/03/45/10d934535a4993d27e1c84f1810e79ccf8b1b7418cef12151a22fe9bb1e1/orjson-3.10.18-cp311-cp311-win_arm64.whl", hash = "sha256:a6c7c391beaedd3fa63206e5c2b7b554196f14debf1ec9deb54b5d279b1b46f5", size = 131400 },
-    { url = "https://files.pythonhosted.org/packages/21/1a/67236da0916c1a192d5f4ccbe10ec495367a726996ceb7614eaa687112f2/orjson-3.10.18-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:50c15557afb7f6d63bc6d6348e0337a880a04eaa9cd7c9d569bcb4e760a24753", size = 249184 },
-    { url = "https://files.pythonhosted.org/packages/b3/bc/c7f1db3b1d094dc0c6c83ed16b161a16c214aaa77f311118a93f647b32dc/orjson-3.10.18-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:356b076f1662c9813d5fa56db7d63ccceef4c271b1fb3dd522aca291375fcf17", size = 133279 },
-    { url = "https://files.pythonhosted.org/packages/af/84/664657cd14cc11f0d81e80e64766c7ba5c9b7fc1ec304117878cc1b4659c/orjson-3.10.18-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:559eb40a70a7494cd5beab2d73657262a74a2c59aff2068fdba8f0424ec5b39d", size = 136799 },
-    { url = "https://files.pythonhosted.org/packages/9a/bb/f50039c5bb05a7ab024ed43ba25d0319e8722a0ac3babb0807e543349978/orjson-3.10.18-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f3c29eb9a81e2fbc6fd7ddcfba3e101ba92eaff455b8d602bf7511088bbc0eae", size = 132791 },
-    { url = "https://files.pythonhosted.org/packages/93/8c/ee74709fc072c3ee219784173ddfe46f699598a1723d9d49cbc78d66df65/orjson-3.10.18-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6612787e5b0756a171c7d81ba245ef63a3533a637c335aa7fcb8e665f4a0966f", size = 137059 },
-    { url = "https://files.pythonhosted.org/packages/6a/37/e6d3109ee004296c80426b5a62b47bcadd96a3deab7443e56507823588c5/orjson-3.10.18-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ac6bd7be0dcab5b702c9d43d25e70eb456dfd2e119d512447468f6405b4a69c", size = 138359 },
-    { url = "https://files.pythonhosted.org/packages/4f/5d/387dafae0e4691857c62bd02839a3bf3fa648eebd26185adfac58d09f207/orjson-3.10.18-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9f72f100cee8dde70100406d5c1abba515a7df926d4ed81e20a9730c062fe9ad", size = 142853 },
-    { url = "https://files.pythonhosted.org/packages/27/6f/875e8e282105350b9a5341c0222a13419758545ae32ad6e0fcf5f64d76aa/orjson-3.10.18-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9dca85398d6d093dd41dc0983cbf54ab8e6afd1c547b6b8a311643917fbf4e0c", size = 133131 },
-    { url = "https://files.pythonhosted.org/packages/48/b2/73a1f0b4790dcb1e5a45f058f4f5dcadc8a85d90137b50d6bbc6afd0ae50/orjson-3.10.18-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:22748de2a07fcc8781a70edb887abf801bb6142e6236123ff93d12d92db3d406", size = 134834 },
-    { url = "https://files.pythonhosted.org/packages/56/f5/7ed133a5525add9c14dbdf17d011dd82206ca6840811d32ac52a35935d19/orjson-3.10.18-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:3a83c9954a4107b9acd10291b7f12a6b29e35e8d43a414799906ea10e75438e6", size = 413368 },
-    { url = "https://files.pythonhosted.org/packages/11/7c/439654221ed9c3324bbac7bdf94cf06a971206b7b62327f11a52544e4982/orjson-3.10.18-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:303565c67a6c7b1f194c94632a4a39918e067bd6176a48bec697393865ce4f06", size = 153359 },
-    { url = "https://files.pythonhosted.org/packages/48/e7/d58074fa0cc9dd29a8fa2a6c8d5deebdfd82c6cfef72b0e4277c4017563a/orjson-3.10.18-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:86314fdb5053a2f5a5d881f03fca0219bfdf832912aa88d18676a5175c6916b5", size = 137466 },
-    { url = "https://files.pythonhosted.org/packages/57/4d/fe17581cf81fb70dfcef44e966aa4003360e4194d15a3f38cbffe873333a/orjson-3.10.18-cp312-cp312-win32.whl", hash = "sha256:187ec33bbec58c76dbd4066340067d9ece6e10067bb0cc074a21ae3300caa84e", size = 142683 },
-    { url = "https://files.pythonhosted.org/packages/e6/22/469f62d25ab5f0f3aee256ea732e72dc3aab6d73bac777bd6277955bceef/orjson-3.10.18-cp312-cp312-win_amd64.whl", hash = "sha256:f9f94cf6d3f9cd720d641f8399e390e7411487e493962213390d1ae45c7814fc", size = 134754 },
-    { url = "https://files.pythonhosted.org/packages/10/b0/1040c447fac5b91bc1e9c004b69ee50abb0c1ffd0d24406e1350c58a7fcb/orjson-3.10.18-cp312-cp312-win_arm64.whl", hash = "sha256:3d600be83fe4514944500fa8c2a0a77099025ec6482e8087d7659e891f23058a", size = 131218 },
-    { url = "https://files.pythonhosted.org/packages/04/f0/8aedb6574b68096f3be8f74c0b56d36fd94bcf47e6c7ed47a7bd1474aaa8/orjson-3.10.18-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:69c34b9441b863175cc6a01f2935de994025e773f814412030f269da4f7be147", size = 249087 },
-    { url = "https://files.pythonhosted.org/packages/bc/f7/7118f965541aeac6844fcb18d6988e111ac0d349c9b80cda53583e758908/orjson-3.10.18-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:1ebeda919725f9dbdb269f59bc94f861afbe2a27dce5608cdba2d92772364d1c", size = 133273 },
-    { url = "https://files.pythonhosted.org/packages/fb/d9/839637cc06eaf528dd8127b36004247bf56e064501f68df9ee6fd56a88ee/orjson-3.10.18-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5adf5f4eed520a4959d29ea80192fa626ab9a20b2ea13f8f6dc58644f6927103", size = 136779 },
-    { url = "https://files.pythonhosted.org/packages/2b/6d/f226ecfef31a1f0e7d6bf9a31a0bbaf384c7cbe3fce49cc9c2acc51f902a/orjson-3.10.18-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7592bb48a214e18cd670974f289520f12b7aed1fa0b2e2616b8ed9e069e08595", size = 132811 },
-    { url = "https://files.pythonhosted.org/packages/73/2d/371513d04143c85b681cf8f3bce743656eb5b640cb1f461dad750ac4b4d4/orjson-3.10.18-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f872bef9f042734110642b7a11937440797ace8c87527de25e0c53558b579ccc", size = 137018 },
-    { url = "https://files.pythonhosted.org/packages/69/cb/a4d37a30507b7a59bdc484e4a3253c8141bf756d4e13fcc1da760a0b00cb/orjson-3.10.18-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0315317601149c244cb3ecef246ef5861a64824ccbcb8018d32c66a60a84ffbc", size = 138368 },
-    { url = "https://files.pythonhosted.org/packages/1e/ae/cd10883c48d912d216d541eb3db8b2433415fde67f620afe6f311f5cd2ca/orjson-3.10.18-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e0da26957e77e9e55a6c2ce2e7182a36a6f6b180ab7189315cb0995ec362e049", size = 142840 },
-    { url = "https://files.pythonhosted.org/packages/6d/4c/2bda09855c6b5f2c055034c9eda1529967b042ff8d81a05005115c4e6772/orjson-3.10.18-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb70d489bc79b7519e5803e2cc4c72343c9dc1154258adf2f8925d0b60da7c58", size = 133135 },
-    { url = "https://files.pythonhosted.org/packages/13/4a/35971fd809a8896731930a80dfff0b8ff48eeb5d8b57bb4d0d525160017f/orjson-3.10.18-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e9e86a6af31b92299b00736c89caf63816f70a4001e750bda179e15564d7a034", size = 134810 },
-    { url = "https://files.pythonhosted.org/packages/99/70/0fa9e6310cda98365629182486ff37a1c6578e34c33992df271a476ea1cd/orjson-3.10.18-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:c382a5c0b5931a5fc5405053d36c1ce3fd561694738626c77ae0b1dfc0242ca1", size = 413491 },
-    { url = "https://files.pythonhosted.org/packages/32/cb/990a0e88498babddb74fb97855ae4fbd22a82960e9b06eab5775cac435da/orjson-3.10.18-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8e4b2ae732431127171b875cb2668f883e1234711d3c147ffd69fe5be51a8012", size = 153277 },
-    { url = "https://files.pythonhosted.org/packages/92/44/473248c3305bf782a384ed50dd8bc2d3cde1543d107138fd99b707480ca1/orjson-3.10.18-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d808e34ddb24fc29a4d4041dcfafbae13e129c93509b847b14432717d94b44f", size = 137367 },
-    { url = "https://files.pythonhosted.org/packages/ad/fd/7f1d3edd4ffcd944a6a40e9f88af2197b619c931ac4d3cfba4798d4d3815/orjson-3.10.18-cp313-cp313-win32.whl", hash = "sha256:ad8eacbb5d904d5591f27dee4031e2c1db43d559edb8f91778efd642d70e6bea", size = 142687 },
-    { url = "https://files.pythonhosted.org/packages/4b/03/c75c6ad46be41c16f4cfe0352a2d1450546f3c09ad2c9d341110cd87b025/orjson-3.10.18-cp313-cp313-win_amd64.whl", hash = "sha256:aed411bcb68bf62e85588f2a7e03a6082cc42e5a2796e06e72a962d7c6310b52", size = 134794 },
-    { url = "https://files.pythonhosted.org/packages/c2/28/f53038a5a72cc4fd0b56c1eafb4ef64aec9685460d5ac34de98ca78b6e29/orjson-3.10.18-cp313-cp313-win_arm64.whl", hash = "sha256:f54c1385a0e6aba2f15a40d703b858bedad36ded0491e55d35d905b2c34a4cc3", size = 131186 },
+    { url = "https://files.pythonhosted.org/packages/37/02/da6cb01fc6087048d7f61522c327edf4250f1683a58a839fdcc435746dd5/orjson-3.11.7-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9487abc2c2086e7c8eb9a211d2ce8855bae0e92586279d0d27b341d5ad76c85c", size = 228664 },
+    { url = "https://files.pythonhosted.org/packages/c1/c2/5885e7a5881dba9a9af51bc564e8967225a642b3e03d089289a35054e749/orjson-3.11.7-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:79cacb0b52f6004caf92405a7e1f11e6e2de8bdf9019e4f76b44ba045125cd6b", size = 125344 },
+    { url = "https://files.pythonhosted.org/packages/a4/1d/4e7688de0a92d1caf600dfd5fb70b4c5bfff51dfa61ac555072ef2d0d32a/orjson-3.11.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2e85fe4698b6a56d5e2ebf7ae87544d668eb6bde1ad1226c13f44663f20ec9e", size = 128404 },
+    { url = "https://files.pythonhosted.org/packages/2f/b2/ec04b74ae03a125db7bd69cffd014b227b7f341e3261bf75b5eb88a1aa92/orjson-3.11.7-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b8d14b71c0b12963fe8a62aac87119f1afdf4cb88a400f61ca5ae581449efcb5", size = 123677 },
+    { url = "https://files.pythonhosted.org/packages/4c/69/f95bdf960605f08f827f6e3291fe243d8aa9c5c9ff017a8d7232209184c3/orjson-3.11.7-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91c81ef070c8f3220054115e1ef468b1c9ce8497b4e526cb9f68ab4dc0a7ac62", size = 128950 },
+    { url = "https://files.pythonhosted.org/packages/a4/1b/de59c57bae1d148ef298852abd31909ac3089cff370dfd4cd84cc99cbc42/orjson-3.11.7-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:411ebaf34d735e25e358a6d9e7978954a9c9d58cfb47bc6683cdc3964cd2f910", size = 141756 },
+    { url = "https://files.pythonhosted.org/packages/ee/9e/9decc59f4499f695f65c650f6cfa6cd4c37a3fbe8fa235a0a3614cb54386/orjson-3.11.7-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a16bcd08ab0bcdfc7e8801d9c4a9cc17e58418e4d48ddc6ded4e9e4b1a94062b", size = 130812 },
+    { url = "https://files.pythonhosted.org/packages/28/e6/59f932bcabd1eac44e334fe8e3281a92eacfcb450586e1f4bde0423728d8/orjson-3.11.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c0b51672e466fd7e56230ffbae7f1639e18d0ce023351fb75da21b71bc2c960", size = 133444 },
+    { url = "https://files.pythonhosted.org/packages/f1/36/b0f05c0eaa7ca30bc965e37e6a2956b0d67adb87a9872942d3568da846ae/orjson-3.11.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:136dcd6a2e796dfd9ffca9fc027d778567b0b7c9968d092842d3c323cef88aa8", size = 138609 },
+    { url = "https://files.pythonhosted.org/packages/b8/03/58ec7d302b8d86944c60c7b4b82975d5161fcce4c9bc8c6cb1d6741b6115/orjson-3.11.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:7ba61079379b0ae29e117db13bda5f28d939766e410d321ec1624afc6a0b0504", size = 408918 },
+    { url = "https://files.pythonhosted.org/packages/06/3a/868d65ef9a8b99be723bd510de491349618abd9f62c826cf206d962db295/orjson-3.11.7-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0527a4510c300e3b406591b0ba69b5dc50031895b0a93743526a3fc45f59d26e", size = 143998 },
+    { url = "https://files.pythonhosted.org/packages/5b/c7/1e18e1c83afe3349f4f6dc9e14910f0ae5f82eac756d1412ea4018938535/orjson-3.11.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a709e881723c9b18acddcfb8ba357322491ad553e277cf467e1e7e20e2d90561", size = 134802 },
+    { url = "https://files.pythonhosted.org/packages/d4/0b/ccb7ee1a65b37e8eeb8b267dc953561d72370e85185e459616d4345bab34/orjson-3.11.7-cp311-cp311-win32.whl", hash = "sha256:c43b8b5bab288b6b90dac410cca7e986a4fa747a2e8f94615aea407da706980d", size = 127828 },
+    { url = "https://files.pythonhosted.org/packages/af/9e/55c776dffda3f381e0f07d010a4f5f3902bf48eaba1bb7684d301acd4924/orjson-3.11.7-cp311-cp311-win_amd64.whl", hash = "sha256:6543001328aa857187f905308a028935864aefe9968af3848401b6fe80dbb471", size = 124941 },
+    { url = "https://files.pythonhosted.org/packages/aa/8e/424a620fa7d263b880162505fb107ef5e0afaa765b5b06a88312ac291560/orjson-3.11.7-cp311-cp311-win_arm64.whl", hash = "sha256:1ee5cc7160a821dfe14f130bc8e63e7611051f964b463d9e2a3a573204446a4d", size = 126245 },
+    { url = "https://files.pythonhosted.org/packages/80/bf/76f4f1665f6983385938f0e2a5d7efa12a58171b8456c252f3bae8a4cf75/orjson-3.11.7-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:bd03ea7606833655048dab1a00734a2875e3e86c276e1d772b2a02556f0d895f", size = 228545 },
+    { url = "https://files.pythonhosted.org/packages/79/53/6c72c002cb13b5a978a068add59b25a8bdf2800ac1c9c8ecdb26d6d97064/orjson-3.11.7-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:89e440ebc74ce8ab5c7bc4ce6757b4a6b1041becb127df818f6997b5c71aa60b", size = 125224 },
+    { url = "https://files.pythonhosted.org/packages/2c/83/10e48852865e5dd151bdfe652c06f7da484578ed02c5fca938e3632cb0b8/orjson-3.11.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ede977b5fe5ac91b1dffc0a517ca4542d2ec8a6a4ff7b2652d94f640796342a", size = 128154 },
+    { url = "https://files.pythonhosted.org/packages/6e/52/a66e22a2b9abaa374b4a081d410edab6d1e30024707b87eab7c734afe28d/orjson-3.11.7-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b7b1dae39230a393df353827c855a5f176271c23434cfd2db74e0e424e693e10", size = 123548 },
+    { url = "https://files.pythonhosted.org/packages/de/38/605d371417021359f4910c496f764c48ceb8997605f8c25bf1dfe58c0ebe/orjson-3.11.7-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed46f17096e28fb28d2975834836a639af7278aa87c84f68ab08fbe5b8bd75fa", size = 129000 },
+    { url = "https://files.pythonhosted.org/packages/44/98/af32e842b0ffd2335c89714d48ca4e3917b42f5d6ee5537832e069a4b3ac/orjson-3.11.7-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3726be79e36e526e3d9c1aceaadbfb4a04ee80a72ab47b3f3c17fefb9812e7b8", size = 141686 },
+    { url = "https://files.pythonhosted.org/packages/96/0b/fc793858dfa54be6feee940c1463370ece34b3c39c1ca0aa3845f5ba9892/orjson-3.11.7-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0724e265bc548af1dedebd9cb3d24b4e1c1e685a343be43e87ba922a5c5fff2f", size = 130812 },
+    { url = "https://files.pythonhosted.org/packages/dc/91/98a52415059db3f374757d0b7f0f16e3b5cd5976c90d1c2b56acaea039e6/orjson-3.11.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7745312efa9e11c17fbd3cb3097262d079da26930ae9ae7ba28fb738367cbad", size = 133440 },
+    { url = "https://files.pythonhosted.org/packages/dc/b6/cb540117bda61791f46381f8c26c8f93e802892830a6055748d3bb1925ab/orjson-3.11.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f904c24bdeabd4298f7a977ef14ca2a022ca921ed670b92ecd16ab6f3d01f867", size = 138386 },
+    { url = "https://files.pythonhosted.org/packages/63/1a/50a3201c334a7f17c231eee5f841342190723794e3b06293f26e7cf87d31/orjson-3.11.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b9fc4d0f81f394689e0814617aadc4f2ea0e8025f38c226cbf22d3b5ddbf025d", size = 408853 },
+    { url = "https://files.pythonhosted.org/packages/87/cd/8de1c67d0be44fdc22701e5989c0d015a2adf391498ad42c4dc589cd3013/orjson-3.11.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:849e38203e5be40b776ed2718e587faf204d184fc9a008ae441f9442320c0cab", size = 144130 },
+    { url = "https://files.pythonhosted.org/packages/0f/fe/d605d700c35dd55f51710d159fc54516a280923cd1b7e47508982fbb387d/orjson-3.11.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4682d1db3bcebd2b64757e0ddf9e87ae5f00d29d16c5cdf3a62f561d08cc3dd2", size = 134818 },
+    { url = "https://files.pythonhosted.org/packages/e4/e4/15ecc67edb3ddb3e2f46ae04475f2d294e8b60c1825fbe28a428b93b3fbd/orjson-3.11.7-cp312-cp312-win32.whl", hash = "sha256:f4f7c956b5215d949a1f65334cf9d7612dde38f20a95f2315deef167def91a6f", size = 127923 },
+    { url = "https://files.pythonhosted.org/packages/34/70/2e0855361f76198a3965273048c8e50a9695d88cd75811a5b46444895845/orjson-3.11.7-cp312-cp312-win_amd64.whl", hash = "sha256:bf742e149121dc5648ba0a08ea0871e87b660467ef168a3a5e53bc1fbd64bb74", size = 125007 },
+    { url = "https://files.pythonhosted.org/packages/68/40/c2051bd19fc467610fed469dc29e43ac65891571138f476834ca192bc290/orjson-3.11.7-cp312-cp312-win_arm64.whl", hash = "sha256:26c3b9132f783b7d7903bf1efb095fed8d4a3a85ec0d334ee8beff3d7a4749d5", size = 126089 },
+    { url = "https://files.pythonhosted.org/packages/89/25/6e0e52cac5aab51d7b6dcd257e855e1dec1c2060f6b28566c509b4665f62/orjson-3.11.7-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:1d98b30cc1313d52d4af17d9c3d307b08389752ec5f2e5febdfada70b0f8c733", size = 228390 },
+    { url = "https://files.pythonhosted.org/packages/a5/29/a77f48d2fc8a05bbc529e5ff481fb43d914f9e383ea2469d4f3d51df3d00/orjson-3.11.7-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:d897e81f8d0cbd2abb82226d1860ad2e1ab3ff16d7b08c96ca00df9d45409ef4", size = 125189 },
+    { url = "https://files.pythonhosted.org/packages/89/25/0a16e0729a0e6a1504f9d1a13cdd365f030068aab64cec6958396b9969d7/orjson-3.11.7-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:814be4b49b228cfc0b3c565acf642dd7d13538f966e3ccde61f4f55be3e20785", size = 128106 },
+    { url = "https://files.pythonhosted.org/packages/66/da/a2e505469d60666a05ab373f1a6322eb671cb2ba3a0ccfc7d4bc97196787/orjson-3.11.7-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d06e5c5fed5caedd2e540d62e5b1c25e8c82431b9e577c33537e5fa4aa909539", size = 123363 },
+    { url = "https://files.pythonhosted.org/packages/23/bf/ed73f88396ea35c71b38961734ea4a4746f7ca0768bf28fd551d37e48dd0/orjson-3.11.7-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:31c80ce534ac4ea3739c5ee751270646cbc46e45aea7576a38ffec040b4029a1", size = 129007 },
+    { url = "https://files.pythonhosted.org/packages/73/3c/b05d80716f0225fc9008fbf8ab22841dcc268a626aa550561743714ce3bf/orjson-3.11.7-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f50979824bde13d32b4320eedd513431c921102796d86be3eee0b58e58a3ecd1", size = 141667 },
+    { url = "https://files.pythonhosted.org/packages/61/e8/0be9b0addd9bf86abfc938e97441dcd0375d494594b1c8ad10fe57479617/orjson-3.11.7-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e54f3808e2b6b945078c41aa8d9b5834b28c50843846e97807e5adb75fa9705", size = 130832 },
+    { url = "https://files.pythonhosted.org/packages/c9/ec/c68e3b9021a31d9ec15a94931db1410136af862955854ed5dd7e7e4f5bff/orjson-3.11.7-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a12b80df61aab7b98b490fe9e4879925ba666fccdfcd175252ce4d9035865ace", size = 133373 },
+    { url = "https://files.pythonhosted.org/packages/d2/45/f3466739aaafa570cc8e77c6dbb853c48bf56e3b43738020e2661e08b0ac/orjson-3.11.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:996b65230271f1a97026fd0e6a753f51fbc0c335d2ad0c6201f711b0da32693b", size = 138307 },
+    { url = "https://files.pythonhosted.org/packages/e1/84/9f7f02288da1ffb31405c1be07657afd1eecbcb4b64ee2817b6fe0f785fa/orjson-3.11.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:ab49d4b2a6a1d415ddb9f37a21e02e0d5dbfe10b7870b21bf779fc21e9156157", size = 408695 },
+    { url = "https://files.pythonhosted.org/packages/18/07/9dd2f0c0104f1a0295ffbe912bc8d63307a539b900dd9e2c48ef7810d971/orjson-3.11.7-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:390a1dce0c055ddf8adb6aa94a73b45a4a7d7177b5c584b8d1c1947f2ba60fb3", size = 144099 },
+    { url = "https://files.pythonhosted.org/packages/a5/66/857a8e4a3292e1f7b1b202883bcdeb43a91566cf59a93f97c53b44bd6801/orjson-3.11.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1eb80451a9c351a71dfaf5b7ccc13ad065405217726b59fdbeadbcc544f9d223", size = 134806 },
+    { url = "https://files.pythonhosted.org/packages/0a/5b/6ebcf3defc1aab3a338ca777214966851e92efb1f30dc7fc8285216e6d1b/orjson-3.11.7-cp313-cp313-win32.whl", hash = "sha256:7477aa6a6ec6139c5cb1cc7b214643592169a5494d200397c7fc95d740d5fcf3", size = 127914 },
+    { url = "https://files.pythonhosted.org/packages/00/04/c6f72daca5092e3117840a1b1e88dfc809cc1470cf0734890d0366b684a1/orjson-3.11.7-cp313-cp313-win_amd64.whl", hash = "sha256:b9f95dcdea9d4f805daa9ddf02617a89e484c6985fa03055459f90e87d7a0757", size = 124986 },
+    { url = "https://files.pythonhosted.org/packages/03/ba/077a0f6f1085d6b806937246860fafbd5b17f3919c70ee3f3d8d9c713f38/orjson-3.11.7-cp313-cp313-win_arm64.whl", hash = "sha256:800988273a014a0541483dc81021247d7eacb0c845a9d1a34a422bc718f41539", size = 126045 },
+    { url = "https://files.pythonhosted.org/packages/e9/1e/745565dca749813db9a093c5ebc4bac1a9475c64d54b95654336ac3ed961/orjson-3.11.7-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:de0a37f21d0d364954ad5de1970491d7fbd0fb1ef7417d4d56a36dc01ba0c0a0", size = 228391 },
+    { url = "https://files.pythonhosted.org/packages/46/19/e40f6225da4d3aa0c8dc6e5219c5e87c2063a560fe0d72a88deb59776794/orjson-3.11.7-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:c2428d358d85e8da9d37cba18b8c4047c55222007a84f97156a5b22028dfbfc0", size = 125188 },
+    { url = "https://files.pythonhosted.org/packages/9d/7e/c4de2babef2c0817fd1f048fd176aa48c37bec8aef53d2fa932983032cce/orjson-3.11.7-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c4bc6c6ac52cdaa267552544c73e486fecbd710b7ac09bc024d5a78555a22f6", size = 128097 },
+    { url = "https://files.pythonhosted.org/packages/eb/74/233d360632bafd2197f217eee7fb9c9d0229eac0c18128aee5b35b0014fe/orjson-3.11.7-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd0d68edd7dfca1b2eca9361a44ac9f24b078de3481003159929a0573f21a6bf", size = 123364 },
+    { url = "https://files.pythonhosted.org/packages/79/51/af79504981dd31efe20a9e360eb49c15f06df2b40e7f25a0a52d9ae888e8/orjson-3.11.7-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:623ad1b9548ef63886319c16fa317848e465a21513b31a6ad7b57443c3e0dcf5", size = 129076 },
+    { url = "https://files.pythonhosted.org/packages/67/e2/da898eb68b72304f8de05ca6715870d09d603ee98d30a27e8a9629abc64b/orjson-3.11.7-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6e776b998ac37c0396093d10290e60283f59cfe0fc3fccbd0ccc4bd04dd19892", size = 141705 },
+    { url = "https://files.pythonhosted.org/packages/c5/89/15364d92acb3d903b029e28d834edb8780c2b97404cbf7929aa6b9abdb24/orjson-3.11.7-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:652c6c3af76716f4a9c290371ba2e390ede06f6603edb277b481daf37f6f464e", size = 130855 },
+    { url = "https://files.pythonhosted.org/packages/c2/8b/ecdad52d0b38d4b8f514be603e69ccd5eacf4e7241f972e37e79792212ec/orjson-3.11.7-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a56df3239294ea5964adf074c54bcc4f0ccd21636049a2cf3ca9cf03b5d03cf1", size = 133386 },
+    { url = "https://files.pythonhosted.org/packages/b9/0e/45e1dcf10e17d0924b7c9162f87ec7b4ca79e28a0548acf6a71788d3e108/orjson-3.11.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bda117c4148e81f746655d5a3239ae9bd00cb7bc3ca178b5fc5a5997e9744183", size = 138295 },
+    { url = "https://files.pythonhosted.org/packages/63/d7/4d2e8b03561257af0450f2845b91fbd111d7e526ccdf737267108075e0ba/orjson-3.11.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:23d6c20517a97a9daf1d48b580fcdc6f0516c6f4b5038823426033690b4d2650", size = 408720 },
+    { url = "https://files.pythonhosted.org/packages/78/cf/d45343518282108b29c12a65892445fc51f9319dc3c552ceb51bb5905ed2/orjson-3.11.7-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:8ff206156006da5b847c9304b6308a01e8cdbc8cce824e2779a5ba71c3def141", size = 144152 },
+    { url = "https://files.pythonhosted.org/packages/a9/3a/d6001f51a7275aacd342e77b735c71fa04125a3f93c36fee4526bc8c654e/orjson-3.11.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:962d046ee1765f74a1da723f4b33e3b228fe3a48bd307acce5021dfefe0e29b2", size = 134814 },
+    { url = "https://files.pythonhosted.org/packages/1d/d3/f19b47ce16820cc2c480f7f1723e17f6d411b3a295c60c8ad3aa9ff1c96a/orjson-3.11.7-cp314-cp314-win32.whl", hash = "sha256:89e13dd3f89f1c38a9c9eba5fbf7cdc2d1feca82f5f290864b4b7a6aac704576", size = 127997 },
+    { url = "https://files.pythonhosted.org/packages/12/df/172771902943af54bf661a8d102bdf2e7f932127968080632bda6054b62c/orjson-3.11.7-cp314-cp314-win_amd64.whl", hash = "sha256:845c3e0d8ded9c9271cd79596b9b552448b885b97110f628fb687aee2eed11c1", size = 124985 },
+    { url = "https://files.pythonhosted.org/packages/6f/1c/f2a8d8a1b17514660a614ce5f7aac74b934e69f5abc2700cc7ced882a009/orjson-3.11.7-cp314-cp314-win_arm64.whl", hash = "sha256:4a2e9c5be347b937a2e0203866f12bba36082e89b402ddb9e927d5822e43088d", size = 126038 },
 ]
 
 [[package]]
@@ -3543,32 +3516,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/4c/b0fe775a2bdd01e176b14b574be679d84fc83958335790f7c9a686c1f468/propcache-0.3.2-cp313-cp313t-win32.whl", hash = "sha256:f86e5d7cd03afb3a1db8e9f9f6eff15794e79e791350ac48a8c924e6f439f394", size = 41175 },
     { url = "https://files.pythonhosted.org/packages/a4/ff/47f08595e3d9b5e149c150f88d9714574f1a7cbd89fe2817158a952674bf/propcache-0.3.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9704bedf6e7cbe3c65eca4379a9b53ee6a83749f047808cbb5044d40d7d72198", size = 44857 },
     { url = "https://files.pythonhosted.org/packages/cc/35/cc0aaecf278bb4575b8555f2b137de5ab821595ddae9da9d3cd1da4072c7/propcache-0.3.2-py3-none-any.whl", hash = "sha256:98f1ec44fb675f5052cccc8e609c46ed23a35a1cfd18545ad4e29002d858a43f", size = 12663 },
-]
-
-[[package]]
-name = "proto-plus"
-version = "1.26.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/ac/87285f15f7cce6d4a008f33f1757fb5a13611ea8914eb58c3d0d26243468/proto_plus-1.26.1.tar.gz", hash = "sha256:21a515a4c4c0088a773899e23c7bbade3d18f9c66c73edd4c7ee3816bc96a012", size = 56142 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/6d/280c4c2ce28b1593a19ad5239c8b826871fc6ec275c21afc8e1820108039/proto_plus-1.26.1-py3-none-any.whl", hash = "sha256:13285478c2dcf2abb829db158e1047e2f1e8d63a077d94263c2b88b043c75a66", size = 50163 },
-]
-
-[[package]]
-name = "protobuf"
-version = "5.29.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/29/d09e70352e4e88c9c7a198d5645d7277811448d76c23b00345670f7c8a38/protobuf-5.29.5.tar.gz", hash = "sha256:bc1463bafd4b0929216c35f437a8e28731a2b7fe3d98bb77a600efced5a15c84", size = 425226 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/11/6e40e9fc5bba02988a214c07cf324595789ca7820160bfd1f8be96e48539/protobuf-5.29.5-cp310-abi3-win32.whl", hash = "sha256:3f1c6468a2cfd102ff4703976138844f78ebd1fb45f49011afc5139e9e283079", size = 422963 },
-    { url = "https://files.pythonhosted.org/packages/81/7f/73cefb093e1a2a7c3ffd839e6f9fcafb7a427d300c7f8aef9c64405d8ac6/protobuf-5.29.5-cp310-abi3-win_amd64.whl", hash = "sha256:3f76e3a3675b4a4d867b52e4a5f5b78a2ef9565549d4037e06cf7b0942b1d3fc", size = 434818 },
-    { url = "https://files.pythonhosted.org/packages/dd/73/10e1661c21f139f2c6ad9b23040ff36fee624310dc28fba20d33fdae124c/protobuf-5.29.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:e38c5add5a311f2a6eb0340716ef9b039c1dfa428b28f25a7838ac329204a671", size = 418091 },
-    { url = "https://files.pythonhosted.org/packages/6c/04/98f6f8cf5b07ab1294c13f34b4e69b3722bb609c5b701d6c169828f9f8aa/protobuf-5.29.5-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:fa18533a299d7ab6c55a238bf8629311439995f2e7eca5caaff08663606e9015", size = 319824 },
-    { url = "https://files.pythonhosted.org/packages/85/e4/07c80521879c2d15f321465ac24c70efe2381378c00bf5e56a0f4fbac8cd/protobuf-5.29.5-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:63848923da3325e1bf7e9003d680ce6e14b07e55d0473253a690c3a8b8fd6e61", size = 319942 },
-    { url = "https://files.pythonhosted.org/packages/7e/cc/7e77861000a0691aeea8f4566e5d3aa716f2b1dece4a24439437e41d3d25/protobuf-5.29.5-py3-none-any.whl", hash = "sha256:6cf42630262c59b2d8de33954443d94b746c952b01434fc58a417fdbd2e84bd5", size = 172823 },
 ]
 
 [[package]]
@@ -4355,18 +4302,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696 },
-]
-
-[[package]]
 name = "ruff"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5095,6 +5030,35 @@ wheels = [
 ]
 
 [[package]]
+name = "uuid-utils"
+version = "0.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/d1/38a573f0c631c062cf42fa1f5d021d4dd3c31fb23e4376e4b56b0c9fbbed/uuid_utils-0.14.1.tar.gz", hash = "sha256:9bfc95f64af80ccf129c604fb6b8ca66c6f256451e32bc4570f760e4309c9b69", size = 22195 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/b7/add4363039a34506a58457d96d4aa2126061df3a143eb4d042aedd6a2e76/uuid_utils-0.14.1-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:93a3b5dc798a54a1feb693f2d1cb4cf08258c32ff05ae4929b5f0a2ca624a4f0", size = 604679 },
+    { url = "https://files.pythonhosted.org/packages/dd/84/d1d0bef50d9e66d31b2019997c741b42274d53dde2e001b7a83e9511c339/uuid_utils-0.14.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ccd65a4b8e83af23eae5e56d88034b2fe7264f465d3e830845f10d1591b81741", size = 309346 },
+    { url = "https://files.pythonhosted.org/packages/ef/ed/b6d6fd52a6636d7c3eddf97d68da50910bf17cd5ac221992506fb56cf12e/uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b56b0cacd81583834820588378e432b0696186683b813058b707aedc1e16c4b1", size = 344714 },
+    { url = "https://files.pythonhosted.org/packages/a8/a7/a19a1719fb626fe0b31882db36056d44fe904dc0cf15b06fdf56b2679cf7/uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bb3cf14de789097320a3c56bfdfdd51b1225d11d67298afbedee7e84e3837c96", size = 350914 },
+    { url = "https://files.pythonhosted.org/packages/1d/fc/f6690e667fdc3bb1a73f57951f97497771c56fe23e3d302d7404be394d4f/uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e0854a90d67f4b0cc6e54773deb8be618f4c9bad98d3326f081423b5d14fae", size = 482609 },
+    { url = "https://files.pythonhosted.org/packages/54/6e/dcd3fa031320921a12ec7b4672dea3bd1dd90ddffa363a91831ba834d559/uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce6743ba194de3910b5feb1a62590cd2587e33a73ab6af8a01b642ceb5055862", size = 345699 },
+    { url = "https://files.pythonhosted.org/packages/04/28/e5220204b58b44ac0047226a9d016a113fde039280cc8732d9e6da43b39f/uuid_utils-0.14.1-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:043fb58fde6cf1620a6c066382f04f87a8e74feb0f95a585e4ed46f5d44af57b", size = 372205 },
+    { url = "https://files.pythonhosted.org/packages/c7/d9/3d2eb98af94b8dfffc82b6a33b4dfc87b0a5de2c68a28f6dde0db1f8681b/uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c915d53f22945e55fe0d3d3b0b87fd965a57f5fd15666fd92d6593a73b1dd297", size = 521836 },
+    { url = "https://files.pythonhosted.org/packages/a8/15/0eb106cc6fe182f7577bc0ab6e2f0a40be247f35c5e297dbf7bbc460bd02/uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:0972488e3f9b449e83f006ead5a0e0a33ad4a13e4462e865b7c286ab7d7566a3", size = 625260 },
+    { url = "https://files.pythonhosted.org/packages/3c/17/f539507091334b109e7496830af2f093d9fc8082411eafd3ece58af1f8ba/uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:1c238812ae0c8ffe77d8d447a32c6dfd058ea4631246b08b5a71df586ff08531", size = 587824 },
+    { url = "https://files.pythonhosted.org/packages/2e/c2/d37a7b2e41f153519367d4db01f0526e0d4b06f1a4a87f1c5dfca5d70a8b/uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:bec8f8ef627af86abf8298e7ec50926627e29b34fa907fcfbedb45aaa72bca43", size = 551407 },
+    { url = "https://files.pythonhosted.org/packages/65/36/2d24b2cbe78547c6532da33fb8613debd3126eccc33a6374ab788f5e46e9/uuid_utils-0.14.1-cp39-abi3-win32.whl", hash = "sha256:b54d6aa6252d96bac1fdbc80d26ba71bad9f220b2724d692ad2f2310c22ef523", size = 183476 },
+    { url = "https://files.pythonhosted.org/packages/83/92/2d7e90df8b1a69ec4cff33243ce02b7a62f926ef9e2f0eca5a026889cd73/uuid_utils-0.14.1-cp39-abi3-win_amd64.whl", hash = "sha256:fc27638c2ce267a0ce3e06828aff786f91367f093c80625ee21dad0208e0f5ba", size = 187147 },
+    { url = "https://files.pythonhosted.org/packages/d9/26/529f4beee17e5248e37e0bc17a2761d34c0fa3b1e5729c88adb2065bae6e/uuid_utils-0.14.1-cp39-abi3-win_arm64.whl", hash = "sha256:b04cb49b42afbc4ff8dbc60cf054930afc479d6f4dd7f1ec3bbe5dbfdde06b7a", size = 188132 },
+    { url = "https://files.pythonhosted.org/packages/91/f9/6c64bdbf71f58ccde7919e00491812556f446a5291573af92c49a5e9aaef/uuid_utils-0.14.1-pp311-pypy311_pp73-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b197cd5424cf89fb019ca7f53641d05bfe34b1879614bed111c9c313b5574cd8", size = 591617 },
+    { url = "https://files.pythonhosted.org/packages/d0/f0/758c3b0fb0c4871c7704fef26a5bc861de4f8a68e4831669883bebe07b0f/uuid_utils-0.14.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:12c65020ba6cb6abe1d57fcbfc2d0ea0506c67049ee031714057f5caf0f9bc9c", size = 303702 },
+    { url = "https://files.pythonhosted.org/packages/85/89/d91862b544c695cd58855efe3201f83894ed82fffe34500774238ab8eba7/uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b5d2ad28063d422ccc2c28d46471d47b61a58de885d35113a8f18cb547e25bf", size = 337678 },
+    { url = "https://files.pythonhosted.org/packages/ee/6b/cf342ba8a898f1de024be0243fac67c025cad530c79ea7f89c4ce718891a/uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:da2234387b45fde40b0fedfee64a0ba591caeea9c48c7698ab6e2d85c7991533", size = 343711 },
+    { url = "https://files.pythonhosted.org/packages/b3/20/049418d094d396dfa6606b30af925cc68a6670c3b9103b23e6990f84b589/uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50fffc2827348c1e48972eed3d1c698959e63f9d030aa5dd82ba451113158a62", size = 476731 },
+    { url = "https://files.pythonhosted.org/packages/77/a1/0857f64d53a90321e6a46a3d4cc394f50e1366132dcd2ae147f9326ca98b/uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dbe718765f70f5b7f9b7f66b6a937802941b1cc56bcf642ce0274169741e01", size = 338902 },
+    { url = "https://files.pythonhosted.org/packages/ed/d0/5bf7cbf1ac138c92b9ac21066d18faf4d7e7f651047b700eb192ca4b9fdb/uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:258186964039a8e36db10810c1ece879d229b01331e09e9030bc5dcabe231bd2", size = 364700 },
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5158,6 +5122,18 @@ wheels = [
 ]
 
 [[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854 },
+]
+
+[[package]]
 name = "wcwidth"
 version = "0.2.14"
 source = { registry = "https://pypi.org/simple" }
@@ -5191,6 +5167,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616 },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340 },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022 },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319 },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631 },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870 },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361 },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615 },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246 },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684 },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365 },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038 },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328 },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915 },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152 },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583 },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880 },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261 },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693 },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364 },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039 },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323 },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975 },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203 },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653 },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920 },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255 },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689 },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406 },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085 },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328 },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044 },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279 },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711 },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982 },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915 },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381 },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737 },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268 },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486 },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331 },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501 },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062 },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356 },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085 },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531 },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947 },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260 },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071 },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968 },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735 },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598 },
 ]
 
 [[package]]

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -23,3 +23,12 @@ def _whitelist_schema(schema):
 
 # create_verbose_logger parameters kept for API backwards compatibility
 # These are consumed via _ = param pattern to avoid vulture warnings
+
+
+# Pytest fixtures used as side-effect-only parameters in conformance tests.
+# The fixture sets up mocks before arun() is called; the parameter name in the
+# test method signature is required by pytest to inject it, but the test body
+# does not reference it directly.
+def _whitelist_conformance_fixtures(mock_deep_agents_agent_result):
+    """Whitelist for conformance test fixture parameters (test_agent_port.py)."""
+    _ = mock_deep_agents_agent_result


### PR DESCRIPTION
## Summary

Adds a new `langchain_deep_agents` adapter that integrates Deep Agents (LangChain's natively agentic framework with built-in planning, context management, and subagent orchestration) into the karenina verification pipeline. Also introduces a reusable adapter conformance test suite.

### Adapter (`src/karenina/adapters/langchain_deep_agents/`)

- **AgentPort** (`agent.py`): Wraps `create_deep_agent()` for agent loops via LangGraph's compiled graph API. Handles message conversion to prompt strings, system prompt extraction, recursion limit detection (via `is_last_step` state and `GraphRecursionError`), dual trace output (raw string + structured `Message` list), and sync/async execution with `anyio` portal support.
- **LLMPort** (`llm.py`): Single-turn LLM calls via `init_chat_model` directly (no agent loop overhead). Supports structured output via `with_structured_output()`.
- **ParserPort** (`parser.py`): Structured data extraction using `with_structured_output(include_raw=True)` for token tracking. Falls back to JSON-from-text extraction when structured output fails.
- **MessageConverter** (`messages.py`): Bidirectional conversion between karenina's unified `Message` and LangGraph `BaseMessage` types. System messages are extracted separately (Deep Agents takes `system_prompt` as a parameter, not as a message).
- **MCP support** (`mcp.py`): Converts karenina's `MCPServerConfig` to `langchain-mcp-adapters` `MultiServerMCPClient` parameters, handling stdio and HTTP/SSE transports.
- **Trace extraction** (`trace.py`): Converts LangGraph message lists to karenina's delimited raw trace format (`--- AI Message ---`, `--- Tool Call ---`, `--- Tool Result ---`).
- **Usage tracking** (`usage.py`): Aggregates token counts across all `AIMessage` instances from `usage_metadata` or `response_metadata.token_usage`. Extracts actual model name from response metadata.
- **Error mapping** (`errors.py`): Maps LangGraph/Deep Agents exceptions to karenina's hierarchy (`AgentExecutionError`, `AgentTimeoutError`, `AgentResponseError`).
- **Backend configuration** (`agent.py`): Always uses `FilesystemBackend` for real disk access. `StateBackend` (virtual/in-memory) is explicitly avoided because it makes the agent blind to real workspace files, a silent failure where the agent generates synthetic data instead of erroring.
- **Prompt instructions** (`prompts/`): Registers adapter-specific instructions for parsing, rubric evaluation, and deep judgment tasks via `AdapterInstructionRegistry`.
- **Registration** (`registration.py`): Registers `AdapterSpec` with `natively_agentic=True`, `supports_mcp=True`, `supports_tools=True`, no fallback interface.

### Infrastructure changes

- **`ModelConfig.interface`**: Added `"langchain_deep_agents"` to the `Literal` type and `InterfaceType` alias in `factory.py`.
- **`AdapterRegistry`**: Added import of `langchain_deep_agents.registration` in `_load_builtins()`.
- **`pyproject.toml`**: Added `deep-agents` optional dependency group (`deepagents>=0.4.0`, `langchain-mcp-adapters>=0.1.0`).
- **`vulture_whitelist.py`**: Whitelisted adapter classes for dead code analysis.

### Conformance test suite (`tests/unit/adapters/conformance/`)

A new shared test suite (7 modules) that validates protocol compliance for any adapter:

- **`test_agent_port.py`**: `isinstance` check, method signatures, `aclose()` lifecycle, `AgentResult` field validation, usage non-negativity
- **`test_llm_port.py`**: `isinstance` check, method signatures, capabilities declaration, `with_structured_output()` immutability
- **`test_parser_port.py`**: `isinstance` check, method signatures, capabilities declaration
- **`test_message_converter.py`**: Roundtrip correctness for user/assistant/system/tool messages, empty input handling
- **`test_registration.py`**: All registered interfaces have specs with factories, boolean feature flags, valid fallback references. Specific assertions for `langchain_deep_agents` spec.
- **`test_trace_format.py`**: Delimiter correctness (`--- AI Message ---`, etc.), content preservation, multi-turn ordering
- **`test_workspace_access.py`**: Natively agentic adapters must use real filesystem backends, `AgentConfig.workspace_path` acceptance

### Adapter-specific tests (`tests/unit/adapters/langchain_deep_agents/`)

- **`test_agent.py`**: Backend configuration (FilesystemBackend, never StateBackend, workspace_path rooting), basic arun, limit detection, tool call traces, aclose
- **`test_availability.py`**: Package detection
- **`test_llm.py`**: Adapter init, capabilities, structured output
- **`test_mcp.py`**: Transport conversion (stdio, HTTP/SSE, unknown)
- **`test_messages.py`**: Prompt string building, system extraction, from_provider conversion, tool call handling
- **`test_parser.py`**: Structured output parsing, text fallback, usage extraction
- **`test_trace.py`**: Raw trace formatting, tool calls, empty input

## Test plan

- [ ] `uv run pytest tests/unit/adapters/langchain_deep_agents/ -x -q` — adapter-specific tests
- [ ] `uv run pytest tests/unit/adapters/conformance/ -x -q` — shared conformance suite
- [ ] `uv run pytest tests/ -x -q` — full suite, no regressions
- [ ] Verify adapter is discoverable via `AdapterRegistry` without `deepagents` installed (graceful skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)