### PR TITLE
fix(scenario): harden scenario subsystem

### DIFF
--- a/src/karenina/benchmark/benchmark.py
+++ b/src/karenina/benchmark/benchmark.py
@@ -787,6 +787,8 @@ class Benchmark:
         manager = ScenarioManager()
         global_rubric = self._rubric_manager.get_global_rubric()
         all_results: list[VerificationResult] = []
+        all_scenario_results: list[Any] = []
+        all_errors: list[tuple[str, BaseException]] = []
 
         # Build the list of (scenario, answering_model, parsing_model) combos
         combos = [
@@ -797,7 +799,7 @@ class Benchmark:
         ]
 
         if async_enabled and len(combos) > 1:
-            all_results = self._run_scenario_parallel(
+            parallel_results, parallel_exec_results, parallel_errors = self._run_scenario_parallel(
                 manager=manager,
                 combos=combos,
                 config=config,
@@ -805,6 +807,9 @@ class Benchmark:
                 global_rubric=global_rubric,
                 progress_callback=progress_callback,
             )
+            all_results = parallel_results
+            all_scenario_results = parallel_exec_results
+            all_errors = parallel_errors
         else:
             for scenario_def, ans_model, parse_model in combos:
                 exec_result = manager.run(
@@ -817,8 +822,13 @@ class Benchmark:
                     progress_callback=progress_callback,
                 )
                 all_results.extend(exec_result.turn_results)
+                all_scenario_results.append(exec_result)
 
-        return VerificationResultSet(results=all_results)
+        return VerificationResultSet(
+            results=all_results,
+            scenario_results=all_scenario_results if all_scenario_results else None,
+            errors=all_errors if all_errors else None,
+        )
 
     def _run_scenario_parallel(
         self,
@@ -828,7 +838,7 @@ class Benchmark:
         run_name: str | None,
         global_rubric: "Rubric | None",
         progress_callback: Callable[..., None] | None,
-    ) -> list[VerificationResult]:
+    ) -> tuple[list[VerificationResult], list[Any], list[tuple[str, BaseException]]]:
         """Run scenario combinations in parallel via asyncio.gather.
 
         Args:
@@ -840,11 +850,11 @@ class Benchmark:
             progress_callback: Optional progress callback.
 
         Returns:
-            Flat list of all per-turn VerificationResults.
+            Tuple of (turn_results, scenario_exec_results, errors).
         """
         import asyncio
 
-        async def _gather() -> list[VerificationResult]:
+        async def _gather() -> tuple[list[VerificationResult], list[Any], list[tuple[str, BaseException]]]:
             coros = [
                 manager.arun(
                     scenario=scenario_def,
@@ -859,15 +869,22 @@ class Benchmark:
             ]
             exec_results = await asyncio.gather(*coros, return_exceptions=True)
             results: list[VerificationResult] = []
-            for er in exec_results:
+            scenario_exec_results: list[Any] = []
+            errors: list[tuple[str, BaseException]] = []
+            for i, er in enumerate(exec_results):
                 if isinstance(er, BaseException):
-                    logger.warning(
-                        "Scenario execution raised an exception: %s",
+                    combo = combos[i]
+                    desc = f"Scenario '{combo[0].name}' with {combo[1].model_name}/{combo[2].model_name}"
+                    logger.error(
+                        "Scenario execution failed: %s: %s",
+                        desc,
                         er,
                     )
+                    errors.append((desc, er))
                     continue
                 results.extend(er.turn_results)
-            return results
+                scenario_exec_results.append(er)
+            return results, scenario_exec_results, errors
 
         # If there is already a running event loop, run in a thread
         try:

--- a/src/karenina/benchmark/verification/stages/core/base.py
+++ b/src/karenina/benchmark/verification/stages/core/base.py
@@ -328,6 +328,9 @@ class VerificationContext:
 
     # Scenario
     scenario_turn: int | None = None
+    scenario_id: str | None = None
+    scenario_node: str | None = None
+    scenario_path: list[str] | None = None
 
     # Workspace
     question_workspace_path: str | None = None  # Raw relative path from Question

--- a/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
@@ -166,6 +166,10 @@ class FinalizeResultStage(BaseVerificationStage):
             result_id=result_id,
             run_name=context.run_name,
             replicate=context.replicate,
+            scenario_id=context.scenario_id,
+            scenario_node=context.scenario_node,
+            scenario_turn=context.scenario_turn,
+            scenario_path=context.scenario_path,
         )
 
         # Build structured trace_messages for storage

--- a/src/karenina/scenario/checkpoint.py
+++ b/src/karenina/scenario/checkpoint.py
@@ -150,6 +150,7 @@ def scenario_to_schema_org(defn: ScenarioDefinition) -> SchemaOrgScenario:
             modelOverride=(node.model_override.model_dump() if node.model_override else None),
             toolFilter=(node.tool_filter.model_dump() if node.tool_filter else None),
             stateUpdateSource=node.state_update_source,
+            questionData=node.question.model_dump(),
             metadata=node.metadata or {},
         )
 
