### PR TITLE
fix(rubric): unify merge semantics, reject same-type collisions

### DIFF
--- a/src/karenina/benchmark/core/rubrics.py
+++ b/src/karenina/benchmark/core/rubrics.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from .base import BenchmarkBase
 
 from karenina.schemas.entities import CallableRubricTrait, LLMRubricTrait, MetricRubricTrait, RegexRubricTrait, Rubric
-from karenina.schemas.entities.rubric import AgenticRubricTrait, DynamicRubric, merge_dynamic_rubrics
+from karenina.schemas.entities.rubric import AgenticRubricTrait, DynamicRubric, merge_dynamic_rubrics, merge_rubrics
 from karenina.utils.checkpoint import (
     add_global_dynamic_rubric_to_benchmark,
     add_global_rubric_to_benchmark,
@@ -112,64 +112,54 @@ class RubricManager:
         return None
 
     def get_merged_rubric_for_question(self, question_id: str) -> Rubric | None:
-        """
-        Get merged rubric for a question (global + question-specific traits).
+        """Get merged rubric for a question (global + question-specific traits).
+
+        Delegates to :func:`merge_rubrics` so that the merge semantics are
+        identical to the verification pipeline path. Same-type trait name
+        collisions raise ``ValueError``.
 
         Args:
-            question_id: The question ID
+            question_id: The question ID.
 
         Returns:
-            Merged rubric with both global and question-specific traits, or None if no rubrics
-        """
-        # Get global rubric traits
-        global_traits = extract_global_rubric_from_benchmark(self.base._checkpoint) or []
+            Merged rubric, or None if neither global nor question rubric exists.
 
-        # Get question-specific rubric traits
-        question_traits: list[
-            LLMRubricTrait | RegexRubricTrait | CallableRubricTrait | MetricRubricTrait | AgenticRubricTrait
-        ] = []
+        Raises:
+            ValueError: If global and question rubrics share a trait name
+                within the same trait type.
+        """
+        global_rubric = self.get_global_rubric()
+
+        question_rubric: Rubric | None = None
         if question_id in self.base._questions_cache:
             q_data = self.base._questions_cache[question_id]
-            question_rubric = q_data.get("question_rubric")
-            if question_rubric:
-                # question_rubric is stored as a dict with llm_traits, regex_traits, etc.
-                if isinstance(question_rubric, dict):
-                    question_traits.extend(question_rubric.get("llm_traits", []))
-                    question_traits.extend(question_rubric.get("regex_traits", []))
-                    question_traits.extend(question_rubric.get("callable_traits", []))
-                    question_traits.extend(question_rubric.get("metric_traits", []))
-                    question_traits.extend(question_rubric.get("agentic_traits", []))
-                elif isinstance(question_rubric, list):
-                    # Backwards compatibility if it's already a flat list
-                    question_traits = question_rubric
+            raw = q_data.get("question_rubric")
+            if raw:
+                if isinstance(raw, dict):
+                    question_rubric = Rubric(
+                        llm_traits=raw.get("llm_traits", []),
+                        regex_traits=raw.get("regex_traits", []),
+                        callable_traits=raw.get("callable_traits", []),
+                        metric_traits=raw.get("metric_traits", []),
+                        agentic_traits=raw.get("agentic_traits", []),
+                    )
+                elif isinstance(raw, list):
+                    # Backwards compatibility: flat trait list
+                    llm = [t for t in raw if isinstance(t, LLMRubricTrait)]
+                    regex = [t for t in raw if isinstance(t, RegexRubricTrait)]
+                    callbl = [t for t in raw if isinstance(t, CallableRubricTrait)]
+                    metric = [t for t in raw if isinstance(t, MetricRubricTrait)]
+                    agentic = [t for t in raw if isinstance(t, AgenticRubricTrait)]
+                    if llm or regex or callbl or metric or agentic:
+                        question_rubric = Rubric(
+                            llm_traits=llm,
+                            regex_traits=regex,
+                            callable_traits=callbl,
+                            metric_traits=metric,
+                            agentic_traits=agentic,
+                        )
 
-        # Merge traits (question-specific traits override global ones with same name)
-        merged_traits = list(global_traits)  # Start with global traits
-
-        # Add question-specific traits, replacing any with the same name
-        for q_trait in question_traits:
-            # Remove any global trait with the same name
-            merged_traits = [t for t in merged_traits if t.name != q_trait.name]
-            # Add the question-specific trait
-            merged_traits.append(q_trait)
-
-        # Return merged rubric if we have any traits
-        if merged_traits:
-            # Separate traits by type
-            llm_traits = [t for t in merged_traits if isinstance(t, LLMRubricTrait)]
-            regex_traits = [t for t in merged_traits if isinstance(t, RegexRubricTrait)]
-            callable_traits = [t for t in merged_traits if isinstance(t, CallableRubricTrait)]
-            metric_traits = [t for t in merged_traits if isinstance(t, MetricRubricTrait)]
-            agentic_traits = [t for t in merged_traits if isinstance(t, AgenticRubricTrait)]
-            return Rubric(
-                llm_traits=llm_traits,
-                regex_traits=regex_traits,
-                callable_traits=callable_traits,
-                metric_traits=metric_traits,
-                agentic_traits=agentic_traits,
-            )
-
-        return None
+        return merge_rubrics(global_rubric, question_rubric)
 
     def clear_global_rubric(self) -> bool:
         """

--- a/src/karenina/benchmark/verification/stages/pipeline/rubric_evaluation.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/rubric_evaluation.py
@@ -396,14 +396,21 @@ class RubricEvaluationStage(BaseVerificationStage):
         if not non_agentic_traits:
             return
 
-        # Check for name conflicts with existing static rubric
-        static_names = set()
+        # Check for same-type name conflicts with existing static rubric.
+        # Cross-type overlaps are allowed (results use type-segregated dicts).
         if context.rubric is not None:
-            static_names = set(context.rubric.get_trait_names())
-        dynamic_names = {t.name for t in non_agentic_traits}
-        conflicts = static_names & dynamic_names
-        if conflicts:
-            raise ValueError(f"Dynamic rubric trait names conflict with static rubric: {conflicts}")
+            static_by_type: dict[type, set[str]] = {
+                LLMRubricTrait: {t.name for t in context.rubric.llm_traits},
+                RegexRubricTrait: {t.name for t in context.rubric.regex_traits},
+                CallableRubricTrait: {t.name for t in context.rubric.callable_traits},
+                MetricRubricTrait: {t.name for t in context.rubric.metric_traits},
+            }
+            for trait in non_agentic_traits:
+                names = static_by_type.get(type(trait), set())
+                if trait.name in names:
+                    raise ValueError(
+                        f"Dynamic {type(trait).__name__} trait '{trait.name}' conflicts with static rubric"
+                    )
 
         # Call LLM for presence check
         presence_map = self._call_presence_check(context, non_agentic_traits)

--- a/src/karenina/benchmark/verification/utils/task_helpers.py
+++ b/src/karenina/benchmark/verification/utils/task_helpers.py
@@ -46,15 +46,11 @@ def merge_rubrics_for_task(
         try:
             question_rubric = Rubric.model_validate(template.question_rubric)
         except Exception as e:
-            logger.warning(f"Failed to parse question rubric for {template.question_id}: {e}")
+            logger.warning("Failed to parse question rubric for %s: %s", template.question_id, e)
 
-    try:
-        from karenina.schemas import merge_rubrics
+    from karenina.schemas import merge_rubrics
 
-        return merge_rubrics(global_rubric, question_rubric)
-    except ValueError as e:
-        logger.error(f"Error merging rubrics for {template.question_id}: {e}")
-        return global_rubric
+    return merge_rubrics(global_rubric, question_rubric)
 
 
 def merge_dynamic_rubrics_for_task(
@@ -90,11 +86,7 @@ def merge_dynamic_rubrics_for_task(
                 e,
             )
 
-    try:
-        return merge_dynamic_rubrics(global_dynamic_rubric, question_dynamic_rubric)
-    except ValueError as e:
-        logger.error("Error merging dynamic rubrics for %s: %s", template.question_id, e)
-        return global_dynamic_rubric
+    return merge_dynamic_rubrics(global_dynamic_rubric, question_dynamic_rubric)
 
 
 def resolve_few_shot_for_task(

--- a/src/karenina/schemas/entities/rubric.py
+++ b/src/karenina/schemas/entities/rubric.py
@@ -771,12 +771,34 @@ class Rubric(BaseModel):
 
     @model_validator(mode="after")
     def validate_trait_names(self) -> "Rubric":
-        """Reject dots in agentic trait names to avoid dot-notation collisions.
+        """Reject duplicate trait names within each type and dots in agentic names.
 
-        Template kind traits produce dot-expanded keys (``trait.field``). A trait
-        named ``"foo.bar"`` would be ambiguous: is it a single trait or the
-        ``bar`` field of trait ``foo``?
+        Each trait type list must have unique names. Cross-type name overlaps
+        are allowed because results are stored in type-segregated dicts
+        (``llm_trait_scores``, ``regex_trait_scores``, etc.).
+
+        Dots in agentic trait names are rejected because template kind traits
+        produce dot-expanded keys (``trait.field``). A trait named ``"foo.bar"``
+        would be ambiguous.
         """
+        type_lists: list[tuple[str, list[Any]]] = [
+            ("llm", self.llm_traits),
+            ("regex", self.regex_traits),
+            ("callable", self.callable_traits),
+            ("metric", self.metric_traits),
+            ("agentic", self.agentic_traits),
+        ]
+        for type_label, traits in type_lists:
+            seen: set[str] = set()
+            for trait in traits:
+                if trait.name in seen:
+                    raise ValueError(
+                        f"Duplicate {type_label} trait name '{trait.name}' "
+                        f"within the same rubric. Trait names must be unique "
+                        f"per type."
+                    )
+                seen.add(trait.name)
+
         for trait in self.agentic_traits:
             if "." in trait.name:
                 raise ValueError(
@@ -944,18 +966,23 @@ class RubricEvaluation(BaseModel):
 
 
 def merge_rubrics(global_rubric: "Rubric | None", question_rubric: "Rubric | None") -> "Rubric | None":
-    """
-    Merge global and question-specific rubrics.
+    """Merge global and question-specific rubrics.
+
+    Same-type trait name collisions (e.g., both rubrics have an LLM trait
+    named "safety") raise ``ValueError``. Cross-type collisions (e.g., global
+    regex trait "quality" + question LLM trait "quality") are allowed because
+    results are stored in type-segregated dicts.
 
     Args:
-        global_rubric: The global rubric (applied to all questions)
-        question_rubric: Question-specific rubric (overrides/adds to global)
+        global_rubric: The global rubric (applied to all questions).
+        question_rubric: Question-specific rubric (adds to global).
 
     Returns:
-        Merged rubric with global traits + question-specific traits, or None if both are None
+        Merged rubric, or None if both are None.
 
     Raises:
-        ValueError: If there are trait name conflicts between global and question rubrics
+        ValueError: If a trait name appears in both rubrics within the same
+            trait type.
     """
     if not global_rubric and not question_rubric:
         return None
@@ -966,27 +993,31 @@ def merge_rubrics(global_rubric: "Rubric | None", question_rubric: "Rubric | Non
     if not question_rubric:
         return global_rubric
 
-    # Check for trait name conflicts (across all trait types)
-    global_all_names = set(global_rubric.get_trait_names())
-    question_all_names = set(question_rubric.get_trait_names())
-    conflicts = global_all_names.intersection(question_all_names)
+    # Check per-type name collisions
+    type_pairs: list[tuple[str, list[Any], list[Any]]] = [
+        ("llm", global_rubric.llm_traits, question_rubric.llm_traits),
+        ("regex", global_rubric.regex_traits, question_rubric.regex_traits),
+        ("callable", global_rubric.callable_traits, question_rubric.callable_traits),
+        ("metric", global_rubric.metric_traits, question_rubric.metric_traits),
+        ("agentic", global_rubric.agentic_traits, question_rubric.agentic_traits),
+    ]
+    all_conflicts: list[str] = []
+    for type_label, g_traits, q_traits in type_pairs:
+        g_names = {t.name for t in g_traits}
+        q_names = {t.name for t in q_traits}
+        overlap = g_names & q_names
+        if overlap:
+            all_conflicts.extend(f"{type_label}:{name}" for name in sorted(overlap))
 
-    if conflicts:
-        raise ValueError(f"Trait name conflicts between global and question rubrics: {conflicts}")
-
-    # Merge all trait types separately
-    merged_traits = list(global_rubric.llm_traits) + list(question_rubric.llm_traits)
-    merged_regex_traits = list(global_rubric.regex_traits) + list(question_rubric.regex_traits)
-    merged_callable_traits = list(global_rubric.callable_traits) + list(question_rubric.callable_traits)
-    merged_metric_traits = list(global_rubric.metric_traits) + list(question_rubric.metric_traits)
-    merged_agentic_traits = list(global_rubric.agentic_traits) + list(question_rubric.agentic_traits)
+    if all_conflicts:
+        raise ValueError(f"Same-type trait name conflicts between global and question rubrics: {all_conflicts}")
 
     return Rubric(
-        llm_traits=merged_traits,
-        regex_traits=merged_regex_traits,
-        callable_traits=merged_callable_traits,
-        metric_traits=merged_metric_traits,
-        agentic_traits=merged_agentic_traits,
+        llm_traits=list(global_rubric.llm_traits) + list(question_rubric.llm_traits),
+        regex_traits=list(global_rubric.regex_traits) + list(question_rubric.regex_traits),
+        callable_traits=list(global_rubric.callable_traits) + list(question_rubric.callable_traits),
+        metric_traits=list(global_rubric.metric_traits) + list(question_rubric.metric_traits),
+        agentic_traits=list(global_rubric.agentic_traits) + list(question_rubric.agentic_traits),
     )
 
 
@@ -1010,6 +1041,32 @@ class DynamicRubric(BaseModel):
     callable_traits: list[CallableRubricTrait] = Field(default_factory=list)
     metric_traits: list[MetricRubricTrait] = Field(default_factory=list)
     agentic_traits: list[AgenticRubricTrait] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_trait_names(self) -> "DynamicRubric":
+        """Reject duplicate trait names within each type.
+
+        Mirrors ``Rubric.validate_trait_names``. Cross-type overlaps are
+        allowed; same-type duplicates are not.
+        """
+        type_lists: list[tuple[str, list[Any]]] = [
+            ("llm", self.llm_traits),
+            ("regex", self.regex_traits),
+            ("callable", self.callable_traits),
+            ("metric", self.metric_traits),
+            ("agentic", self.agentic_traits),
+        ]
+        for type_label, traits in type_lists:
+            seen: set[str] = set()
+            for trait in traits:
+                if trait.name in seen:
+                    raise ValueError(
+                        f"Duplicate {type_label} trait name '{trait.name}' "
+                        f"within the same dynamic rubric. Trait names must be "
+                        f"unique per type."
+                    )
+                seen.add(trait.name)
+        return self
 
     @model_validator(mode="after")
     def validate_concept_text(self) -> "DynamicRubric":
@@ -1083,9 +1140,8 @@ def merge_dynamic_rubrics(
 ) -> "DynamicRubric | None":
     """Merge global and question-specific dynamic rubrics.
 
-    Mirrors :func:`merge_rubrics` for the dynamic rubric variant. Traits from
-    both sources are concatenated. Name collisions (across all trait types) are
-    rejected.
+    Mirrors :func:`merge_rubrics` for the dynamic rubric variant. Same-type
+    name collisions are rejected; cross-type overlaps are allowed.
 
     Args:
         global_dynamic: The global dynamic rubric (applied to all questions).
@@ -1095,7 +1151,8 @@ def merge_dynamic_rubrics(
         Merged DynamicRubric with traits from both sources, or None if both are None.
 
     Raises:
-        ValueError: If there are trait name conflicts between global and question dynamic rubrics.
+        ValueError: If a trait name appears in both rubrics within the same
+            trait type.
     """
     if not global_dynamic and not question_dynamic:
         return None
@@ -1106,13 +1163,23 @@ def merge_dynamic_rubrics(
     if not question_dynamic:
         return global_dynamic
 
-    # Check for trait name conflicts across all trait types
-    global_names = set(global_dynamic.get_trait_names())
-    question_names = set(question_dynamic.get_trait_names())
-    conflicts = global_names.intersection(question_names)
+    type_pairs: list[tuple[str, list[Any], list[Any]]] = [
+        ("llm", global_dynamic.llm_traits, question_dynamic.llm_traits),
+        ("regex", global_dynamic.regex_traits, question_dynamic.regex_traits),
+        ("callable", global_dynamic.callable_traits, question_dynamic.callable_traits),
+        ("metric", global_dynamic.metric_traits, question_dynamic.metric_traits),
+        ("agentic", global_dynamic.agentic_traits, question_dynamic.agentic_traits),
+    ]
+    all_conflicts: list[str] = []
+    for type_label, g_traits, q_traits in type_pairs:
+        g_names = {t.name for t in g_traits}
+        q_names = {t.name for t in q_traits}
+        overlap = g_names & q_names
+        if overlap:
+            all_conflicts.extend(f"{type_label}:{name}" for name in sorted(overlap))
 
-    if conflicts:
-        raise ValueError(f"Trait name conflicts between global and question dynamic rubrics: {conflicts}")
+    if all_conflicts:
+        raise ValueError(f"Same-type trait name conflicts between global and question dynamic rubrics: {all_conflicts}")
 
     return DynamicRubric(
         llm_traits=list(global_dynamic.llm_traits) + list(question_dynamic.llm_traits),

--- a/src/karenina/schemas/verification/result_components.py
+++ b/src/karenina/schemas/verification/result_components.py
@@ -212,8 +212,11 @@ class VerificationResultRubric(BaseModel):
     dynamic_rubric_promoted_traits: list[str] | None = None  # Traits promoted after presence check
 
     def get_all_trait_scores(self) -> dict[str, int | bool | float | str | list[Any] | dict[str, float] | None]:
-        """
-        Get all trait scores across all trait types in a flat dictionary.
+        """Get all trait scores across all trait types in a flat dictionary.
+
+        If cross-type same-name traits exist (e.g., an LLM trait and a regex
+        trait both named "quality"), later types overwrite earlier ones. Access
+        the individual ``*_trait_scores`` dicts directly in that case.
 
         Returns:
             dict: All trait scores, e.g.:

--- a/tests/test_dynamic_rubric.py
+++ b/tests/test_dynamic_rubric.py
@@ -335,12 +335,13 @@ class TestMergeDynamicRubrics:
         with pytest.raises(ValueError, match="safety"):
             merge_dynamic_rubrics(global_dr, question_dr)
 
-    def test_cross_type_name_collision_raises(self) -> None:
-        """Name collision between different trait types raises ValueError."""
+    def test_cross_type_name_allowed(self) -> None:
+        """Cross-type same-name traits merge without error (type-segregated storage)."""
         global_dr = DynamicRubric(llm_traits=[_make_llm_trait("check", summary="LLM check")])
         question_dr = DynamicRubric(regex_traits=[_make_regex_trait("check", summary="Regex check")])
-        with pytest.raises(ValueError, match="check"):
-            merge_dynamic_rubrics(global_dr, question_dr)
+        result = merge_dynamic_rubrics(global_dr, question_dr)
+        assert len(result.llm_traits) == 1
+        assert len(result.regex_traits) == 1
 
     def test_merged_result_is_new_instance(self) -> None:
         """Merged result is a new DynamicRubric, not one of the inputs."""

--- a/tests/unit/benchmark/core/test_rubrics.py
+++ b/tests/unit/benchmark/core/test_rubrics.py
@@ -282,8 +282,8 @@ class TestGetMergedRubricForQuestion:
         assert merged is not None
         assert len(merged.llm_traits) == 2
 
-    def test_merged_rubric_question_overrides_global(self) -> None:
-        """Test question trait overrides global trait with same name."""
+    def test_merged_rubric_rejects_same_type_collision(self) -> None:
+        """Test same-type trait name collision raises ValueError."""
         benchmark = Benchmark.create(name="test")
         manager = RubricManager(benchmark)
 
@@ -310,12 +310,8 @@ class TestGetMergedRubricForQuestion:
             ),
         )
 
-        merged = manager.get_merged_rubric_for_question(q_id)
-        assert merged is not None
-        assert len(merged.regex_traits) == 1
-        # Question's pattern should override
-        assert merged.regex_traits[0].pattern == r"[A-Z]+"
-        assert merged.regex_traits[0].description == "Question pattern"
+        with pytest.raises(ValueError, match="Same-type trait name conflicts"):
+            manager.get_merged_rubric_for_question(q_id)
 
 
 @pytest.mark.unit

--- a/tests/unit/schemas/test_rubric_schemas.py
+++ b/tests/unit/schemas/test_rubric_schemas.py
@@ -551,11 +551,8 @@ def test_merge_rubrics_with_conflict_raises_error() -> None:
     global_rubric = Rubric(llm_traits=[global_trait])
     question_rubric = Rubric(llm_traits=[question_trait])
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="Same-type trait name conflicts"):
         merge_rubrics(global_rubric, question_rubric)
-
-    assert "Trait name conflicts" in str(exc_info.value)
-    assert "clarity" in str(exc_info.value)
 
 
 @pytest.mark.unit
@@ -600,6 +597,75 @@ def test_merge_rubrics_all_trait_types() -> None:
         "has_citation",
         "entity_check",
     }
+
+
+# =============================================================================
+# Intra-Rubric Duplicate Name Validation (Issue 128)
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_rubric_rejects_duplicate_llm_trait_names() -> None:
+    """Duplicate LLM trait names within one Rubric raise at construction."""
+    t1 = LLMRubricTrait(name="safety", kind="boolean", higher_is_better=True)
+    t2 = LLMRubricTrait(name="safety", kind="score", min_score=1, max_score=5, higher_is_better=True)
+    with pytest.raises(ValidationError, match="Duplicate llm trait name 'safety'"):
+        Rubric(llm_traits=[t1, t2])
+
+
+@pytest.mark.unit
+def test_rubric_rejects_duplicate_regex_trait_names() -> None:
+    """Duplicate regex trait names within one Rubric raise at construction."""
+    t1 = RegexRubricTrait(name="has_email", pattern=r"\S+@\S+", higher_is_better=True)
+    t2 = RegexRubricTrait(name="has_email", pattern=r".+@.+", higher_is_better=True)
+    with pytest.raises(ValidationError, match="Duplicate regex trait name 'has_email'"):
+        Rubric(regex_traits=[t1, t2])
+
+
+@pytest.mark.unit
+def test_rubric_allows_cross_type_same_name() -> None:
+    """Same name across different types is allowed (type-segregated storage)."""
+    llm = LLMRubricTrait(name="quality", kind="boolean", higher_is_better=True)
+    regex = RegexRubricTrait(name="quality", pattern=r"quality", higher_is_better=True)
+    rubric = Rubric(llm_traits=[llm], regex_traits=[regex])
+    assert len(rubric.get_trait_names()) == 2
+
+
+@pytest.mark.unit
+def test_dynamic_rubric_rejects_duplicate_llm_trait_names() -> None:
+    """Duplicate LLM trait names within one DynamicRubric raise at construction."""
+    from karenina.schemas.entities.rubric import DynamicRubric
+
+    t1 = LLMRubricTrait(name="safety", kind="boolean", higher_is_better=True, summary="s")
+    t2 = LLMRubricTrait(name="safety", kind="score", min_score=1, max_score=5, higher_is_better=True, summary="s")
+    with pytest.raises(ValidationError, match="Duplicate llm trait name 'safety'"):
+        DynamicRubric(llm_traits=[t1, t2])
+
+
+# =============================================================================
+# Cross-Type Merge Allowed (Issue 183)
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_merge_rubrics_cross_type_same_name_allowed() -> None:
+    """Cross-type same-name traits merge without error."""
+    global_rubric = Rubric(regex_traits=[RegexRubricTrait(name="quality", pattern=r"quality", higher_is_better=True)])
+    question_rubric = Rubric(llm_traits=[LLMRubricTrait(name="quality", kind="boolean", higher_is_better=True)])
+    merged = merge_rubrics(global_rubric, question_rubric)
+    assert len(merged.regex_traits) == 1
+    assert len(merged.llm_traits) == 1
+
+
+@pytest.mark.unit
+def test_merge_rubrics_same_type_same_name_rejected() -> None:
+    """Same-type same-name traits are rejected even if config differs."""
+    global_rubric = Rubric(llm_traits=[LLMRubricTrait(name="clarity", kind="boolean", higher_is_better=True)])
+    question_rubric = Rubric(
+        llm_traits=[LLMRubricTrait(name="clarity", kind="score", min_score=1, max_score=5, higher_is_better=True)]
+    )
+    with pytest.raises(ValueError, match="Same-type trait name conflicts.*llm:clarity"):
+        merge_rubrics(global_rubric, question_rubric)
 
 
 @pytest.mark.unit
@@ -806,15 +872,16 @@ class TestRubricAgenticTraitSupport:
     def test_merge_rubrics_detects_agentic_name_conflict(self):
         r1 = Rubric(agentic_traits=[self._make_agentic_trait("dup")])
         r2 = Rubric(agentic_traits=[self._make_agentic_trait("dup")])
-        with pytest.raises(ValueError, match="Trait name conflicts"):
+        with pytest.raises(ValueError, match="Same-type trait name conflicts"):
             merge_rubrics(r1, r2)
 
-    def test_merge_rubrics_cross_type_name_conflict(self):
-        """Agentic trait name colliding with LLM trait name is detected."""
+    def test_merge_rubrics_cross_type_allowed(self):
+        """Cross-type same-name traits are allowed (type-segregated storage)."""
         r1 = Rubric(llm_traits=[LLMRubricTrait(name="shared", kind="boolean")])
         r2 = Rubric(agentic_traits=[self._make_agentic_trait("shared")])
-        with pytest.raises(ValueError, match="Trait name conflicts"):
-            merge_rubrics(r1, r2)
+        merged = merge_rubrics(r1, r2)
+        assert len(merged.llm_traits) == 1
+        assert len(merged.agentic_traits) == 1
 
     def test_validate_evaluation_includes_agentic(self):
         """validate_evaluation checks agentic trait scores."""


### PR DESCRIPTION
## Summary

- **Unified merge paths**: `RubricManager.get_merged_rubric_for_question()` now delegates to `merge_rubrics()` instead of using its own override-by-name logic. Both code paths produce identical results.
- **Removed silent fallback**: The `try/except ValueError` in `task_helpers.merge_rubrics_for_task()` (and its dynamic rubric counterpart) that silently dropped question-specific rubrics is removed. Collisions now propagate as errors.
- **Relaxed cross-type rejection**: `merge_rubrics()` and `merge_dynamic_rubrics()` now only reject same-type name collisions (e.g., two LLM traits named "safety"). Cross-type overlaps (e.g., regex "quality" + LLM "quality") are allowed since results use type-segregated dicts.
- **Intra-Rubric duplicate validation**: `Rubric` and `DynamicRubric` now reject duplicate trait names within the same type at construction time via model validators.

## Test plan

- [x] Existing rubric schema tests updated and passing (125 tests)
- [x] Full unit test suite passing (2854 tests)
- [x] Full non-e2e test suite passing (3524 tests)
- [x] New tests for: intra-Rubric duplicate rejection, cross-type merge allowed, same-type merge rejected, RubricManager collision behavior
- [x] Pre-commit hooks pass (ruff, mypy, vulture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)