### PR TITLE
fix(checkpoint): fix 6 serialization round-trip bugs

### DIFF
--- a/src/karenina/benchmark/core/base.py
+++ b/src/karenina/benchmark/core/base.py
@@ -90,15 +90,15 @@ class BenchmarkBase:
 
         return instance
 
-    def save(self, path: Path, save_deep_judgment_config: bool = False) -> None:
+    def save(self, path: Path, save_deep_judgment_config: bool = True) -> None:
         """
         Save the benchmark to a JSON-LD file.
 
         Args:
             path: Path where to save the benchmark
-            save_deep_judgment_config: If True, include deep judgment configuration
-                in LLM rubric traits. If False (default), deep judgment settings
-                are stripped before saving. Default is False for backward compatibility.
+            save_deep_judgment_config: If True (default), include deep judgment
+                configuration in LLM rubric traits. If False, deep judgment
+                settings are stripped before saving.
         """
         from copy import deepcopy
 

--- a/src/karenina/utils/checkpoint.py
+++ b/src/karenina/utils/checkpoint.py
@@ -33,9 +33,42 @@ from .checkpoint_trait_converters import (
 
 logger = logging.getLogger(__name__)
 
+VALID_QUESTION_TRAIT_TYPES: frozenset[str] = frozenset(
+    [
+        "karenina:GlobalRubricTrait",
+        "karenina:QuestionSpecificRubricTrait",
+        "karenina:GlobalRegexTrait",
+        "karenina:QuestionSpecificRegexTrait",
+        "karenina:GlobalCallableTrait",
+        "karenina:QuestionSpecificCallableTrait",
+        "karenina:GlobalMetricRubricTrait",
+        "karenina:QuestionSpecificMetricRubricTrait",
+        "karenina:GlobalLLMRubricTrait",
+        "karenina:QuestionSpecificLLMRubricTrait",
+        "karenina:GlobalDynamicRubricTrait",
+        "karenina:QuestionSpecificDynamicRubricTrait",
+        "karenina:GlobalAgenticRubricTrait",
+        "karenina:QuestionSpecificAgenticRubricTrait",
+    ]
+)
+
+VALID_GLOBAL_TRAIT_TYPES: frozenset[str] = frozenset(
+    [
+        "karenina:GlobalRubricTrait",
+        "karenina:GlobalRegexTrait",
+        "karenina:GlobalCallableTrait",
+        "karenina:GlobalMetricRubricTrait",
+        "karenina:GlobalLLMRubricTrait",
+        "karenina:GlobalDynamicRubricTrait",
+        "karenina:GlobalAgenticRubricTrait",
+    ]
+)
+
 # Re-export for backward compatibility
 __all__ = [
     "BenchmarkConversionError",
+    "VALID_QUESTION_TRAIT_TYPES",
+    "VALID_GLOBAL_TRAIT_TYPES",
     "generate_question_id",
     "generate_template_id",
     "convert_rubric_trait_to_rating",
@@ -542,20 +575,7 @@ def validate_jsonld_benchmark(benchmark: JsonLdCheckpoint) -> tuple[bool, str]:
                 # Validate ratings if present
                 if item.item.rating:
                     for rating in item.item.rating:
-                        if rating.additionalType not in [
-                            "karenina:GlobalRubricTrait",
-                            "karenina:QuestionSpecificRubricTrait",
-                            "karenina:GlobalRegexTrait",
-                            "karenina:QuestionSpecificRegexTrait",
-                            "karenina:GlobalCallableTrait",
-                            "karenina:QuestionSpecificCallableTrait",
-                            "karenina:GlobalMetricRubricTrait",
-                            "karenina:QuestionSpecificMetricRubricTrait",
-                            "karenina:GlobalLLMRubricTrait",
-                            "karenina:QuestionSpecificLLMRubricTrait",
-                            "karenina:GlobalDynamicRubricTrait",
-                            "karenina:QuestionSpecificDynamicRubricTrait",
-                        ]:
+                        if rating.additionalType not in VALID_QUESTION_TRAIT_TYPES:
                             return (
                                 False,
                                 f"Invalid additionalType for rating: {rating.additionalType}",
@@ -564,14 +584,7 @@ def validate_jsonld_benchmark(benchmark: JsonLdCheckpoint) -> tuple[bool, str]:
         # Validate global ratings if present
         if benchmark.rating:
             for rating in benchmark.rating:
-                if rating.additionalType not in [
-                    "karenina:GlobalRubricTrait",
-                    "karenina:GlobalRegexTrait",
-                    "karenina:GlobalCallableTrait",
-                    "karenina:GlobalMetricRubricTrait",
-                    "karenina:GlobalLLMRubricTrait",
-                    "karenina:GlobalDynamicRubricTrait",
-                ]:
+                if rating.additionalType not in VALID_GLOBAL_TRAIT_TYPES:
                     return (
                         False,
                         f"Dataset-level rating must be a global trait type, got {rating.additionalType}",

--- a/src/karenina/utils/checkpoint_trait_converters.py
+++ b/src/karenina/utils/checkpoint_trait_converters.py
@@ -72,6 +72,8 @@ def _convert_metric_trait_to_rating(trait: MetricRubricTrait, rubric_type: str) 
         additional_props.append(SchemaOrgPropertyValue(name="tp_instructions", value=trait.tp_instructions))
     if trait.tn_instructions:
         additional_props.append(SchemaOrgPropertyValue(name="tn_instructions", value=trait.tn_instructions))
+    if trait.summary is not None:
+        additional_props.append(SchemaOrgPropertyValue(name="summary", value=trait.summary))
 
     return SchemaOrgRating(
         name=trait.name,
@@ -94,6 +96,8 @@ def _convert_regex_trait_to_rating(trait: RegexRubricTrait, rubric_type: str) ->
         SchemaOrgPropertyValue(name="invert_result", value=trait.invert_result),
         SchemaOrgPropertyValue(name="higher_is_better", value=trait.higher_is_better),
     ]
+    if trait.summary is not None:
+        additional_props.append(SchemaOrgPropertyValue(name="summary", value=trait.summary))
 
     return SchemaOrgRating(
         name=trait.name,
@@ -123,6 +127,8 @@ def _convert_callable_trait_to_rating(trait: CallableRubricTrait, rubric_type: s
             additional_props.append(SchemaOrgPropertyValue(name="min_score", value=trait.min_score))
         if trait.max_score is not None:
             additional_props.append(SchemaOrgPropertyValue(name="max_score", value=trait.max_score))
+    if trait.summary is not None:
+        additional_props.append(SchemaOrgPropertyValue(name="summary", value=trait.summary))
 
     # Determine best/worst rating based on kind
     if trait.kind == "boolean":
@@ -168,6 +174,12 @@ def _convert_agentic_trait_to_rating(trait: AgenticRubricTrait, rubric_type: str
         additional_props.append(SchemaOrgPropertyValue(name="classes", value=trait.classes))
     if trait.model_override is not None:
         additional_props.append(SchemaOrgPropertyValue(name="model_override", value=trait.model_override.model_dump()))
+    if trait.summary is not None:
+        additional_props.append(SchemaOrgPropertyValue(name="summary", value=trait.summary))
+    if trait.min_score is not None:
+        additional_props.append(SchemaOrgPropertyValue(name="min_score", value=trait.min_score))
+    if trait.max_score is not None:
+        additional_props.append(SchemaOrgPropertyValue(name="max_score", value=trait.max_score))
 
     # Determine best/worst rating based on kind
     if trait.is_template_kind:
@@ -222,6 +234,12 @@ def _convert_llm_trait_to_rating(trait: LLMRubricTrait, rubric_type: str) -> Sch
 
     # Add directionality field
     additional_props.append(SchemaOrgPropertyValue(name="higher_is_better", value=trait.higher_is_better))
+    if trait.summary is not None:
+        additional_props.append(SchemaOrgPropertyValue(name="summary", value=trait.summary))
+    if trait.min_score is not None:
+        additional_props.append(SchemaOrgPropertyValue(name="min_score", value=trait.min_score))
+    if trait.max_score is not None:
+        additional_props.append(SchemaOrgPropertyValue(name="max_score", value=trait.max_score))
 
     if trait.kind == "boolean":
         return SchemaOrgRating(
@@ -324,6 +342,7 @@ def _convert_rating_to_metric_trait(rating: SchemaOrgRating) -> MetricRubricTrai
     evaluation_mode: Literal["tp_only", "full_matrix"] = "tp_only"  # Default for backward compatibility
     tp_instructions = []
     tn_instructions = []
+    summary: str | None = None
 
     if rating.additionalProperty:
         for prop in rating.additionalProperty:
@@ -347,11 +366,13 @@ def _convert_rating_to_metric_trait(rating: SchemaOrgRating) -> MetricRubricTrai
                     tn_instructions = json.loads(prop.value)
                 except (json.JSONDecodeError, TypeError):
                     tn_instructions = prop.value if isinstance(prop.value, list) else []
+            elif prop.name == "summary":
+                summary = prop.value
 
     return MetricRubricTrait(
         name=rating.name,
         description=rating.description,
-        summary=None,
+        summary=summary,
         evaluation_mode=evaluation_mode,
         metrics=metrics,
         tp_instructions=tp_instructions,
@@ -367,6 +388,7 @@ def _convert_rating_to_regex_trait(rating: SchemaOrgRating) -> RegexRubricTrait:
     case_sensitive = True
     invert_result = False
     higher_is_better = True  # Legacy default
+    summary: str | None = None
 
     if rating.additionalProperty:
         for prop in rating.additionalProperty:
@@ -378,11 +400,13 @@ def _convert_rating_to_regex_trait(rating: SchemaOrgRating) -> RegexRubricTrait:
                 invert_result = prop.value
             elif prop.name == "higher_is_better":
                 higher_is_better = prop.value
+            elif prop.name == "summary":
+                summary = prop.value
 
     return RegexRubricTrait(
         name=rating.name,
         description=rating.description,
-        summary=None,
+        summary=summary,
         pattern=pattern,
         case_sensitive=case_sensitive,
         invert_result=invert_result,
@@ -399,6 +423,7 @@ def _convert_rating_to_callable_trait(rating: SchemaOrgRating) -> CallableRubric
     min_score = None
     max_score = None
     higher_is_better = True  # Legacy default
+    summary: str | None = None
 
     if rating.additionalProperty:
         for prop in rating.additionalProperty:
@@ -414,11 +439,13 @@ def _convert_rating_to_callable_trait(rating: SchemaOrgRating) -> CallableRubric
                 max_score = prop.value
             elif prop.name == "higher_is_better":
                 higher_is_better = prop.value
+            elif prop.name == "summary":
+                summary = prop.value
 
     return CallableRubricTrait(
         name=rating.name,
         description=rating.description,
-        summary=None,
+        summary=summary,
         kind=kind,
         callable_code=callable_code,
         min_score=min_score,
@@ -432,7 +459,7 @@ def _convert_rating_to_llm_trait(rating: SchemaOrgRating) -> LLMRubricTrait:
     """Convert SchemaOrgRating to LLMRubricTrait."""
     # Extract configuration from additionalProperty
     deep_judgment_enabled = False
-    deep_judgment_excerpt_enabled = False
+    deep_judgment_excerpt_enabled = True  # Match LLMRubricTrait model default
     deep_judgment_search_enabled = False
     deep_judgment_max_excerpts = None
     deep_judgment_fuzzy_match_threshold = None
@@ -440,6 +467,9 @@ def _convert_rating_to_llm_trait(rating: SchemaOrgRating) -> LLMRubricTrait:
     higher_is_better = True  # Legacy default
     kind: TraitKind | None = None  # Explicit kind from property (for literal)
     classes: dict[str, str] | None = None  # Classes for literal kind
+    summary: str | None = None
+    min_score = None
+    max_score = None
 
     if rating.additionalProperty:
         for prop in rating.additionalProperty:
@@ -469,6 +499,12 @@ def _convert_rating_to_llm_trait(rating: SchemaOrgRating) -> LLMRubricTrait:
                     except json.JSONDecodeError:
                         logger.warning("Failed to parse classes JSON for trait '%s'", rating.name)
                         classes = None
+            elif prop.name == "summary":
+                summary = prop.value
+            elif prop.name == "min_score":
+                min_score = prop.value
+            elif prop.name == "max_score":
+                max_score = prop.value
 
     # Determine kind: explicit kind takes precedence, then infer from rating range
     if kind is None:
@@ -476,59 +512,31 @@ def _convert_rating_to_llm_trait(rating: SchemaOrgRating) -> LLMRubricTrait:
         is_boolean = rating.bestRating == 1 and rating.worstRating == 0
         kind = "boolean" if is_boolean else "score"
 
-    # Build the trait based on kind
+    # Build common kwargs; omit min_score/max_score when None so Pydantic defaults apply
+    common_kwargs: dict[str, Any] = {
+        "name": rating.name,
+        "description": rating.description,
+        "summary": summary,
+        "deep_judgment_enabled": deep_judgment_enabled,
+        "deep_judgment_excerpt_enabled": deep_judgment_excerpt_enabled,
+        "deep_judgment_max_excerpts": deep_judgment_max_excerpts,
+        "deep_judgment_fuzzy_match_threshold": deep_judgment_fuzzy_match_threshold,
+        "deep_judgment_excerpt_retry_attempts": deep_judgment_excerpt_retry_attempts,
+        "deep_judgment_search_enabled": deep_judgment_search_enabled,
+        "higher_is_better": higher_is_better,
+    }
+    if min_score is not None:
+        common_kwargs["min_score"] = min_score
+    if max_score is not None:
+        common_kwargs["max_score"] = max_score
+
     if kind == "literal":
         # Literal kind: min_score/max_score are auto-derived from classes by the model validator
-        return LLMRubricTrait(
-            name=rating.name,
-            description=rating.description,
-            summary=None,
-            kind="literal",
-            classes=classes,
-            min_score=None,  # Auto-derived by model validator
-            max_score=None,  # Auto-derived by model validator
-            deep_judgment_enabled=deep_judgment_enabled,
-            deep_judgment_excerpt_enabled=deep_judgment_excerpt_enabled,
-            deep_judgment_max_excerpts=deep_judgment_max_excerpts,
-            deep_judgment_fuzzy_match_threshold=deep_judgment_fuzzy_match_threshold,
-            deep_judgment_excerpt_retry_attempts=deep_judgment_excerpt_retry_attempts,
-            deep_judgment_search_enabled=deep_judgment_search_enabled,
-            higher_is_better=higher_is_better,
-        )
+        return LLMRubricTrait(kind="literal", classes=classes, **common_kwargs)
     elif kind == "boolean":
-        return LLMRubricTrait(
-            name=rating.name,
-            description=rating.description,
-            summary=None,
-            kind="boolean",
-            min_score=None,
-            max_score=None,
-            classes=None,
-            deep_judgment_enabled=deep_judgment_enabled,
-            deep_judgment_excerpt_enabled=deep_judgment_excerpt_enabled,
-            deep_judgment_max_excerpts=deep_judgment_max_excerpts,
-            deep_judgment_fuzzy_match_threshold=deep_judgment_fuzzy_match_threshold,
-            deep_judgment_excerpt_retry_attempts=deep_judgment_excerpt_retry_attempts,
-            deep_judgment_search_enabled=deep_judgment_search_enabled,
-            higher_is_better=higher_is_better,
-        )
+        return LLMRubricTrait(kind="boolean", classes=None, **common_kwargs)
     else:  # score
-        return LLMRubricTrait(
-            name=rating.name,
-            description=rating.description,
-            summary=None,
-            kind="score",
-            min_score=int(rating.worstRating),
-            max_score=int(rating.bestRating),
-            classes=None,
-            deep_judgment_enabled=deep_judgment_enabled,
-            deep_judgment_excerpt_enabled=deep_judgment_excerpt_enabled,
-            deep_judgment_max_excerpts=deep_judgment_max_excerpts,
-            deep_judgment_fuzzy_match_threshold=deep_judgment_fuzzy_match_threshold,
-            deep_judgment_excerpt_retry_attempts=deep_judgment_excerpt_retry_attempts,
-            deep_judgment_search_enabled=deep_judgment_search_enabled,
-            higher_is_better=higher_is_better,
-        )
+        return LLMRubricTrait(kind="score", classes=None, **common_kwargs)
 
 
 def _convert_rating_to_agentic_trait(rating: SchemaOrgRating) -> AgenticRubricTrait:
@@ -542,6 +550,9 @@ def _convert_rating_to_agentic_trait(rating: SchemaOrgRating) -> AgenticRubricTr
     timeout_seconds = 120
     classes: dict[str, str] | None = None
     model_override = None
+    summary: str | None = None
+    min_score = None
+    max_score = None
 
     if rating.additionalProperty:
         for prop in rating.additionalProperty:
@@ -574,23 +585,33 @@ def _convert_rating_to_agentic_trait(rating: SchemaOrgRating) -> AgenticRubricTr
                 from ..schemas.config.models import ModelConfig
 
                 model_override = ModelConfig(**prop.value)
+            elif prop.name == "summary":
+                summary = prop.value
+            elif prop.name == "min_score":
+                min_score = prop.value
+            elif prop.name == "max_score":
+                max_score = prop.value
 
-    return AgenticRubricTrait(
-        name=rating.name,
-        description=rating.description or "",
-        summary=None,
-        kind=kind,
-        higher_is_better=higher_is_better,
-        context_mode=context_mode,
-        materialize_trace=materialize_trace,
-        persist_trace=persist_trace,
-        max_turns=max_turns,
-        timeout_seconds=timeout_seconds,
-        min_score=int(rating.worstRating),
-        max_score=int(rating.bestRating),
-        classes=classes,
-        model_override=model_override,
-    )
+    kwargs: dict[str, Any] = {
+        "name": rating.name,
+        "description": rating.description or "",
+        "summary": summary,
+        "kind": kind,
+        "higher_is_better": higher_is_better,
+        "context_mode": context_mode,
+        "materialize_trace": materialize_trace,
+        "persist_trace": persist_trace,
+        "max_turns": max_turns,
+        "timeout_seconds": timeout_seconds,
+        "classes": classes,
+        "model_override": model_override,
+    }
+    if min_score is not None:
+        kwargs["min_score"] = min_score
+    if max_score is not None:
+        kwargs["max_score"] = max_score
+
+    return AgenticRubricTrait(**kwargs)
 
 
 def convert_dynamic_rubric_to_ratings(
@@ -758,7 +779,13 @@ def strip_deep_judgment_config_from_checkpoint(checkpoint: JsonLdCheckpoint) -> 
     if checkpoint.rating:
         for rating in checkpoint.rating:
             if (
-                rating.additionalType in ["karenina:GlobalRubricTrait", "karenina:QuestionSpecificRubricTrait"]
+                rating.additionalType
+                in [
+                    "karenina:GlobalRubricTrait",
+                    "karenina:QuestionSpecificRubricTrait",
+                    "karenina:GlobalLLMRubricTrait",
+                    "karenina:QuestionSpecificLLMRubricTrait",
+                ]
                 and rating.additionalProperty
             ):
                 # Filter out deep judgment properties
@@ -774,7 +801,13 @@ def strip_deep_judgment_config_from_checkpoint(checkpoint: JsonLdCheckpoint) -> 
         if item.item.rating:
             for rating in item.item.rating:
                 if (
-                    rating.additionalType in ["karenina:QuestionSpecificRubricTrait", "karenina:GlobalRubricTrait"]
+                    rating.additionalType
+                    in [
+                        "karenina:GlobalRubricTrait",
+                        "karenina:QuestionSpecificRubricTrait",
+                        "karenina:GlobalLLMRubricTrait",
+                        "karenina:QuestionSpecificLLMRubricTrait",
+                    ]
                     and rating.additionalProperty
                 ):
                     # Filter out deep judgment properties

--- a/tests/unit/utils/test_checkpoint_serialization_roundtrip.py
+++ b/tests/unit/utils/test_checkpoint_serialization_roundtrip.py
@@ -1,0 +1,481 @@
+"""Tests for checkpoint serialization round-trip fixes.
+
+Covers issues: 171, 078, 172, 079, 173.
+"""
+
+import inspect
+from datetime import datetime
+
+import pytest
+
+from karenina.schemas.checkpoint import (
+    SchemaOrgAnswer,
+    SchemaOrgDataFeedItem,
+    SchemaOrgPropertyValue,
+    SchemaOrgQuestion,
+    SchemaOrgRating,
+    SchemaOrgSoftwareSourceCode,
+)
+from karenina.schemas.entities.rubric import (
+    AgenticRubricTrait,
+    CallableRubricTrait,
+    LLMRubricTrait,
+    MetricRubricTrait,
+    RegexRubricTrait,
+)
+from karenina.utils.checkpoint import (
+    create_jsonld_benchmark,
+    validate_jsonld_benchmark,
+)
+from karenina.utils.checkpoint_trait_converters import (
+    convert_rating_to_rubric_trait,
+    convert_rubric_trait_to_rating,
+    strip_deep_judgment_config_from_checkpoint,
+)
+
+# =============================================================================
+# Issue 171: Checkpoint validation must accept agentic rubric trait types
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestIssue171AgenticTraitValidation:
+    """Checkpoint validation must accept agentic rubric trait types."""
+
+    def test_global_agentic_trait_accepted_at_dataset_level(self) -> None:
+        """Global AgenticRubricTrait should be valid at dataset level."""
+        benchmark = create_jsonld_benchmark(name="Test")
+        benchmark.rating = [
+            SchemaOrgRating(
+                name="agentic_test",
+                bestRating=1,
+                worstRating=0,
+                additionalType="karenina:GlobalAgenticRubricTrait",
+            )
+        ]
+
+        is_valid, message = validate_jsonld_benchmark(benchmark)
+
+        assert is_valid is True, f"Expected valid but got: {message}"
+
+    def test_global_agentic_trait_accepted_at_question_level(self) -> None:
+        """Global AgenticRubricTrait should be valid at question level."""
+        benchmark = create_jsonld_benchmark(name="Test")
+        item = SchemaOrgDataFeedItem(
+            dateCreated=datetime.now().isoformat(),
+            dateModified=datetime.now().isoformat(),
+            item=SchemaOrgQuestion(
+                text="Test question?",
+                acceptedAnswer=SchemaOrgAnswer(text="Answer"),
+                hasPart=SchemaOrgSoftwareSourceCode(name="Answer", text="class Answer: pass"),
+                rating=[
+                    SchemaOrgRating(
+                        name="agentic_test",
+                        bestRating=1,
+                        worstRating=0,
+                        additionalType="karenina:GlobalAgenticRubricTrait",
+                    )
+                ],
+            ),
+        )
+        benchmark.dataFeedElement.append(item)
+
+        is_valid, message = validate_jsonld_benchmark(benchmark)
+
+        assert is_valid is True, f"Expected valid but got: {message}"
+
+    def test_question_specific_agentic_trait_accepted_at_question_level(self) -> None:
+        """QuestionSpecificAgenticRubricTrait should be valid at question level."""
+        benchmark = create_jsonld_benchmark(name="Test")
+        item = SchemaOrgDataFeedItem(
+            dateCreated=datetime.now().isoformat(),
+            dateModified=datetime.now().isoformat(),
+            item=SchemaOrgQuestion(
+                text="Test question?",
+                acceptedAnswer=SchemaOrgAnswer(text="Answer"),
+                hasPart=SchemaOrgSoftwareSourceCode(name="Answer", text="class Answer: pass"),
+                rating=[
+                    SchemaOrgRating(
+                        name="agentic_test",
+                        bestRating=1,
+                        worstRating=0,
+                        additionalType="karenina:QuestionSpecificAgenticRubricTrait",
+                    )
+                ],
+            ),
+        )
+        benchmark.dataFeedElement.append(item)
+
+        is_valid, message = validate_jsonld_benchmark(benchmark)
+
+        assert is_valid is True, f"Expected valid but got: {message}"
+
+    def test_question_specific_agentic_trait_rejected_at_dataset_level(self) -> None:
+        """QuestionSpecific traits should still be rejected at dataset level."""
+        benchmark = create_jsonld_benchmark(name="Test")
+        benchmark.rating = [
+            SchemaOrgRating(
+                name="agentic_test",
+                bestRating=1,
+                worstRating=0,
+                additionalType="karenina:QuestionSpecificAgenticRubricTrait",
+            )
+        ]
+
+        is_valid, message = validate_jsonld_benchmark(benchmark)
+
+        assert is_valid is False
+
+
+# =============================================================================
+# Issue 078: Strip function must cover literal-kind LLM traits
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestIssue078StripLiteralLLMTraits:
+    """strip_deep_judgment_config_from_checkpoint must cover literal-kind LLM traits."""
+
+    def test_strip_removes_dj_from_global_literal_llm_trait(self) -> None:
+        """DJ properties should be stripped from GlobalLLMRubricTrait ratings."""
+        checkpoint = create_jsonld_benchmark(name="Test")
+        checkpoint.rating = [
+            SchemaOrgRating(
+                name="literal_trait",
+                bestRating=2,
+                worstRating=0,
+                additionalType="karenina:GlobalLLMRubricTrait",
+                additionalProperty=[
+                    SchemaOrgPropertyValue(name="deep_judgment_enabled", value=True),
+                    SchemaOrgPropertyValue(name="deep_judgment_excerpt_enabled", value=True),
+                    SchemaOrgPropertyValue(name="kind", value="literal"),
+                    SchemaOrgPropertyValue(name="higher_is_better", value=True),
+                ],
+            )
+        ]
+
+        strip_deep_judgment_config_from_checkpoint(checkpoint)
+
+        remaining_names = [p.name for p in checkpoint.rating[0].additionalProperty]
+        assert "deep_judgment_enabled" not in remaining_names
+        assert "deep_judgment_excerpt_enabled" not in remaining_names
+        assert "kind" in remaining_names
+        assert "higher_is_better" in remaining_names
+
+    def test_strip_removes_dj_from_question_specific_literal_llm_trait(self) -> None:
+        """DJ properties should be stripped from QuestionSpecificLLMRubricTrait."""
+        checkpoint = create_jsonld_benchmark(name="Test")
+        item = SchemaOrgDataFeedItem(
+            dateCreated=datetime.now().isoformat(),
+            dateModified=datetime.now().isoformat(),
+            item=SchemaOrgQuestion(
+                text="Test?",
+                acceptedAnswer=SchemaOrgAnswer(text="A"),
+                hasPart=SchemaOrgSoftwareSourceCode(name="A", text="class A: pass"),
+                rating=[
+                    SchemaOrgRating(
+                        name="literal_trait",
+                        bestRating=2,
+                        worstRating=0,
+                        additionalType="karenina:QuestionSpecificLLMRubricTrait",
+                        additionalProperty=[
+                            SchemaOrgPropertyValue(name="deep_judgment_enabled", value=True),
+                            SchemaOrgPropertyValue(name="deep_judgment_excerpt_enabled", value=True),
+                            SchemaOrgPropertyValue(name="kind", value="literal"),
+                        ],
+                    )
+                ],
+            ),
+        )
+        checkpoint.dataFeedElement.append(item)
+
+        strip_deep_judgment_config_from_checkpoint(checkpoint)
+
+        remaining = [p.name for p in checkpoint.dataFeedElement[0].item.rating[0].additionalProperty]
+        assert "deep_judgment_enabled" not in remaining
+        assert "deep_judgment_excerpt_enabled" not in remaining
+
+
+# =============================================================================
+# Issue 172: DJ config defaults
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestIssue172DJConfigDefaults:
+    """Deep judgment config must be preserved by default and deserialization defaults must match model."""
+
+    def test_excerpt_enabled_defaults_to_true_when_not_in_checkpoint(self) -> None:
+        """When DJ properties are absent (old checkpoint), excerpt_enabled should be True (model default)."""
+        rating = SchemaOrgRating(
+            name="test_trait",
+            bestRating=1,
+            worstRating=0,
+            additionalType="karenina:GlobalRubricTrait",
+            additionalProperty=[
+                SchemaOrgPropertyValue(name="higher_is_better", value=True),
+            ],
+        )
+
+        trait = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(trait, LLMRubricTrait)
+        assert trait.deep_judgment_excerpt_enabled is True
+
+    def test_save_default_is_true(self) -> None:
+        """BenchmarkBase.save() should default to preserving DJ config."""
+        from karenina.benchmark.core.base import BenchmarkBase
+
+        sig = inspect.signature(BenchmarkBase.save)
+        default = sig.parameters["save_deep_judgment_config"].default
+        assert default is True, f"Expected default True, got {default}"
+
+
+# =============================================================================
+# Issue 079: Summary field must survive round-trip for all trait types
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestIssue079SummaryRoundTrip:
+    """Summary field must survive serialize/deserialize round-trip for all trait types."""
+
+    def test_llm_boolean_summary_roundtrip(self) -> None:
+        """LLMRubricTrait boolean summary survives round-trip."""
+        trait = LLMRubricTrait(
+            name="test_llm",
+            description="Test LLM trait",
+            summary="LLM summary text",
+            kind="boolean",
+        )
+
+        rating = convert_rubric_trait_to_rating(trait, "global")
+        restored = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(restored, LLMRubricTrait)
+        assert restored.summary == "LLM summary text"
+
+    def test_llm_score_summary_roundtrip(self) -> None:
+        """Score-kind LLMRubricTrait summary survives round-trip."""
+        trait = LLMRubricTrait(
+            name="test_score",
+            description="Score trait",
+            summary="Score summary",
+            kind="score",
+            min_score=1,
+            max_score=10,
+        )
+
+        rating = convert_rubric_trait_to_rating(trait, "global")
+        restored = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(restored, LLMRubricTrait)
+        assert restored.summary == "Score summary"
+
+    def test_llm_literal_summary_roundtrip(self) -> None:
+        """Literal-kind LLMRubricTrait summary survives round-trip."""
+        trait = LLMRubricTrait(
+            name="test_literal",
+            description="Literal trait",
+            summary="Literal summary",
+            kind="literal",
+            classes={"0": "bad", "1": "ok", "2": "good"},
+        )
+
+        rating = convert_rubric_trait_to_rating(trait, "global")
+        restored = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(restored, LLMRubricTrait)
+        assert restored.summary == "Literal summary"
+
+    def test_regex_summary_roundtrip(self) -> None:
+        """RegexRubricTrait summary survives round-trip."""
+        trait = RegexRubricTrait(
+            name="test_regex",
+            description="Test regex",
+            summary="Regex summary text",
+            pattern=r"\d+",
+        )
+
+        rating = convert_rubric_trait_to_rating(trait, "global")
+        restored = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(restored, RegexRubricTrait)
+        assert restored.summary == "Regex summary text"
+
+    def test_callable_summary_roundtrip(self) -> None:
+        """CallableRubricTrait summary survives round-trip."""
+        trait = CallableRubricTrait(
+            name="test_callable",
+            description="Test callable",
+            summary="Callable summary text",
+            kind="boolean",
+            callable_code=b"def evaluate(response): return True",
+        )
+
+        rating = convert_rubric_trait_to_rating(trait, "global")
+        restored = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(restored, CallableRubricTrait)
+        assert restored.summary == "Callable summary text"
+
+    def test_metric_summary_roundtrip(self) -> None:
+        """MetricRubricTrait summary survives round-trip."""
+        trait = MetricRubricTrait(
+            name="test_metric",
+            description="Test metric",
+            summary="Metric summary text",
+            metrics=["precision"],
+            tp_instructions=["Check for correct items"],
+        )
+
+        rating = convert_rubric_trait_to_rating(trait, "global")
+        restored = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(restored, MetricRubricTrait)
+        assert restored.summary == "Metric summary text"
+
+    def test_agentic_summary_roundtrip(self) -> None:
+        """AgenticRubricTrait summary survives round-trip."""
+        trait = AgenticRubricTrait(
+            name="test_agentic",
+            description="Test agentic",
+            summary="Agentic summary text",
+            kind="boolean",
+        )
+
+        rating = convert_rubric_trait_to_rating(trait, "global")
+        restored = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(restored, AgenticRubricTrait)
+        assert restored.summary == "Agentic summary text"
+
+    def test_none_summary_stays_none(self) -> None:
+        """Traits with summary=None should stay None after round-trip."""
+        trait = LLMRubricTrait(
+            name="no_summary",
+            description="No summary",
+            kind="boolean",
+        )
+
+        rating = convert_rubric_trait_to_rating(trait, "global")
+        restored = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(restored, LLMRubricTrait)
+        assert restored.summary is None
+
+
+# =============================================================================
+# Issue 173: min_score/max_score must survive round-trip
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestIssue173MinMaxScoreRoundTrip:
+    """min_score and max_score must survive serialize/deserialize round-trip."""
+
+    def test_llm_boolean_preserves_default_min_max(self) -> None:
+        """Boolean LLMRubricTrait should preserve Pydantic default min_score=1, max_score=5."""
+        trait = LLMRubricTrait(
+            name="bool_trait",
+            description="Boolean trait",
+            kind="boolean",
+        )
+        assert trait.min_score == 1
+        assert trait.max_score == 5
+
+        rating = convert_rubric_trait_to_rating(trait, "global")
+        restored = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(restored, LLMRubricTrait)
+        assert restored.min_score == 1, f"Expected min_score=1, got {restored.min_score}"
+        assert restored.max_score == 5, f"Expected max_score=5, got {restored.max_score}"
+
+    def test_llm_score_preserves_custom_min_max(self) -> None:
+        """Score LLMRubricTrait should preserve custom min_score/max_score."""
+        trait = LLMRubricTrait(
+            name="score_trait",
+            description="Score trait",
+            kind="score",
+            min_score=0,
+            max_score=10,
+        )
+
+        rating = convert_rubric_trait_to_rating(trait, "global")
+        restored = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(restored, LLMRubricTrait)
+        assert restored.min_score == 0
+        assert restored.max_score == 10
+
+    def test_agentic_boolean_preserves_default_min_max(self) -> None:
+        """Boolean AgenticRubricTrait should preserve Pydantic default min_score=1, max_score=5."""
+        trait = AgenticRubricTrait(
+            name="agentic_bool",
+            description="Agentic boolean",
+            kind="boolean",
+        )
+        assert trait.min_score == 1
+        assert trait.max_score == 5
+
+        rating = convert_rubric_trait_to_rating(trait, "global")
+        restored = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(restored, AgenticRubricTrait)
+        assert restored.min_score == 1, f"Expected min_score=1, got {restored.min_score}"
+        assert restored.max_score == 5, f"Expected max_score=5, got {restored.max_score}"
+
+    def test_agentic_score_preserves_custom_min_max(self) -> None:
+        """Score AgenticRubricTrait should preserve custom min_score/max_score."""
+        trait = AgenticRubricTrait(
+            name="agentic_score",
+            description="Agentic score",
+            kind="score",
+            min_score=0,
+            max_score=100,
+        )
+
+        rating = convert_rubric_trait_to_rating(trait, "global")
+        restored = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(restored, AgenticRubricTrait)
+        assert restored.min_score == 0
+        assert restored.max_score == 100
+
+    def test_llm_literal_min_max_auto_derived(self) -> None:
+        """Literal LLMRubricTrait min_score/max_score auto-derived from classes survives round-trip."""
+        trait = LLMRubricTrait(
+            name="literal_trait",
+            description="Literal trait",
+            kind="literal",
+            classes={"0": "bad", "1": "ok", "2": "good"},
+        )
+        assert trait.min_score == 0
+        assert trait.max_score == 2
+
+        rating = convert_rubric_trait_to_rating(trait, "global")
+        restored = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(restored, LLMRubricTrait)
+        assert restored.min_score == 0
+        assert restored.max_score == 2
+
+    def test_old_checkpoint_without_min_max_gets_pydantic_defaults(self) -> None:
+        """Old checkpoints without min_score/max_score get Pydantic defaults, not bestRating/worstRating."""
+        rating = SchemaOrgRating(
+            name="old_score_trait",
+            description="Old trait",
+            bestRating=10.0,
+            worstRating=1.0,
+            additionalType="karenina:GlobalRubricTrait",
+            additionalProperty=[
+                SchemaOrgPropertyValue(name="higher_is_better", value=True),
+            ],
+        )
+
+        restored = convert_rating_to_rubric_trait(rating)
+
+        assert isinstance(restored, LLMRubricTrait)
+        # No fallback to bestRating/worstRating; Pydantic defaults apply
+        assert restored.min_score == 1
+        assert restored.max_score == 5


### PR DESCRIPTION
## Summary

Checkpoint save/load silently lost trait fields across multiple independent bugs. This fixes all mechanical serialization issues in the trait converter layer:

- **Validation whitelist**: Add `GlobalAgenticRubricTrait` / `QuestionSpecificAgenticRubricTrait`; refactor inline lists into `VALID_GLOBAL_TRAIT_TYPES` and `VALID_QUESTION_TRAIT_TYPES` frozenset constants
- **Strip function coverage**: `strip_deep_judgment_config_from_checkpoint()` now covers literal-kind LLM trait types (`GlobalLLMRubricTrait`, `QuestionSpecificLLMRubricTrait`)
- **DJ config preservation**: `save()` defaults to `save_deep_judgment_config=True` (was `False`); deserialization default for `deep_judgment_excerpt_enabled` corrected to `True` to match model default
- **Summary field round-trip**: `summary` field preserved in all 5 per-type serializers and deserializers (was only preserved in DynamicRubric converter)
- **min/max score round-trip**: `min_score`/`max_score` stored as `additionalProperty` in LLM and agentic serializers; deserializers omit these when absent so Pydantic defaults apply (no `bestRating`/`worstRating` fallback)

## Test plan

- [x] 22 new tests covering all fixes (validation, strip function, DJ defaults, summary round-trip for all 5 trait types, min/max score round-trip for LLM and agentic traits)
- [x] 49 existing checkpoint tests pass with zero regressions
- [x] All pre-commit hooks pass (ruff, mypy, vulture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)