@@ -289,11 +290,15 @@ def schema_org_to_scenario(schema: SchemaOrgScenario) -> ScenarioDefinition:
 
     nodes: dict[str, ScenarioNode] = {}
     for node_id, snode in schema.nodes.items():
-        q = Question(
-            question=snode.question.text,
-            raw_answer=snode.question.acceptedAnswer.text,
-            answer_template=snode.question.hasPart.text,
-        )
+        if snode.questionData is not None:
+            q = Question(**snode.questionData)
+        else:
+            # Backward compat: old checkpoints without questionData
+            q = Question(
+                question=snode.question.text,
+                raw_answer=snode.question.acceptedAnswer.text,
+                answer_template=snode.question.hasPart.text,
+            )
 
         state_update_fn = None
         if snode.stateUpdateSource:

--- a/src/karenina/scenario/manager.py
+++ b/src/karenina/scenario/manager.py
@@ -6,7 +6,9 @@ Peer to VerificationManager, following karenina's {Domain}Manager naming.
 from __future__ import annotations
 
 import contextlib
+import copy
 import logging
+import warnings
 from collections.abc import Callable
 from typing import Any, Literal
 
@@ -54,6 +56,15 @@ class ScenarioManager:
         Returns:
             ScenarioExecutionResult with all turn data.
         """
+        if config.evaluation_mode == "rubric_only":
+            warnings.warn(
+                "evaluation_mode='rubric_only' is not supported in scenarios. "
+                "Scenarios always auto-detect evaluation mode from rubric presence. "
+                "The rubric_only setting will be ignored.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         # Initialize state
         state = ScenarioState(
             turn=0,
@@ -86,7 +97,7 @@ class ScenarioManager:
             question_msg = Message.user(node.question.question)
             accumulated_messages.append(question_msg)
 
-            # Run the 14-stage verification pipeline for this turn
+            # Run the verification pipeline for this turn
             vr, trace_messages, parsed_answer, raw_response = self._run_turn(
                 node=node,
                 accumulated_messages=accumulated_messages,
@@ -96,6 +107,9 @@ class ScenarioManager:
                 run_name=run_name,
                 global_rubric=global_rubric,
                 turn_index=state.turn,
+                scenario_id=scenario.name,
+                scenario_node=state.current_node,
+                scenario_path=list(path),
             )
 
             # Grow accumulated history with trace
@@ -137,6 +151,7 @@ class ScenarioManager:
 
             # Run state_update if defined (opt-in custom state)
             if node.state_update is not None:
+                snapshot = copy.deepcopy(state.accumulated)
                 try:
                     state.accumulated = node.state_update(
                         state.accumulated,
@@ -144,10 +159,11 @@ class ScenarioManager:
                     )
                 except Exception:
                     logger.warning(
-                        "state_update for node '%s' raised an exception",
+                        "state_update for node '%s' raised; restoring from snapshot",
                         state.current_node,
                         exc_info=True,
                     )
+                    state.accumulated = snapshot
 
             # Update state
             state.turn += 1
@@ -236,6 +252,9 @@ class ScenarioManager:
         run_name: str | None,
         global_rubric: Rubric | None,
         turn_index: int = 0,
+        scenario_id: str | None = None,
+        scenario_node: str | None = None,
+        scenario_path: list[str] | None = None,
     ) -> tuple[VerificationResult, list[Message] | None, Any, str | None]:
         """Execute one turn of the verification pipeline.
 
@@ -285,6 +304,9 @@ class ScenarioManager:
             use_full_trace_for_template=config.use_full_trace_for_template,
             use_full_trace_for_rubric=config.use_full_trace_for_rubric,
             scenario_turn=turn_index,
+            scenario_id=scenario_id,
+            scenario_node=scenario_node,
+            scenario_path=scenario_path,
         )
 
         # Set conversation history artifact (the key integration point).

--- a/src/karenina/scenario/validation.py
+++ b/src/karenina/scenario/validation.py
@@ -7,6 +7,7 @@ a ScenarioDefinition: reachability, edge validity, and fallback coverage.
 from __future__ import annotations
 
 import logging
+import warnings
 from collections import defaultdict
 
 from karenina.schemas.scenario.types import END, ScenarioEdge, ScenarioNode
@@ -79,4 +80,17 @@ def validate_scenario_graph(
             raise ValueError(
                 f"Node '{source}' has conditional edges but no unconditional fallback. "
                 "Add an unconditional edge (when=None) as a default path."
+            )
+
+    # 4. Multiple unconditional edges check
+    for source, source_edges in edges_by_source.items():
+        unconditional = [e for e in source_edges if e.condition is None and e.condition_callable is None]
+        if len(unconditional) > 1:
+            targets = [e.target for e in unconditional]
+            warnings.warn(
+                f"Node '{source}' has {len(unconditional)} unconditional edges "
+                f"(targets: {targets}). Only the first will be used; "
+                f"the rest are silently ignored. This is likely a graph error.",
+                UserWarning,
+                stacklevel=2,
             )

--- a/src/karenina/schemas/checkpoint.py
+++ b/src/karenina/schemas/checkpoint.py
@@ -174,6 +174,7 @@ class SchemaOrgScenarioNode(BaseModel):
     modelOverride: dict[str, Any] | None = None
     toolFilter: dict[str, Any] | None = None
     stateUpdateSource: str | None = None
+    questionData: dict[str, Any] | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/src/karenina/schemas/results/verification_result_set.py
+++ b/src/karenina/schemas/results/verification_result_set.py
@@ -38,6 +38,14 @@ class VerificationResultSet(BaseModel):
     """
 
     results: list[VerificationResult] = Field(description="List of all verification results from the run")
+    scenario_results: list[Any] | None = Field(
+        default=None,
+        description="ScenarioExecutionResult objects from scenario verification runs",
+    )
+    errors: list[tuple[str, BaseException]] | None = Field(
+        default=None,
+        description="Errors from failed scenario executions as (description, exception) tuples",
+    )
 
     model_config = {"arbitrary_types_allowed": True}
 

--- a/tests/unit/scenario/test_checkpoint_question_roundtrip.py
+++ b/tests/unit/scenario/test_checkpoint_question_roundtrip.py
@@ -1,0 +1,79 @@
+"""Tests for issue 103: full Question serialization in scenario checkpoint."""
+
+import pytest
+
+from karenina.scenario.builder import Scenario
+from karenina.scenario.checkpoint import scenario_to_schema_org, schema_org_to_scenario
+from karenina.schemas.entities import Question
+from karenina.schemas.scenario.types import END
+
+
+def _make_rich_question() -> Question:
+    """Create a Question with many optional fields set."""
+    return Question(
+        question="What drug targets BRCA1?",
+        raw_answer="Olaparib",
+        answer_template="class Answer: pass",
+        keywords=["bio", "pharma", "oncology"],
+        few_shot_examples=[{"q": "What targets EGFR?", "a": "Erlotinib"}],
+        author={"name": "Test Author", "url": "https://example.com"},
+        sources=[{"name": "PubMed", "url": "https://pubmed.ncbi.nlm.nih.gov"}],
+        custom_metadata={"difficulty": "hard", "domain": "oncology"},
+        workspace_path="task_01",
+        answer_notes="Olaparib is a PARP inhibitor",
+    )
+
+
+def _build_scenario_with_rich_question():
+    """Build a scenario with a Question that has all optional fields."""
+    s = Scenario("rich_test")
+    s.add_node("ask", question=_make_rich_question())
+    s.add_edge("ask", END)
+    s.set_entry("ask")
+    return s.validate()
+
+
+@pytest.mark.unit
+class TestCheckpointQuestionRoundtrip:
+    """Issue 103: all Question fields should survive checkpoint round-trip."""
+
+    def test_rich_question_survives_roundtrip(self):
+        """Keywords, few_shot_examples, author, sources, custom_metadata, workspace_path survive."""
+        defn = _build_scenario_with_rich_question()
+        original_q = defn.nodes["ask"].question
+
+        # Round-trip through checkpoint
+        schema_org = scenario_to_schema_org(defn)
+        restored = schema_org_to_scenario(schema_org)
+        restored_q = restored.nodes["ask"].question
+
+        assert restored_q.question == original_q.question
+        assert restored_q.raw_answer == original_q.raw_answer
+        assert restored_q.answer_template == original_q.answer_template
+        assert restored_q.keywords == ["bio", "pharma", "oncology"]
+        assert restored_q.few_shot_examples == [{"q": "What targets EGFR?", "a": "Erlotinib"}]
+        assert restored_q.author == {"name": "Test Author", "url": "https://example.com"}
+        assert restored_q.sources == [{"name": "PubMed", "url": "https://pubmed.ncbi.nlm.nih.gov"}]
+        assert restored_q.custom_metadata == {"difficulty": "hard", "domain": "oncology"}
+        assert restored_q.workspace_path == "task_01"
+        assert restored_q.answer_notes == "Olaparib is a PARP inhibitor"
+
+    def test_backward_compat_without_question_data(self):
+        """Old checkpoints without questionData still deserialize (3-field fallback)."""
+        defn = _build_scenario_with_rich_question()
+        schema_org = scenario_to_schema_org(defn)
+
+        # Simulate old checkpoint: remove questionData from all nodes
+        for node in schema_org.nodes.values():
+            if hasattr(node, "questionData"):
+                node.questionData = None
+
+        restored = schema_org_to_scenario(schema_org)
+        restored_q = restored.nodes["ask"].question
+
+        # Basic fields should still work
+        assert restored_q.question == "What drug targets BRCA1?"
+        assert restored_q.raw_answer == "Olaparib"
+        assert restored_q.answer_template == "class Answer: pass"
+        # Rich fields lost in old format (this is expected)
+        assert restored_q.keywords == []  # default

--- a/tests/unit/scenario/test_evaluation_mode_warning.py
+++ b/tests/unit/scenario/test_evaluation_mode_warning.py
@@ -1,0 +1,113 @@
+"""Tests for issue 104: warn when evaluation_mode='rubric_only' in scenarios."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.scenario.builder import Scenario
+from karenina.scenario.manager import ScenarioManager
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.scenario.types import END
+from karenina.schemas.verification import VerificationConfig, VerificationResult
+from karenina.schemas.verification.result_components import VerificationResultMetadata, VerificationResultTemplate
+
+
+def _make_question(text: str = "What?"):
+    from karenina.schemas.entities import Question
+
+    return Question(question=text, raw_answer="Y", answer_template="class Answer: pass")
+
+
+def _make_model(name: str = "claude", provider: str = "anthropic") -> ModelConfig:
+    return ModelConfig(id=name, model_name=name, model_provider=provider)
+
+
+def _make_mock_vr() -> VerificationResult:
+    """Create a mock VerificationResult that causes the loop to exit."""
+    from karenina.schemas.verification.model_identity import ModelIdentity
+
+    identity = ModelIdentity.from_model_config(_make_model(), role="answering")
+    metadata = VerificationResultMetadata(
+        question_id="q1",
+        template_id="t1",
+        completed_without_errors=False,  # causes loop exit
+        question_text="What?",
+        answering=identity,
+        parsing=identity,
+        execution_time=0.0,
+        timestamp="2024-01-01",
+        result_id="r1",
+    )
+    template = VerificationResultTemplate(raw_llm_response="")
+    return VerificationResult(metadata=metadata, template=template)
+
+
+@pytest.mark.unit
+class TestEvaluationModeWarning:
+    """Issue 104: ScenarioManager should warn on rubric_only."""
+
+    def test_warns_on_rubric_only_evaluation_mode(self, monkeypatch):
+        """Passing evaluation_mode='rubric_only' triggers UserWarning."""
+        s = Scenario("test")
+        s.add_node("ask", question=_make_question())
+        s.add_edge("ask", END)
+        s.set_entry("ask")
+        defn = s.validate()
+
+        config = VerificationConfig(
+            answering_models=[_make_model()],
+            parsing_models=[_make_model()],
+            evaluation_mode="rubric_only",
+        )
+
+        mock_vr = _make_mock_vr()
+
+        # Monkeypatch _run_turn to avoid real pipeline execution
+        monkeypatch.setattr(
+            ScenarioManager,
+            "_run_turn",
+            lambda _self, **_kw: (mock_vr, None, None, None),
+        )
+
+        manager = ScenarioManager()
+        with pytest.warns(UserWarning, match="rubric_only"):
+            manager.run(
+                scenario=defn,
+                config=config,
+                base_answering_model=_make_model(),
+                base_parsing_model=_make_model(),
+            )
+
+    def test_no_warning_on_template_only(self, monkeypatch):
+        """evaluation_mode='template_only' does not trigger warning."""
+        import warnings
+
+        s = Scenario("test")
+        s.add_node("ask", question=_make_question())
+        s.add_edge("ask", END)
+        s.set_entry("ask")
+        defn = s.validate()
+
+        config = VerificationConfig(
+            answering_models=[_make_model()],
+            parsing_models=[_make_model()],
+            evaluation_mode="template_only",
+        )
+
+        mock_vr = _make_mock_vr()
+
+        monkeypatch.setattr(
+            ScenarioManager,
+            "_run_turn",
+            lambda _self, **_kw: (mock_vr, None, None, None),
+        )
+
+        manager = ScenarioManager()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            manager.run(
+                scenario=defn,
+                config=config,
+                base_answering_model=_make_model(),
+                base_parsing_model=_make_model(),
+            )

--- a/tests/unit/scenario/test_parallel_execution.py
+++ b/tests/unit/scenario/test_parallel_execution.py
@@ -157,9 +157,9 @@ class TestScenarioRunParallel:
 
         parallel_called = {"called": False}
 
-        def fake_parallel(_self, **kwargs: Any) -> list:
+        def fake_parallel(_self, **kwargs: Any) -> tuple:
             parallel_called["called"] = True
-            return []
+            return ([], [], [])
 
         monkeypatch.setattr(
             Benchmark,
@@ -216,7 +216,7 @@ class TestScenarioRunParallel:
             (bm.get_scenario("beta"), _make_model("claude"), _make_model("haiku")),
         ]
 
-        results = bm._run_scenario_parallel(
+        turn_results, exec_results, errors = bm._run_scenario_parallel(
             manager=manager,
             combos=combos,
             config=config,
@@ -227,7 +227,9 @@ class TestScenarioRunParallel:
 
         assert arun_count["n"] == 2
         # Both exec_results have empty turn_results, so total is 0
-        assert len(results) == 0
+        assert len(turn_results) == 0
+        assert len(exec_results) == 2
+        assert len(errors) == 0
 
     def test_parallel_exception_in_one_combo_does_not_block_others(self, monkeypatch):
         """If one arun raises, the others still complete successfully."""
@@ -256,8 +258,8 @@ class TestScenarioRunParallel:
             (bm.get_scenario("beta"), _make_model("claude"), _make_model("haiku")),
         ]
 
-        # Should not raise; the exception is logged and skipped
-        results = bm._run_scenario_parallel(
+        # Should not raise; the exception is logged and collected
+        turn_results, exec_results, errors = bm._run_scenario_parallel(
             manager=manager,
             combos=combos,
             config=config,
@@ -266,4 +268,6 @@ class TestScenarioRunParallel:
             progress_callback=None,
         )
         # Only the second combo succeeded (with empty turn_results)
-        assert isinstance(results, list)
+        assert isinstance(turn_results, list)
+        assert len(errors) == 1
+        assert "alpha" in errors[0][0]

--- a/tests/unit/scenario/test_result_preservation.py
+++ b/tests/unit/scenario/test_result_preservation.py
@@ -1,0 +1,134 @@
+"""Tests for issues 137 and 143: ScenarioExecutionResult preservation and error collection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from karenina.benchmark.benchmark import Benchmark
+from karenina.scenario.builder import Scenario
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.scenario.state import ScenarioExecutionResult, ScenarioState
+from karenina.schemas.scenario.types import END
+from karenina.schemas.verification import VerificationConfig
+
+
+def _make_question(text: str = "What is X?"):
+    from karenina.schemas.entities import Question
+
+    return Question(question=text, raw_answer="Y", answer_template="class Answer: pass")
+
+
+def _make_model(name: str = "claude", provider: str = "anthropic") -> ModelConfig:
+    return ModelConfig(id=name, model_name=name, model_provider=provider)
+
+
+def _make_exec_result(scenario_id: str = "test") -> ScenarioExecutionResult:
+    state = ScenarioState(
+        turn=1,
+        current_node="ask",
+        verify_result=True,
+        parsed={},
+        node_visits={"ask": 1},
+        history=[],
+        accumulated={},
+        node_results={},
+    )
+    return ScenarioExecutionResult(
+        scenario_id=scenario_id,
+        status="completed",
+        path=["ask"],
+        turn_count=1,
+        history=[],
+        turn_results=[],
+        final_state=state,
+        outcome_results={"passed": True},
+    )
+
+
+def _make_config() -> VerificationConfig:
+    return VerificationConfig(
+        answering_models=[_make_model()],
+        parsing_models=[_make_model("haiku")],
+    )
+
+
+@pytest.mark.unit
+class TestScenarioResultPreservation:
+    """Issue 137: VerificationResultSet should preserve ScenarioExecutionResult."""
+
+    def test_sync_path_preserves_scenario_results(self, monkeypatch):
+        """Sync scenario verification populates result_set.scenario_results."""
+        bm = Benchmark("scenario_bm")
+        s = Scenario("alpha")
+        s.add_node("ask", question=_make_question())
+        s.add_edge("ask", END)
+        s.set_entry("ask")
+        bm.add_scenario(s)
+
+        exec_result = _make_exec_result("alpha")
+
+        monkeypatch.setattr(
+            "karenina.scenario.manager.ScenarioManager.run",
+            lambda _self, **_kw: exec_result,
+        )
+
+        config = _make_config()
+        result_set = bm._run_scenario_verification(config=config)
+
+        assert result_set.scenario_results is not None
+        assert len(result_set.scenario_results) == 1
+        assert result_set.scenario_results[0].scenario_id == "alpha"
+        assert result_set.scenario_results[0].status == "completed"
+        assert result_set.scenario_results[0].outcome_results == {"passed": True}
+
+
+@pytest.mark.unit
+class TestParallelErrorCollection:
+    """Issue 143: parallel execution should collect errors, not drop them."""
+
+    def test_parallel_errors_collected_on_result_set(self, monkeypatch):
+        """Failed parallel executions are collected in result_set.errors."""
+        bm = Benchmark("scenario_bm")
+        s = Scenario("alpha")
+        s.add_node("ask", question=_make_question())
+        s.add_edge("ask", END)
+        s.set_entry("ask")
+        bm.add_scenario(s)
+
+        config = VerificationConfig(
+            answering_models=[_make_model("claude"), _make_model("gpt4")],
+            parsing_models=[_make_model("haiku")],
+        )
+
+        exec_ok = _make_exec_result("alpha")
+        err = RuntimeError("LLM provider down")
+
+        call_count = {"n": 0}
+
+        async def fake_arun(_self, **kwargs: Any) -> ScenarioExecutionResult:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return exec_ok
+            raise err
+
+        monkeypatch.setattr(
+            "karenina.scenario.manager.ScenarioManager.arun",
+            fake_arun,
+        )
+
+        result_set = bm._run_scenario_verification(
+            config=config,
+            async_enabled=True,
+        )
+
+        # Successful results still present
+        assert len(result_set.results) == 0  # exec_ok has empty turn_results
+
+        # Errors should be collected
+        assert result_set.errors is not None
+        assert len(result_set.errors) == 1
+        desc, exc = result_set.errors[0]
+        assert "alpha" in desc
+        assert isinstance(exc, RuntimeError)

--- a/tests/unit/scenario/test_scenario_metadata.py
+++ b/tests/unit/scenario/test_scenario_metadata.py
@@ -1,0 +1,83 @@
+"""Tests for issue 163: scenario metadata plumbing to VerificationResult."""
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import VerificationContext
+from karenina.benchmark.verification.stages.pipeline.finalize_result import FinalizeResultStage
+from karenina.schemas.config import ModelConfig
+
+
+def _make_model(name: str = "test", provider: str = "test") -> ModelConfig:
+    return ModelConfig(id=name, model_name=name, model_provider=provider)
+
+
+@pytest.mark.unit
+class TestScenarioMetadataPlumbing:
+    """Issue 163: scenario fields must flow from VerificationContext to VerificationResultMetadata."""
+
+    def test_verification_context_accepts_scenario_fields(self):
+        """VerificationContext can be constructed with scenario_id, scenario_node, scenario_path."""
+        ctx = VerificationContext(
+            question_id="q1",
+            template_id="t1",
+            question_text="What is X?",
+            template_code="",
+            answering_model=_make_model(),
+            parsing_model=_make_model(),
+            scenario_id="my_scenario",
+            scenario_node="ask",
+            scenario_turn=0,
+            scenario_path=["ask"],
+        )
+        assert ctx.scenario_id == "my_scenario"
+        assert ctx.scenario_node == "ask"
+        assert ctx.scenario_turn == 0
+        assert ctx.scenario_path == ["ask"]
+
+    def test_finalize_transfers_scenario_metadata(self):
+        """FinalizeResultStage transfers scenario fields to VerificationResultMetadata."""
+        ctx = VerificationContext(
+            question_id="q1",
+            template_id="t1",
+            question_text="What is X?",
+            template_code="",
+            answering_model=_make_model(),
+            parsing_model=_make_model(),
+            scenario_id="my_scenario",
+            scenario_node="ask",
+            scenario_turn=0,
+            scenario_path=["ask"],
+        )
+        ctx.set_result_field("timestamp", "2024-01-01T00:00:00")
+        ctx.set_result_field("execution_time", 1.0)
+
+        stage = FinalizeResultStage()
+        stage.execute(ctx)
+
+        result = ctx.get_artifact("final_result")
+        assert result.metadata.scenario_id == "my_scenario"
+        assert result.metadata.scenario_node == "ask"
+        assert result.metadata.scenario_turn == 0
+        assert result.metadata.scenario_path == ["ask"]
+
+    def test_scenario_fields_default_to_none(self):
+        """Non-scenario contexts have None for all scenario fields."""
+        ctx = VerificationContext(
+            question_id="q1",
+            template_id="t1",
+            question_text="What is X?",
+            template_code="",
+            answering_model=_make_model(),
+            parsing_model=_make_model(),
+        )
+        ctx.set_result_field("timestamp", "2024-01-01T00:00:00")
+        ctx.set_result_field("execution_time", 1.0)
+
+        stage = FinalizeResultStage()
+        stage.execute(ctx)
+
+        result = ctx.get_artifact("final_result")
+        assert result.metadata.scenario_id is None
+        assert result.metadata.scenario_node is None
+        assert result.metadata.scenario_turn is None
+        assert result.metadata.scenario_path is None

--- a/tests/unit/scenario/test_state_update_safety.py
+++ b/tests/unit/scenario/test_state_update_safety.py
@@ -1,0 +1,93 @@
+"""Tests for issue 106: state_update snapshot/restore on failure."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.scenario.builder import Scenario
+from karenina.scenario.manager import ScenarioManager
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.scenario.types import END
+from karenina.schemas.verification import VerificationConfig, VerificationResult
+from karenina.schemas.verification.result_components import VerificationResultMetadata, VerificationResultTemplate
+
+
+def _make_question(text: str = "What?"):
+    from karenina.schemas.entities import Question
+
+    return Question(question=text, raw_answer="Y", answer_template="class Answer: pass")
+
+
+def _make_model(name: str = "claude", provider: str = "anthropic") -> ModelConfig:
+    return ModelConfig(id=name, model_name=name, model_provider=provider)
+
+
+def _make_mock_vr(completed: bool = True) -> VerificationResult:
+    """Create a mock VerificationResult."""
+    from karenina.schemas.verification.model_identity import ModelIdentity
+
+    identity = ModelIdentity.from_model_config(_make_model(), role="answering")
+    metadata = VerificationResultMetadata(
+        question_id="q1",
+        template_id="t1",
+        completed_without_errors=completed,
+        question_text="What?",
+        answering=identity,
+        parsing=identity,
+        execution_time=0.0,
+        timestamp="2024-01-01",
+        result_id="r1",
+    )
+    template = VerificationResultTemplate(raw_llm_response="test response")
+    return VerificationResult(metadata=metadata, template=template)
+
+
+@pytest.mark.unit
+class TestStateUpdateSafety:
+    """Issue 106: snapshot/restore state.accumulated on state_update failure."""
+
+    def test_corrupted_state_is_restored_on_state_update_failure(self, monkeypatch):
+        """state_update that mutates in-place then raises should not corrupt state."""
+
+        def bad_state_update(acc, parsed):
+            acc["corrupted_key"] = "bad_value"
+            raise ValueError("intentional failure after in-place mutation")
+
+        s = Scenario("test")
+        s.add_node("ask", question=_make_question())
+        s.add_edge("ask", END)
+        s.set_entry("ask")
+        defn = s.validate()
+
+        # Inject the callable directly onto the node (bypassing builder string compilation)
+        defn.nodes["ask"].state_update = bad_state_update
+
+        config = VerificationConfig(
+            answering_models=[_make_model()],
+            parsing_models=[_make_model()],
+        )
+
+        # Mock pipeline to return a successful VR (so state_update runs)
+        # then exit on next iteration via turn limit
+        mock_vr = _make_mock_vr(completed=True)
+        monkeypatch.setattr(
+            ScenarioManager,
+            "_run_turn",
+            lambda _self, **_kw: (mock_vr, None, None, None),
+        )
+
+        manager = ScenarioManager()
+        # Set turn limit to 1 so we exit after one turn
+        config_dict = config.model_dump()
+        config_dict["scenario_turn_limit"] = 1
+        limited_config = VerificationConfig(**config_dict)
+
+        result = manager.run(
+            scenario=defn,
+            config=limited_config,
+            base_answering_model=_make_model(),
+            base_parsing_model=_make_model(),
+        )
+
+        # The key assertion: corrupted_key should NOT be in accumulated
+        assert "corrupted_key" not in result.final_state.accumulated

--- a/tests/unit/scenario/test_validation_warnings.py
+++ b/tests/unit/scenario/test_validation_warnings.py
@@ -1,0 +1,57 @@
+"""Tests for scenario graph validation warnings."""
+
+import warnings
+
+import pytest
+
+from karenina.schemas.entities import Question
+from karenina.schemas.scenario.types import END, ScenarioEdge, ScenarioNode
+
+
+def _make_question(text: str = "What?") -> Question:
+    return Question(question=text, raw_answer="Y", answer_template="class Answer: pass")
+
+
+def _make_node(node_id: str, text: str = "What?") -> ScenarioNode:
+    return ScenarioNode(node_id=node_id, question=_make_question(text))
+
+
+@pytest.mark.unit
+class TestMultipleUnconditionalEdgesWarning:
+    """Issue 105: warn when a node has multiple unconditional edges."""
+
+    def test_warns_on_multiple_unconditional_edges_from_same_source(self):
+        """Two unconditional edges from same source triggers UserWarning."""
+        from karenina.scenario.validation import validate_scenario_graph
+
+        nodes = {
+            "ask": _make_node("ask", "Q1?"),
+            "path_a": _make_node("path_a", "Q2?"),
+            "path_b": _make_node("path_b", "Q3?"),
+        }
+        edges = [
+            ScenarioEdge(source="ask", target="path_a"),  # unconditional
+            ScenarioEdge(source="ask", target="path_b"),  # unconditional (duplicate)
+            ScenarioEdge(source="path_a", target=END),
+            ScenarioEdge(source="path_b", target=END),
+        ]
+
+        with pytest.warns(UserWarning, match="ask"):
+            validate_scenario_graph(nodes, edges, entry_node="ask")
+
+    def test_no_warning_on_single_unconditional_edge(self):
+        """Single unconditional edge does not trigger warning."""
+        from karenina.scenario.validation import validate_scenario_graph
+
+        nodes = {
+            "ask": _make_node("ask", "Q1?"),
+            "confirm": _make_node("confirm", "Q2?"),
+        }
+        edges = [
+            ScenarioEdge(source="ask", target="confirm"),  # single unconditional
+            ScenarioEdge(source="confirm", target=END),
+        ]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            validate_scenario_graph(nodes, edges, entry_node="ask")


### PR DESCRIPTION
## Summary

- **Checkpoint round-trip**: full Question serialization via `questionData` field on `SchemaOrgScenarioNode`, with backward compat fallback for old checkpoints
- **Scenario metadata plumbing**: `scenario_id`, `scenario_node`, `scenario_path` added to `VerificationContext`, set in `ScenarioManager._run_turn()`, transferred by `FinalizeResultStage` to `VerificationResultMetadata`
- **Result preservation**: `VerificationResultSet.scenario_results` preserves `ScenarioExecutionResult` objects alongside per-turn results
- **Error surfacing**: parallel execution failures collected as `(description, exception)` tuples on `VerificationResultSet.errors` with ERROR-level logging (previously silently dropped with WARNING)
- **State safety**: `state_update` uses `copy.deepcopy` snapshot/restore to prevent partial mutation on failure
- **Validation**: `validate_scenario_graph()` warns on redundant unconditional edges from same source
- **Config warning**: `ScenarioManager.run()` warns when `evaluation_mode='rubric_only'` is passed (unsupported in scenarios)
- **Comment fix**: removed stale "14-stage" pipeline reference

## Test plan

- [x] 12 new unit tests across 6 test files covering all fixes
- [x] 215 scenario unit tests passing (0 regressions)
- [x] 3587 total tests passing across full suite
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy, vulture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)