### PR TITLE
fix: type, serialization, and validation one-liners (19 issues)

### DIFF
--- a/src/karenina/benchmark/core/exports.py
+++ b/src/karenina/benchmark/core/exports.py
@@ -188,7 +188,7 @@ class ExportManager:
             "creator": self.base.creator,
             "created_at": self.base.created_at,
             "modified_at": self.base.modified_at,
-            "question_count": float(self.base.question_count),
+            "question_count": self.base.question_count,
             "finished_count": self.base.finished_count,
             "has_template_count": has_template_count,
             "has_rubric_count": has_rubric_count,

--- a/src/karenina/benchmark/core/results_io.py
+++ b/src/karenina/benchmark/core/results_io.py
@@ -162,55 +162,53 @@ class ResultsIOManager:
 
         return [
             index,  # row_index
-            ResultsIOManager._escape_csv_field(result.metadata.question_id),
-            ResultsIOManager._escape_csv_field(result.metadata.question_text),
-            ResultsIOManager._escape_csv_field(result.template.raw_llm_response if result.template else ""),
-            ResultsIOManager._escape_csv_field(
+            result.metadata.question_id,
+            result.metadata.question_text,
+            result.template.raw_llm_response if result.template else "",
+            (
                 json.dumps(result.template.parsed_gt_response)
                 if result.template and result.template.parsed_gt_response
                 else ""
             ),
-            ResultsIOManager._escape_csv_field(
+            (
                 json.dumps(result.template.parsed_llm_response)
                 if result.template and result.template.parsed_llm_response
                 else ""
             ),
-            ResultsIOManager._escape_csv_field(
+            (
                 json.dumps(result.template.verify_result)
                 if result.template and result.template.verify_result is not None
                 else "N/A"
             ),
-            ResultsIOManager._escape_csv_field(
+            (
                 json.dumps(result.template.verify_granular_result)
                 if result.template and result.template.verify_granular_result is not None
                 else "N/A"
             ),
-            *[ResultsIOManager._escape_csv_field(value) for value in global_rubric_values],
+            *global_rubric_values,
             *([question_specific_rubrics_value] if question_specific_traits else []),
-            ResultsIOManager._escape_csv_field(rubric_summary),
-            ResultsIOManager._escape_csv_field(result.metadata.answering_model),
-            ResultsIOManager._escape_csv_field(result.metadata.parsing_model),
-            ResultsIOManager._escape_csv_field(result.metadata.replicate or ""),
-            ResultsIOManager._escape_csv_field(result.metadata.answering_system_prompt or ""),
-            ResultsIOManager._escape_csv_field(result.metadata.parsing_system_prompt or ""),
-            ResultsIOManager._escape_csv_field(
+            rubric_summary,
+            result.metadata.answering_model,
+            result.metadata.parsing_model,
+            result.metadata.replicate or "",
+            result.metadata.answering_system_prompt or "",
+            result.metadata.parsing_system_prompt or "",
+            (
                 "abstained"
                 if result.template
                 and result.template.abstention_detected
                 and result.template.abstention_override_applied
                 else result.metadata.completed_without_errors
             ),
-            ResultsIOManager._escape_csv_field(result.metadata.error or ""),
-            ResultsIOManager._escape_csv_field(result.metadata.execution_time),
-            ResultsIOManager._escape_csv_field(result.metadata.timestamp),
-            ResultsIOManager._escape_csv_field(result.metadata.run_name or ""),
+            result.metadata.error or "",
+            result.metadata.execution_time,
+            result.metadata.timestamp,
+            result.metadata.run_name or "",
             # Embedding check fields
-            ResultsIOManager._escape_csv_field(result.template.embedding_check_performed if result.template else False),
-            ResultsIOManager._escape_csv_field(result.template.embedding_similarity_score if result.template else ""),
-            ResultsIOManager._escape_csv_field(
-                result.template.embedding_override_applied if result.template else False
-            ),
-            ResultsIOManager._escape_csv_field(result.template.embedding_model_used if result.template else ""),
+            result.template.embedding_check_performed if result.template else False,
+            result.template.embedding_similarity_score if result.template else "",
+            result.template.embedding_override_applied if result.template else False,
+            result.template.embedding_model_used if result.template else "",
         ]
 
     @staticmethod

--- a/src/karenina/benchmark/core/rubrics.py
+++ b/src/karenina/benchmark/core/rubrics.py
@@ -256,8 +256,18 @@ class RubricManager:
 
         # Check question-specific rubrics
         for q_id, q_data in self.base._questions_cache.items():
-            if q_data.get("question_rubric"):
-                for trait in q_data["question_rubric"]:
+            question_rubric = q_data.get("question_rubric")
+            if question_rubric:
+                # Collect traits: dict format (keyed by trait type) or flat list
+                if isinstance(question_rubric, dict):
+                    traits_to_validate = []
+                    for trait_list in question_rubric.values():
+                        if isinstance(trait_list, list):
+                            traits_to_validate.extend(trait_list)
+                else:
+                    traits_to_validate = list(question_rubric)
+
+                for trait in traits_to_validate:
                     if not trait.name or not trait.description:
                         errors.append(f"Question {q_id} rubric trait missing name or description")
                     # Check score fields for LLM traits

--- a/src/karenina/benchmark/task_eval/task_eval.py
+++ b/src/karenina/benchmark/task_eval/task_eval.py
@@ -146,7 +146,11 @@ class TaskEval:
         """
         from karenina.ports.messages import Message
 
-        trace_messages = [Message.assistant(messages)] if isinstance(messages, str) else messages
+        if isinstance(messages, str):
+            messages = messages.removeprefix("--- AI Message ---\n")
+            trace_messages = [Message.assistant(messages)]
+        else:
+            trace_messages = messages
 
         log_event = LogEvent(
             level=level,

--- a/src/karenina/benchmark/verification/evaluators/template/evaluator.py
+++ b/src/karenina/benchmark/verification/evaluators/template/evaluator.py
@@ -194,7 +194,15 @@ class TemplateEvaluator:
         result = FieldVerificationResult()
 
         try:
-            result.success = parsed_answer.verify()
+            verify_return = parsed_answer.verify()
+            if not isinstance(verify_return, bool):
+                logger.warning(
+                    "verify() returned non-bool value %r (type %s); "
+                    "expected bool. Truthy non-bool values may mask bugs.",
+                    verify_return,
+                    type(verify_return).__name__,
+                )
+            result.success = verify_return
         except Exception as e:
             result.error = f"Field verification failed: {e}"
             logger.error(result.error)

--- a/src/karenina/benchmark/verification/stages/core/orchestrator.py
+++ b/src/karenina/benchmark/verification/stages/core/orchestrator.py
@@ -139,14 +139,22 @@ class StageOrchestrator:
             if abstention_enabled:
                 stages.append(AbstentionCheckStage())
 
+            # Sufficiency check is not applicable in rubric_only mode (no template parsing)
+            if sufficiency_enabled:
+                logger.info(
+                    "sufficiency_enabled=True ignored in rubric_only mode: "
+                    "sufficiency check requires template parsing which is skipped"
+                )
+
             # Rubric evaluation (required for rubric_only mode)
             _rubric_has_non_agentic = rubric and (
                 rubric.llm_traits or rubric.regex_traits or rubric.callable_traits or rubric.metric_traits
             )
             if _rubric_has_non_agentic or _dynamic_has_non_agentic:
                 stages.append(RubricEvaluationStage())
-                # Deep judgment rubric auto-fail (if deep judgment traits were evaluated)
-                stages.append(DeepJudgmentRubricAutoFailStage())
+                # Deep judgment rubric auto-fail (only when deep judgment is enabled)
+                if deep_judgment_enabled:
+                    stages.append(DeepJudgmentRubricAutoFailStage())
 
             # Stage 11b: Agentic rubric evaluation
             if (rubric and rubric.agentic_traits) or _dynamic_has_agentic:
@@ -198,8 +206,9 @@ class StageOrchestrator:
             )
             if evaluation_mode == "template_and_rubric" and (_rubric_has_non_agentic or _dynamic_has_non_agentic):
                 stages.append(RubricEvaluationStage())
-                # Deep judgment rubric auto-fail (if deep judgment traits were evaluated)
-                stages.append(DeepJudgmentRubricAutoFailStage())
+                # Deep judgment rubric auto-fail (only when deep judgment is enabled)
+                if deep_judgment_enabled:
+                    stages.append(DeepJudgmentRubricAutoFailStage())
 
             # Stage 11b: Agentic rubric evaluation (after Stage 11)
             if evaluation_mode == "template_and_rubric" and (

--- a/src/karenina/benchmark/verification/stages/pipeline/verify_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/verify_template.py
@@ -135,7 +135,11 @@ class VerifyTemplateStage(BaseVerificationStage):
 
                 # Field verification: call verify() if defined, else True (no fields)
                 if hasattr(parsed_answer, "verify") and callable(parsed_answer.verify):
-                    field_verification_result = parsed_answer.verify()
+                    try:
+                        field_verification_result = parsed_answer.verify()
+                    except Exception as e:
+                        logger.warning("Field verification error (regex-only): %s", e)
+                        field_verification_result = False
                 else:
                     field_verification_result = True
 

--- a/src/karenina/benchmark/verification/utils/template_parsing_helpers.py
+++ b/src/karenina/benchmark/verification/utils/template_parsing_helpers.py
@@ -5,8 +5,8 @@ evaluators/template_parsing.py which is used by TemplateEvaluator.
 For new code, prefer using TemplateEvaluator for template parsing operations.
 """
 
+import json
 import logging
-import re
 from typing import Any, get_args, get_origin
 
 from karenina.schemas.entities import BaseAnswer
@@ -116,16 +116,23 @@ def _extract_attribute_descriptions(json_schema: str, attribute_names: list[str]
         {"drug_target": "The target protein"}
     """
     attribute_descriptions = {}
+
+    # Parse the JSON schema once, falling back to per-attribute fallbacks on error
+    try:
+        schema_dict = json.loads(json_schema)
+        properties = schema_dict.get("properties", {})
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Failed to parse JSON schema, using fallback descriptions")
+        properties = {}
+
     for attr in attribute_names:
-        # Extract description from JSON schema using regex
-        # Pattern matches: "attr_name": {..., "description": "text", ...}
-        pattern = rf'"{attr}":\s*{{[^}}]*"description":\s*"([^"]*)"'
-        match = re.search(pattern, json_schema)
-        if match:
-            attribute_descriptions[attr] = match.group(1)
+        prop = properties.get(attr, {})
+        description = prop.get("description") if isinstance(prop, dict) else None
+        if description:
+            attribute_descriptions[attr] = description
         else:
-            # Fallback if description not found
             attribute_descriptions[attr] = f"Evidence for {attr}"
+
     return attribute_descriptions
 
 
@@ -191,10 +198,11 @@ def format_excerpts_for_reasoning(excerpts: dict[str, list[dict[str, Any]]]) -> 
                 lines.append("    Search Results:")
 
                 if not isinstance(search_results, list):
-                    raise TypeError(
-                        f"Unsupported search_results format: {type(search_results).__name__}. "
-                        "Expected list of structured results."
+                    logger.warning(
+                        "Unsupported search_results format: %s. Expected list of structured results.",
+                        type(search_results).__name__,
                     )
+                    continue
                 formatted = _format_search_results_for_llm(search_results)
                 search_lines = formatted.split("\n")
 

--- a/src/karenina/ports/messages.py
+++ b/src/karenina/ports/messages.py
@@ -308,9 +308,9 @@ class Message:
                 )
             )
 
-        # Add text content if present
+        # Add text content if present (skip for tool messages to avoid duplication)
         text = data.get("content", "")
-        if text:
+        if text and "tool_result" not in data:
             content_blocks.append(TextContent(text=text))
 
         # Add tool calls if present

--- a/src/karenina/schemas/entities/answer.py
+++ b/src/karenina/schemas/entities/answer.py
@@ -236,8 +236,21 @@ class BaseAnswer(BaseModel):
                 result[name] = meta
         return result
 
+    def _clear_verification_cache(self) -> None:
+        """Clear the cached _field_results, forcing recomputation on next call.
+
+        Call this after mutating field values if you need _compute_field_results()
+        to reflect the updated state.
+        """
+        self.__dict__.pop("_field_results", None)
+
     def _compute_field_results(self) -> dict[str, bool]:
         """Evaluate all VerifiedField checks and cache in _field_results.
+
+        Results are cached in self.__dict__["_field_results"] after the first
+        call. Subsequent calls return the cached value without recomputation.
+        Call _clear_verification_cache() to invalidate the cache after
+        mutating field values.
 
         For TracePrimitive fields, reads self._raw_trace and compares
         check_trace() result against bool(meta.ground_truth). For parsed

--- a/src/karenina/schemas/primitives/comparisons.py
+++ b/src/karenina/schemas/primitives/comparisons.py
@@ -117,7 +117,11 @@ class RegexMatch(VerificationPrimitive):
     def check(self, extracted: Any, _expected: Any) -> bool:
         flag_value = 0
         for f in self.flags:
-            flag_value |= getattr(re, f, 0)
+            resolved = getattr(re, f, None)
+            if resolved is None:
+                logger.warning("Unknown regex flag %r, ignoring", f)
+            else:
+                flag_value |= resolved
         return bool(re.search(self.pattern, str(extracted), flag_value))
 
 

--- a/src/karenina/schemas/results/verification_result_set.py
+++ b/src/karenina/schemas/results/verification_result_set.py
@@ -474,9 +474,23 @@ class VerificationResultSet(BaseModel):
             "total_execution_time": total_execution_time,
         }
 
-    def _calculate_token_stats(
-        self, num_with_judgment: int
-    ) -> tuple[dict[str, Any], dict[tuple[str, str, tuple[str, ...] | None], dict[str, int]]]:
+    @staticmethod
+    def _combo_key_to_string(combo_key: tuple[str, str, tuple[str, ...] | None]) -> str:
+        """Convert a model combo tuple key to a pipe-delimited string for JSON serialization.
+
+        Args:
+            combo_key: Tuple of (answering_model, parsing_model, mcp_servers_tuple_or_none)
+
+        Returns:
+            String in the format "answering_model | parsing_model" or
+            "answering_model | parsing_model | mcp1, mcp2" if MCP servers are present.
+        """
+        answering, parsing, mcp_tuple = combo_key
+        if mcp_tuple:
+            return f"{answering} | {parsing} | {', '.join(mcp_tuple)}"
+        return f"{answering} | {parsing}"
+
+    def _calculate_token_stats(self, num_with_judgment: int) -> tuple[dict[str, Any], dict[str, dict[str, int]]]:
         """Calculate token usage statistics.
 
         Returns:
@@ -651,7 +665,7 @@ class VerificationResultSet(BaseModel):
                         combo_token_stats[combo_key]["output"] += int(dj_out)
 
         tokens_by_combo = {
-            combo_key: {
+            self._combo_key_to_string(combo_key): {
                 "input": stats["input"],
                 "output": stats["output"],
                 "total": stats["input"] + stats["output"],
@@ -691,7 +705,7 @@ class VerificationResultSet(BaseModel):
 
     def _calculate_completion_by_combo(
         self,
-    ) -> dict[tuple[str, str, tuple[str, ...] | None], dict[str, Any]]:
+    ) -> dict[str, dict[str, Any]]:
         """Calculate completion status by model combination."""
         from collections import defaultdict
 
@@ -713,7 +727,7 @@ class VerificationResultSet(BaseModel):
                 combo_stats[combo_key]["completed"] += 1
 
         return {
-            combo_key: {
+            self._combo_key_to_string(combo_key): {
                 "total": stats["total"],
                 "completed": stats["completed"],
                 "completion_pct": (stats["completed"] / stats["total"] * 100) if stats["total"] > 0 else 0,
@@ -750,8 +764,8 @@ class VerificationResultSet(BaseModel):
                         trait_questions[trait_name].add(q_id)
                         trait_types[trait_name] = "callable"
 
-                if result.rubric.metric_trait_confusion_lists:
-                    for trait_name in result.rubric.metric_trait_confusion_lists:
+                if result.rubric.metric_trait_scores:
+                    for trait_name in result.rubric.metric_trait_scores:
                         trait_questions[trait_name].add(q_id)
                         trait_types[trait_name] = "metric"
 
@@ -785,8 +799,8 @@ class VerificationResultSet(BaseModel):
                         else:
                             qs_callable += 1
 
-                if result.rubric.metric_trait_confusion_lists:
-                    for trait in result.rubric.metric_trait_confusion_lists:
+                if result.rubric.metric_trait_scores:
+                    for trait in result.rubric.metric_trait_scores:
                         if trait in global_traits:
                             global_metric += 1
                         else:
@@ -809,7 +823,7 @@ class VerificationResultSet(BaseModel):
 
     def _calculate_template_pass_rates(
         self, num_with_template: int
-    ) -> tuple[dict[tuple[str, str, tuple[str, ...] | None], dict[str, Any]] | None, dict[str, Any] | None]:
+    ) -> tuple[dict[str, dict[str, Any]] | None, dict[str, Any] | None]:
         """Calculate template pass rates by combo and overall.
 
         Returns:
@@ -835,7 +849,7 @@ class VerificationResultSet(BaseModel):
                     combo_pass_stats[combo_key]["passed"] += 1
 
         template_pass_by_combo = {
-            combo_key: {
+            self._combo_key_to_string(combo_key): {
                 "total": stats["total"],
                 "passed": stats["passed"],
                 "pass_pct": (stats["passed"] / stats["total"] * 100) if stats["total"] > 0 else 0,

--- a/src/karenina/schemas/verification/config.py
+++ b/src/karenina/schemas/verification/config.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, computed_field
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
 
 from ..config.models import (
     FewShotConfig,
@@ -240,6 +240,24 @@ class VerificationConfig(BaseModel):
     # Scenario execution settings
     scenario_turn_limit: int = Field(default=20, ge=1)  # Max turns before forced termination in scenario execution
 
+    @field_validator("db_config", mode="before")
+    @classmethod
+    def _validate_db_config(cls, v: Any) -> Any:
+        """Validate that db_config is a DBConfig instance or None.
+
+        Uses runtime import to avoid circular dependency with karenina.storage.
+
+        Raises:
+            TypeError: If value is not None and not a DBConfig instance.
+        """
+        if v is None:
+            return v
+        from karenina.storage.db_config import DBConfig
+
+        if not isinstance(v, DBConfig):
+            raise TypeError(f"db_config must be a DBConfig instance or None, got {type(v).__name__}")
+        return v
+
     def __init__(self, **data: Any) -> None:
         """
         Initialize with environment variable support and default system prompts.
@@ -285,20 +303,31 @@ class VerificationConfig(BaseModel):
                     data["async_max_workers"] = int(env_val)
             # else: let Pydantic use field default (DEFAULT_ASYNC_MAX_WORKERS)
 
-        # Apply default system prompts to models that don't have one
+        # Apply default system prompts to models that don't have one.
+        # Deep-copy ModelConfig instances to avoid mutating shared objects.
         if "answering_models" in data:
-            for model in data["answering_models"]:
-                if isinstance(model, ModelConfig) and not model.system_prompt:
-                    model.system_prompt = DEFAULT_ANSWERING_SYSTEM_PROMPT
-                elif isinstance(model, dict) and not model.get("system_prompt"):
-                    model["system_prompt"] = DEFAULT_ANSWERING_SYSTEM_PROMPT
+            data["answering_models"] = [
+                m.model_copy(update={"system_prompt": DEFAULT_ANSWERING_SYSTEM_PROMPT})
+                if isinstance(m, ModelConfig) and not m.system_prompt
+                else (
+                    {**m, "system_prompt": DEFAULT_ANSWERING_SYSTEM_PROMPT}
+                    if isinstance(m, dict) and not m.get("system_prompt")
+                    else m
+                )
+                for m in data["answering_models"]
+            ]
 
         if "parsing_models" in data:
-            for model in data["parsing_models"]:
-                if isinstance(model, ModelConfig) and not model.system_prompt:
-                    model.system_prompt = DEFAULT_PARSING_SYSTEM_PROMPT
-                elif isinstance(model, dict) and not model.get("system_prompt"):
-                    model["system_prompt"] = DEFAULT_PARSING_SYSTEM_PROMPT
+            data["parsing_models"] = [
+                m.model_copy(update={"system_prompt": DEFAULT_PARSING_SYSTEM_PROMPT})
+                if isinstance(m, ModelConfig) and not m.system_prompt
+                else (
+                    {**m, "system_prompt": DEFAULT_PARSING_SYSTEM_PROMPT}
+                    if isinstance(m, dict) and not m.get("system_prompt")
+                    else m
+                )
+                for m in data["parsing_models"]
+            ]
 
         # Strip rubric_enabled from input: now derived from evaluation_mode
         data.pop("rubric_enabled", None)

--- a/src/karenina/utils/checkpoint.py
+++ b/src/karenina/utils/checkpoint.py
@@ -218,6 +218,15 @@ def add_question_to_benchmark(
     Returns:
         The question ID that was added
     """
+    # Extract existing IDs from benchmark
+    existing_ids = set()
+    for item in benchmark.dataFeedElement:
+        if item.id:
+            existing_ids.add(item.id)
+        else:
+            # Generate ID from question text if no ID set
+            existing_ids.add(generate_question_id(item.item.text))
+
     if question_id is None:
         # Generate base ID from question text
         base_id = generate_question_id(question)
@@ -226,18 +235,13 @@ def add_question_to_benchmark(
         question_id = base_id
         counter = 1
 
-        # Extract existing IDs from benchmark
-        existing_ids = set()
-        for item in benchmark.dataFeedElement:
-            if item.id:
-                existing_ids.add(item.id)
-            else:
-                # Generate ID from question text if no ID set
-                existing_ids.add(generate_question_id(item.item.text))
-
         while question_id in existing_ids:
             question_id = f"{base_id}-{counter}"
             counter += 1
+    else:
+        # Explicit ID provided: reject duplicates
+        if question_id in existing_ids:
+            raise ValueError(f"Question with ID {question_id} already exists")
 
     timestamp = datetime.now().isoformat()
 

--- a/src/karenina/utils/json_extraction.py
+++ b/src/karenina/utils/json_extraction.py
@@ -213,9 +213,13 @@ def extract_json_from_response(text: str) -> str:
     """
     text = text.strip()
 
-    # Try direct parsing first - if it starts with { or [, return as-is
+    # Try direct parsing first: if it starts with { or [, validate before returning
     if text.startswith("{") or text.startswith("["):
-        return text
+        try:
+            json.loads(text)
+            return text
+        except json.JSONDecodeError:
+            pass  # Invalid JSON, fall through to other extraction strategies
 
     # Try to extract from markdown code blocks
     code_block_pattern = r"```(?:json)?\s*\n?([\s\S]*?)\n?```"

--- a/tests/unit/benchmark/test_exports_issues.py
+++ b/tests/unit/benchmark/test_exports_issues.py
@@ -1,0 +1,57 @@
+"""Tests for ExportManager issues.
+
+Covers:
+- Issue 110: get_summary() returns question_count as float instead of int
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from karenina.benchmark.core.exports import ExportManager
+
+
+def _make_export_manager(question_count: int = 5) -> ExportManager:
+    """Create an ExportManager with mocked dependencies."""
+    base = MagicMock()
+    base.name = "test-benchmark"
+    base.version = "1.0"
+    base.creator = "tester"
+    base.created_at = "2026-01-01"
+    base.modified_at = "2026-01-02"
+    base.question_count = question_count
+    base.finished_count = 3
+    base.get_progress.return_value = 60.0
+    base.is_complete = False
+    base._questions_cache = {f"q{i}": {"question": f"Q{i}"} for i in range(question_count)}
+
+    templates_manager = MagicMock()
+    templates_manager.has_template.return_value = True
+
+    rubrics_manager = MagicMock()
+    rubrics_manager.get_global_rubric.return_value = None
+
+    return ExportManager(base=base, templates_manager=templates_manager, rubrics_manager=rubrics_manager)
+
+
+@pytest.mark.unit
+class TestIssue110QuestionCountAsFloat:
+    """Issue 110: get_summary() wraps question_count in float(), but it should be int."""
+
+    def test_question_count_is_int(self) -> None:
+        """question_count in get_summary() should be an int, not a float."""
+        manager = _make_export_manager(question_count=5)
+        summary = manager.get_summary()
+
+        assert summary["question_count"] == 5
+        assert isinstance(summary["question_count"], int), (
+            f"question_count should be int, got {type(summary['question_count']).__name__}"
+        )
+
+    def test_question_count_zero_is_int(self) -> None:
+        """Even zero question_count should be int, not float."""
+        manager = _make_export_manager(question_count=0)
+        summary = manager.get_summary()
+
+        assert summary["question_count"] == 0
+        assert isinstance(summary["question_count"], int)

--- a/tests/unit/benchmark/test_questions_issues.py
+++ b/tests/unit/benchmark/test_questions_issues.py
@@ -1,0 +1,48 @@
+"""Tests for issue 113: add_question() with explicit duplicate ID corrupts state.
+
+When a user explicitly passes a question_id that already exists, the checkpoint
+gets a duplicate entry while the cache silently overwrites. This causes counts
+to diverge between checkpoint and cache. The fix is to raise ValueError before
+appending when a duplicate explicit ID is detected.
+"""
+
+import pytest
+
+from karenina import Benchmark
+
+
+@pytest.mark.unit
+class TestAddQuestionDuplicateId:
+    """Tests for issue 113: duplicate explicit question ID detection."""
+
+    def test_duplicate_explicit_id_raises_value_error(self) -> None:
+        """add_question() should raise ValueError when an explicit duplicate ID is given."""
+        benchmark = Benchmark.create(name="test-dup-id")
+        benchmark.add_question("What is 2+2?", "4", question_id="q1")
+
+        with pytest.raises(ValueError, match="already exists"):
+            benchmark.add_question("What is 3+3?", "6", question_id="q1")
+
+    def test_duplicate_explicit_id_does_not_corrupt_checkpoint(self) -> None:
+        """After a rejected duplicate, checkpoint and cache should remain consistent."""
+        benchmark = Benchmark.create(name="test-dup-state")
+        benchmark.add_question("What is 2+2?", "4", question_id="q1")
+
+        with pytest.raises(ValueError):
+            benchmark.add_question("What is 3+3?", "6", question_id="q1")
+
+        # Checkpoint should have exactly one entry
+        assert len(benchmark._checkpoint.dataFeedElement) == 1
+        # Cache should also have exactly one entry
+        assert len(benchmark._questions_cache) == 1
+
+    def test_auto_generated_ids_do_not_collide(self) -> None:
+        """Auto-generated IDs should still auto-increment to avoid collisions."""
+        benchmark = Benchmark.create(name="test-auto-id")
+        id1 = benchmark.add_question("What is 2+2?", "4")
+        id2 = benchmark.add_question("What is 2+2?", "4")
+
+        # Same question text should get different IDs via auto-incrementing
+        assert id1 != id2
+        assert len(benchmark._checkpoint.dataFeedElement) == 2
+        assert len(benchmark._questions_cache) == 2

--- a/tests/unit/benchmark/test_results_io_issues.py
+++ b/tests/unit/benchmark/test_results_io_issues.py
@@ -1,0 +1,137 @@
+"""Tests for ResultsIOManager issues.
+
+Covers:
+- Issue 111: _escape_csv_field() double-escapes CSV values
+"""
+
+import csv
+from io import StringIO
+
+import pytest
+
+from karenina.benchmark.core.results_io import ResultsIOManager
+from karenina.schemas.verification.model_identity import ModelIdentity
+from karenina.schemas.verification.result import VerificationResult
+from karenina.schemas.verification.result_components import (
+    VerificationResultMetadata,
+    VerificationResultTemplate,
+)
+
+
+def _make_result(
+    question_id: str = "q1",
+    question_text: str = "What is 2+2?",
+    raw_llm_response: str = "4",
+) -> VerificationResult:
+    """Create a minimal VerificationResult for testing CSV export."""
+    answering = ModelIdentity(interface="langchain", model_name="gpt-4")
+    parsing = ModelIdentity(interface="langchain", model_name="gpt-4")
+    metadata = VerificationResultMetadata(
+        question_id=question_id,
+        template_id="tmpl_abc",
+        completed_without_errors=True,
+        question_text=question_text,
+        answering=answering,
+        parsing=parsing,
+        execution_time=1.0,
+        timestamp="2026-01-01T00:00:00",
+        result_id="abcdef1234567890",
+    )
+    template = VerificationResultTemplate(
+        raw_llm_response=raw_llm_response,
+        template_verification_performed=True,
+        verify_result=True,
+    )
+    return VerificationResult(metadata=metadata, template=template)
+
+
+@pytest.mark.unit
+class TestIssue111DoubleEscapedCsvValues:
+    """Issue 111: _escape_csv_field() manually escapes values before passing them
+    to csv.writer, which also escapes values per RFC 4180. This causes
+    double-escaping: a field containing a comma gets wrapped in quotes twice."""
+
+    def test_csv_field_with_comma_not_double_escaped(self) -> None:
+        """A question_text with a comma should not be double-quoted in CSV output."""
+        result = _make_result(question_text='Hello, "world"')
+        results = {"q1": result}
+
+        csv_output = ResultsIOManager.export_to_csv(results)
+
+        # Parse the CSV output back
+        reader = csv.reader(StringIO(csv_output))
+        rows = list(reader)
+
+        # Row 0 is headers, row 1 is data
+        assert len(rows) == 2
+        header = rows[0]
+        data = rows[1]
+
+        # Find the question_text column
+        qt_index = header.index("question_text")
+        parsed_value = data[qt_index]
+
+        # The parsed value should be exactly the original string,
+        # not a double-escaped version
+        assert parsed_value == 'Hello, "world"', (
+            f"Expected 'Hello, \"world\"' but got '{parsed_value}'. "
+            "The value was likely double-escaped by _escape_csv_field + csv.writer."
+        )
+
+    def test_csv_field_with_newline_not_double_escaped(self) -> None:
+        """A field with a newline should not be double-escaped."""
+        result = _make_result(raw_llm_response="line1\nline2")
+        results = {"q1": result}
+
+        csv_output = ResultsIOManager.export_to_csv(results)
+
+        reader = csv.reader(StringIO(csv_output))
+        rows = list(reader)
+
+        header = rows[0]
+        data = rows[1]
+
+        raw_index = header.index("raw_llm_response")
+        parsed_value = data[raw_index]
+
+        assert parsed_value == "line1\nline2", (
+            f"Expected 'line1\\nline2' but got '{parsed_value}'. Newlines were likely double-escaped."
+        )
+
+    def test_csv_field_with_quotes_not_double_escaped(self) -> None:
+        """A field with double quotes should have them properly escaped once."""
+        result = _make_result(question_text='She said "hello"')
+        results = {"q1": result}
+
+        csv_output = ResultsIOManager.export_to_csv(results)
+
+        reader = csv.reader(StringIO(csv_output))
+        rows = list(reader)
+
+        header = rows[0]
+        data = rows[1]
+
+        qt_index = header.index("question_text")
+        parsed_value = data[qt_index]
+
+        assert parsed_value == 'She said "hello"', (
+            f"Expected 'She said \"hello\"' but got '{parsed_value}'. Quotes were likely double-escaped."
+        )
+
+    def test_csv_plain_field_unchanged(self) -> None:
+        """A plain text field without special characters should pass through cleanly."""
+        result = _make_result(question_text="Simple question")
+        results = {"q1": result}
+
+        csv_output = ResultsIOManager.export_to_csv(results)
+
+        reader = csv.reader(StringIO(csv_output))
+        rows = list(reader)
+
+        header = rows[0]
+        data = rows[1]
+
+        qt_index = header.index("question_text")
+        parsed_value = data[qt_index]
+
+        assert parsed_value == "Simple question"

--- a/tests/unit/benchmark/test_rubrics_issues.py
+++ b/tests/unit/benchmark/test_rubrics_issues.py
@@ -1,0 +1,63 @@
+"""Tests for issue 108: validate_rubrics() crashes on dict-format question rubrics.
+
+When question_rubric is stored as a dict (keyed by trait type) rather than a
+flat list, validate_rubrics() iterates over the dict keys (strings) instead
+of the trait objects within each value list, causing AttributeError.
+"""
+
+import pytest
+
+from karenina import Benchmark
+from karenina.schemas.entities import LLMRubricTrait
+
+
+@pytest.mark.unit
+class TestValidateRubricsDictFormat:
+    """Tests for issue 108: validate_rubrics() with dict-format question rubrics."""
+
+    def test_validate_rubrics_does_not_crash_on_dict_format(self) -> None:
+        """validate_rubrics() should handle dict-format question rubrics without error.
+
+        When question_rubric is a dict like {"llm_traits": [...], "regex_traits": [...]},
+        the validator must iterate over the trait lists within the dict values,
+        not over the dict keys (which are strings).
+        """
+        benchmark = Benchmark.create(name="test-dict-rubric")
+        q_id = benchmark.add_question("What is 2+2?", "4")
+
+        # Inject dict-format question rubric into the cache directly
+        # (this simulates how rubrics can end up as dicts after deserialization)
+        trait = LLMRubricTrait(name="accuracy", description="Is the answer correct?", kind="boolean")
+        benchmark._questions_cache[q_id]["question_rubric"] = {
+            "llm_traits": [trait],
+            "regex_traits": [],
+            "callable_traits": [],
+            "metric_traits": [],
+            "agentic_traits": [],
+        }
+
+        # This should NOT raise AttributeError
+        valid, errors = benchmark.validate_rubrics()
+
+        # Should validate successfully since the trait has name and description
+        assert valid is True
+        assert errors == []
+
+    def test_validate_rubrics_reports_errors_for_dict_format_traits(self) -> None:
+        """validate_rubrics() should correctly report errors for invalid traits in dict format."""
+        benchmark = Benchmark.create(name="test-dict-rubric-errors")
+        q_id = benchmark.add_question("What is 2+2?", "4")
+
+        # Inject a trait with missing description
+        bad_trait = LLMRubricTrait(name="accuracy", description="", kind="boolean")
+        benchmark._questions_cache[q_id]["question_rubric"] = {
+            "llm_traits": [bad_trait],
+            "regex_traits": [],
+            "callable_traits": [],
+            "metric_traits": [],
+            "agentic_traits": [],
+        }
+
+        valid, errors = benchmark.validate_rubrics()
+        assert valid is False
+        assert len(errors) > 0

--- a/tests/unit/benchmark/test_task_eval_issues.py
+++ b/tests/unit/benchmark/test_task_eval_issues.py
@@ -1,0 +1,67 @@
+"""Tests for issue 170: log_trace(string) doubles AI message prefix.
+
+When a plain string containing '--- AI Message ---' prefix is passed to
+log_trace(), it gets wrapped as Message.assistant(text), which later
+gets serialized with messages_to_raw_trace() adding another
+'--- AI Message ---' prefix. This results in doubled prefixes in
+raw_llm_response.
+"""
+
+import pytest
+
+from karenina.benchmark.task_eval.task_eval import TaskEval
+from karenina.ports.messages import Message
+
+
+@pytest.mark.unit
+class TestLogTraceStringPrefix:
+    """Tests for issue 170: AI message prefix duplication in log_trace()."""
+
+    def test_log_trace_strips_ai_message_prefix(self) -> None:
+        """log_trace() should strip existing AI message prefix from string input.
+
+        When a user passes a string that already contains the '--- AI Message ---'
+        prefix, the method should strip it before wrapping it as a Message to
+        avoid double-prefixing in the serialized output.
+        """
+        task = TaskEval(task_id="test")
+        prefixed_text = "--- AI Message ---\nThe answer is 42"
+
+        task.log_trace(prefixed_text)
+
+        # The stored trace_messages should have the text without the prefix
+        assert len(task.global_logs) == 1
+        log_event = task.global_logs[0]
+        assert log_event.trace_messages is not None
+        assert len(log_event.trace_messages) == 1
+
+        msg = log_event.trace_messages[0]
+        assert msg.text == "The answer is 42"
+
+    def test_log_trace_string_without_prefix_unchanged(self) -> None:
+        """log_trace() should not alter strings without the AI message prefix."""
+        task = TaskEval(task_id="test")
+        plain_text = "The answer is 42"
+
+        task.log_trace(plain_text)
+
+        assert len(task.global_logs) == 1
+        log_event = task.global_logs[0]
+        assert log_event.trace_messages is not None
+        msg = log_event.trace_messages[0]
+        assert msg.text == "The answer is 42"
+
+    def test_log_trace_message_list_not_affected(self) -> None:
+        """log_trace() with a Message list should not be affected by prefix stripping."""
+        task = TaskEval(task_id="test")
+        messages = [Message.assistant("--- AI Message ---\nSome text")]
+
+        task.log_trace(messages)
+
+        # Message lists are passed through unchanged
+        assert len(task.global_logs) == 1
+        log_event = task.global_logs[0]
+        assert log_event.trace_messages is not None
+        msg = log_event.trace_messages[0]
+        # The text should be unchanged since it was passed as a Message object
+        assert msg.text == "--- AI Message ---\nSome text"

--- a/tests/unit/ports/test_messages_issues.py
+++ b/tests/unit/ports/test_messages_issues.py
@@ -1,0 +1,80 @@
+"""Tests for issue 140: Message.from_dict() duplicates content for tool messages.
+
+When deserializing a tool message, from_dict() creates both a TextContent
+block (from the "content" field) and a ToolResultContent block (from the
+"tool_result" field) with the same text. This causes the .text property
+to return content that should only be in the ToolResultContent block.
+"""
+
+import pytest
+
+from karenina.ports.messages import (
+    Message,
+    Role,
+    TextContent,
+    ToolResultContent,
+)
+
+
+@pytest.mark.unit
+class TestFromDictToolMessageDuplication:
+    """Tests for issue 140: tool message content duplication in from_dict()."""
+
+    def test_tool_message_roundtrip_no_duplicate_content(self) -> None:
+        """A tool message should not have TextContent after from_dict() roundtrip.
+
+        to_dict() puts the tool result content in the "content" field for
+        serialization. from_dict() should not create a redundant TextContent
+        block from it when a tool_result is present.
+        """
+        original = Message.tool_result(
+            tool_use_id="call_123",
+            content="Tool output text",
+            is_error=False,
+        )
+
+        serialized = original.to_dict()
+        restored = Message.from_dict(serialized)
+
+        # Should have only ToolResultContent, no TextContent
+        text_blocks = [c for c in restored.content if isinstance(c, TextContent)]
+        tool_blocks = [c for c in restored.content if isinstance(c, ToolResultContent)]
+
+        assert len(text_blocks) == 0, (
+            f"Expected no TextContent blocks, got {len(text_blocks)}: "
+            f"from_dict() should skip TextContent when tool_result is present"
+        )
+        assert len(tool_blocks) == 1
+        assert tool_blocks[0].content == "Tool output text"
+        assert tool_blocks[0].tool_use_id == "call_123"
+
+    def test_tool_message_text_property_empty_after_roundtrip(self) -> None:
+        """The .text property on a tool message should be empty after roundtrip.
+
+        Tool messages store content in ToolResultContent, not TextContent.
+        The .text property should return empty string.
+        """
+        original = Message.tool_result(
+            tool_use_id="call_456",
+            content="Some result",
+        )
+
+        serialized = original.to_dict()
+        restored = Message.from_dict(serialized)
+
+        assert restored.text == ""
+        assert restored.role == Role.TOOL
+
+    def test_non_tool_message_still_gets_text_content(self) -> None:
+        """Non-tool messages should still get TextContent from the content field."""
+        data = {
+            "role": "assistant",
+            "content": "Hello world",
+            "block_index": 0,
+        }
+
+        msg = Message.from_dict(data)
+
+        text_blocks = [c for c in msg.content if isinstance(c, TextContent)]
+        assert len(text_blocks) == 1
+        assert text_blocks[0].text == "Hello world"

--- a/tests/unit/schemas/test_answer_cache_issues.py
+++ b/tests/unit/schemas/test_answer_cache_issues.py
@@ -1,0 +1,90 @@
+"""Tests for BaseAnswer caching bug fixes.
+
+Covers:
+- Issue 132: _compute_field_results() mutable cache never invalidated
+"""
+
+import pytest
+
+from karenina.schemas.entities.answer import BaseAnswer
+from karenina.schemas.entities.verified_field import VerifiedField
+from karenina.schemas.primitives.comparisons import ExactMatch
+
+
+@pytest.mark.unit
+class TestFieldResultsCacheInvalidation:
+    """Issue 132: _compute_field_results cache should be clearable."""
+
+    def _make_answer_class(self) -> type[BaseAnswer]:
+        """Create a simple VerifiedField-based answer class for testing."""
+
+        class TestAnswer(BaseAnswer):
+            name: str = VerifiedField(
+                description="The name",
+                ground_truth="alice",
+                verify_with=ExactMatch(),
+            )
+
+        return TestAnswer
+
+    def test_cache_populated_on_first_call(self) -> None:
+        """First call to _compute_field_results should populate cache."""
+        cls = self._make_answer_class()
+        answer = cls(name="alice")
+        result = answer._compute_field_results()
+        assert result == {"name": True}
+        # Cache should now be stored
+        assert "_field_results" in answer.__dict__
+
+    def test_cache_returns_same_on_second_call(self) -> None:
+        """Second call returns cached result without recomputation."""
+        cls = self._make_answer_class()
+        answer = cls(name="alice")
+        result1 = answer._compute_field_results()
+        result2 = answer._compute_field_results()
+        assert result1 is result2  # Same object (cached)
+
+    def test_clear_verification_cache_exists(self) -> None:
+        """_clear_verification_cache method should exist on BaseAnswer."""
+        cls = self._make_answer_class()
+        answer = cls(name="alice")
+        assert hasattr(answer, "_clear_verification_cache")
+
+    def test_clear_cache_allows_recomputation(self) -> None:
+        """After clearing cache, _compute_field_results should recompute."""
+        cls = self._make_answer_class()
+        answer = cls(name="alice")
+
+        # First call: cache populated, name matches
+        result1 = answer._compute_field_results()
+        assert result1 == {"name": True}
+
+        # Mutate the field value
+        answer.name = "bob"
+
+        # Without clearing: stale cache returns old result
+        stale = answer._compute_field_results()
+        assert stale == {"name": True}  # Still cached
+
+        # Clear cache
+        answer._clear_verification_cache()
+
+        # After clearing: recomputes with new value
+        result2 = answer._compute_field_results()
+        assert result2 == {"name": False}  # bob != alice
+
+    def test_clear_cache_is_idempotent(self) -> None:
+        """Clearing cache when no cache exists should not raise."""
+        cls = self._make_answer_class()
+        answer = cls(name="alice")
+        # No cache yet; clearing should not raise
+        answer._clear_verification_cache()
+        # And computing should still work
+        result = answer._compute_field_results()
+        assert result == {"name": True}
+
+    def test_docstring_documents_caching(self) -> None:
+        """The _compute_field_results docstring should mention caching behavior."""
+        docstring = BaseAnswer._compute_field_results.__doc__
+        assert docstring is not None
+        assert "cache" in docstring.lower() or "Cache" in docstring

--- a/tests/unit/schemas/test_comparisons_issues.py
+++ b/tests/unit/schemas/test_comparisons_issues.py
@@ -1,0 +1,52 @@
+"""Tests for comparison primitive bug fixes.
+
+Covers:
+- Issue 045: RegexMatch silently ignores unknown flag names
+"""
+
+import logging
+
+import pytest
+
+from karenina.schemas.primitives.comparisons import RegexMatch
+
+
+@pytest.mark.unit
+class TestRegexMatchUnknownFlags:
+    """Issue 045: RegexMatch should warn on unknown flag names."""
+
+    def test_known_flags_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Valid re flags like IGNORECASE should produce no warning."""
+        rm = RegexMatch(pattern=r"hello", flags=["IGNORECASE"])
+        with caplog.at_level(logging.WARNING):
+            result = rm.check("Hello World", None)
+        assert result is True
+        assert "Unknown regex flag" not in caplog.text
+
+    def test_unknown_flag_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A typo like 'IGNORCASE' should log a warning."""
+        rm = RegexMatch(pattern=r"hello", flags=["IGNORCASE"])
+        with caplog.at_level(logging.WARNING):
+            rm.check("hello world", None)
+        assert "Unknown regex flag" in caplog.text
+        assert "IGNORCASE" in caplog.text
+
+    def test_unknown_flag_does_not_contribute_to_flags(self) -> None:
+        """An unknown flag must not contribute bits (no silent fallback to 0)."""
+        # With correct IGNORECASE, this should match
+        rm_good = RegexMatch(pattern=r"HELLO", flags=["IGNORECASE"])
+        assert rm_good.check("hello", None) is True
+
+        # With typo IGNORCASE, the flag is skipped, so case-sensitive
+        rm_bad = RegexMatch(pattern=r"HELLO", flags=["IGNORCASE"])
+        assert rm_bad.check("hello", None) is False
+
+    def test_multiple_flags_with_one_unknown(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When mixing valid and invalid flags, only the valid ones apply."""
+        rm = RegexMatch(pattern=r"hello", flags=["IGNORECASE", "BADFLAG"])
+        with caplog.at_level(logging.WARNING):
+            result = rm.check("Hello", None)
+        # IGNORECASE still applies, so match should succeed
+        assert result is True
+        # But a warning should be emitted for BADFLAG
+        assert "BADFLAG" in caplog.text

--- a/tests/unit/schemas/test_verification_config_issues.py
+++ b/tests/unit/schemas/test_verification_config_issues.py
@@ -1,0 +1,164 @@
+"""Tests for VerificationConfig bug fixes.
+
+Covers:
+- Issue 015: System prompt auto-assignment mutates shared ModelConfig in-place
+- Issue 135: db_config typed as Any instead of DBConfig
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification.config import (
+    DEFAULT_ANSWERING_SYSTEM_PROMPT,
+    DEFAULT_PARSING_SYSTEM_PROMPT,
+    VerificationConfig,
+)
+from karenina.storage.db_config import DBConfig
+
+
+@pytest.mark.unit
+class TestSharedModelConfigMutation:
+    """Issue 015: Shared ModelConfig should not be mutated in-place."""
+
+    def test_shared_model_gets_correct_prompts(self) -> None:
+        """When the same ModelConfig is used for answering and parsing,
+        each role should get its own system prompt without cross-contamination.
+        """
+        shared = ModelConfig(
+            id="shared",
+            model_name="gpt-4",
+            model_provider="openai",
+            interface="langchain",
+        )
+        config = VerificationConfig(
+            answering_models=[shared],
+            parsing_models=[shared],
+        )
+        # After construction, the answering copy should have the answering prompt
+        assert config.answering_models[0].system_prompt == DEFAULT_ANSWERING_SYSTEM_PROMPT
+        # And the parsing copy should have the parsing prompt
+        assert config.parsing_models[0].system_prompt == DEFAULT_PARSING_SYSTEM_PROMPT
+
+    def test_original_model_not_mutated(self) -> None:
+        """The original ModelConfig instance must not be mutated by VerificationConfig.__init__."""
+        original = ModelConfig(
+            id="original",
+            model_name="gpt-4",
+            model_provider="openai",
+            interface="langchain",
+        )
+        assert original.system_prompt is None
+
+        VerificationConfig(
+            answering_models=[original],
+            parsing_models=[
+                ModelConfig(
+                    id="parser",
+                    model_name="gpt-4",
+                    model_provider="openai",
+                    interface="langchain",
+                )
+            ],
+        )
+        # The original should still be None (not mutated)
+        assert original.system_prompt is None
+
+    def test_explicit_prompt_preserved(self) -> None:
+        """Models with an explicit system_prompt should not be overwritten."""
+        custom_prompt = "I am a custom prompt"
+        model = ModelConfig(
+            id="custom",
+            model_name="gpt-4",
+            model_provider="openai",
+            interface="langchain",
+            system_prompt=custom_prompt,
+        )
+        config = VerificationConfig(
+            answering_models=[model],
+            parsing_models=[
+                ModelConfig(
+                    id="parser",
+                    model_name="gpt-4",
+                    model_provider="openai",
+                    interface="langchain",
+                )
+            ],
+        )
+        assert config.answering_models[0].system_prompt == custom_prompt
+
+
+@pytest.mark.unit
+class TestDBConfigTyping:
+    """Issue 135: db_config should validate against DBConfig, not accept Any."""
+
+    def test_valid_db_config_accepted(self) -> None:
+        """A valid DBConfig instance should be accepted."""
+        db = DBConfig(storage_url="sqlite:///test.db")
+        config = VerificationConfig(
+            answering_models=[
+                ModelConfig(
+                    id="a",
+                    model_name="gpt-4",
+                    model_provider="openai",
+                    interface="langchain",
+                )
+            ],
+            parsing_models=[
+                ModelConfig(
+                    id="p",
+                    model_name="gpt-4",
+                    model_provider="openai",
+                    interface="langchain",
+                )
+            ],
+            db_config=db,
+        )
+        assert config.db_config is not None
+        assert config.db_config.storage_url == "sqlite:///test.db"
+
+    def test_none_db_config_accepted(self) -> None:
+        """None should still be accepted for db_config."""
+        config = VerificationConfig(
+            answering_models=[
+                ModelConfig(
+                    id="a",
+                    model_name="gpt-4",
+                    model_provider="openai",
+                    interface="langchain",
+                )
+            ],
+            parsing_models=[
+                ModelConfig(
+                    id="p",
+                    model_name="gpt-4",
+                    model_provider="openai",
+                    interface="langchain",
+                )
+            ],
+            db_config=None,
+        )
+        assert config.db_config is None
+
+    def test_arbitrary_value_rejected(self) -> None:
+        """An arbitrary non-DBConfig value should be rejected by validation."""
+        with pytest.raises((ValidationError, TypeError)):
+            VerificationConfig(
+                answering_models=[
+                    ModelConfig(
+                        id="a",
+                        model_name="gpt-4",
+                        model_provider="openai",
+                        interface="langchain",
+                    )
+                ],
+                parsing_models=[
+                    ModelConfig(
+                        id="p",
+                        model_name="gpt-4",
+                        model_provider="openai",
+                        interface="langchain",
+                    )
+                ],
+                db_config="not-a-db-config",
+            )

--- a/tests/unit/schemas/test_verification_result_set_issues.py
+++ b/tests/unit/schemas/test_verification_result_set_issues.py
@@ -1,0 +1,258 @@
+"""Tests for VerificationResultSet serialization and metric detection issues.
+
+Covers:
+- Issue 016: get_summary() tuple keys break JSON serialization
+- Issue 119: _calculate_rubric_traits uses confusion_lists for metric detection
+"""
+
+import json
+
+import pytest
+
+from karenina.schemas.results.verification_result_set import VerificationResultSet
+from karenina.schemas.verification.model_identity import ModelIdentity
+from karenina.schemas.verification.result import VerificationResult
+from karenina.schemas.verification.result_components import (
+    VerificationResultMetadata,
+    VerificationResultRubric,
+    VerificationResultTemplate,
+)
+
+
+def _make_model_identity(interface: str = "langchain", model_name: str = "gpt-4") -> ModelIdentity:
+    """Create a ModelIdentity for testing."""
+    return ModelIdentity(interface=interface, model_name=model_name)
+
+
+def _make_metadata(
+    question_id: str = "q1",
+    answering_model: str = "gpt-4",
+    parsing_model: str = "gpt-4",
+) -> VerificationResultMetadata:
+    """Create a VerificationResultMetadata for testing."""
+    answering = _make_model_identity(model_name=answering_model)
+    parsing = _make_model_identity(model_name=parsing_model)
+    return VerificationResultMetadata(
+        question_id=question_id,
+        template_id="tmpl_abc",
+        completed_without_errors=True,
+        question_text="What is 2+2?",
+        answering=answering,
+        parsing=parsing,
+        execution_time=1.0,
+        timestamp="2026-01-01T00:00:00",
+        result_id="abcdef1234567890",
+    )
+
+
+def _make_result(
+    question_id: str = "q1",
+    answering_model: str = "gpt-4",
+    parsing_model: str = "gpt-4",
+    template: VerificationResultTemplate | None = None,
+    rubric: VerificationResultRubric | None = None,
+) -> VerificationResult:
+    """Create a minimal VerificationResult for testing."""
+    return VerificationResult(
+        metadata=_make_metadata(
+            question_id=question_id,
+            answering_model=answering_model,
+            parsing_model=parsing_model,
+        ),
+        template=template,
+        rubric=rubric,
+    )
+
+
+@pytest.mark.unit
+class TestIssue016TupleKeysBreakJsonSerialization:
+    """Issue 016: tokens_by_combo, completion_by_combo, template_pass_by_combo
+    dicts use Python tuple keys, which cause json.dumps() TypeError."""
+
+    def test_summary_tokens_by_combo_is_json_serializable(self) -> None:
+        """tokens_by_combo keys must be strings, not tuples."""
+        template = VerificationResultTemplate(
+            raw_llm_response="answer",
+            template_verification_performed=True,
+            verify_result=True,
+            usage_metadata={
+                "total": {"input_tokens": 100, "output_tokens": 50},
+            },
+        )
+        result = _make_result(template=template)
+        result_set = VerificationResultSet(results=[result])
+
+        summary = result_set.get_summary()
+
+        # This must not raise TypeError: keys must be str, int, float, bool or None, not tuple
+        serialized = json.dumps(summary)
+        parsed = json.loads(serialized)
+
+        # Verify the keys are strings in the format "model1 | model2"
+        assert isinstance(parsed["tokens_by_combo"], dict)
+        for key in parsed["tokens_by_combo"]:
+            assert isinstance(key, str)
+            assert " | " in key
+
+    def test_summary_completion_by_combo_is_json_serializable(self) -> None:
+        """completion_by_combo keys must be strings, not tuples."""
+        result = _make_result()
+        result_set = VerificationResultSet(results=[result])
+
+        summary = result_set.get_summary()
+
+        serialized = json.dumps(summary)
+        parsed = json.loads(serialized)
+
+        assert isinstance(parsed["completion_by_combo"], dict)
+        for key in parsed["completion_by_combo"]:
+            assert isinstance(key, str)
+
+    def test_summary_template_pass_by_combo_is_json_serializable(self) -> None:
+        """template_pass_by_combo keys must be strings, not tuples."""
+        template = VerificationResultTemplate(
+            raw_llm_response="answer",
+            template_verification_performed=True,
+            verify_result=True,
+        )
+        result = _make_result(template=template)
+        result_set = VerificationResultSet(results=[result])
+
+        summary = result_set.get_summary()
+
+        serialized = json.dumps(summary)
+        parsed = json.loads(serialized)
+
+        assert isinstance(parsed["template_pass_by_combo"], dict)
+        for key in parsed["template_pass_by_combo"]:
+            assert isinstance(key, str)
+
+    def test_combo_key_format_without_mcp(self) -> None:
+        """Combo key should be 'answering_model | parsing_model' when no MCP servers."""
+        template = VerificationResultTemplate(
+            raw_llm_response="answer",
+            template_verification_performed=True,
+            verify_result=True,
+            usage_metadata={
+                "total": {"input_tokens": 100, "output_tokens": 50},
+            },
+        )
+        result = _make_result(
+            answering_model="gpt-4",
+            parsing_model="gpt-3.5-turbo",
+            template=template,
+        )
+        result_set = VerificationResultSet(results=[result])
+
+        summary = result_set.get_summary()
+
+        # Check that the key is a pipe-delimited string
+        expected_key = "langchain:gpt-4 | langchain:gpt-3.5-turbo"
+        assert expected_key in summary["tokens_by_combo"]
+        assert expected_key in summary["completion_by_combo"]
+        assert expected_key in summary["template_pass_by_combo"]
+
+    def test_combo_key_format_with_mcp(self) -> None:
+        """Combo key should include MCP servers when present."""
+        template = VerificationResultTemplate(
+            raw_llm_response="answer",
+            template_verification_performed=True,
+            verify_result=True,
+            answering_mcp_servers=["brave_search", "filesystem"],
+            usage_metadata={
+                "total": {"input_tokens": 100, "output_tokens": 50},
+            },
+        )
+        result = _make_result(template=template)
+        result_set = VerificationResultSet(results=[result])
+
+        summary = result_set.get_summary()
+
+        # The key must be a string and include MCP server info
+        for key in summary["tokens_by_combo"]:
+            assert isinstance(key, str)
+
+    def test_full_summary_json_round_trip(self) -> None:
+        """The entire get_summary() output must survive json.dumps/loads."""
+        template = VerificationResultTemplate(
+            raw_llm_response="answer",
+            template_verification_performed=True,
+            verify_result=True,
+            usage_metadata={
+                "total": {"input_tokens": 100, "output_tokens": 50},
+                "answer_generation": {"input_tokens": 60, "output_tokens": 30},
+                "parsing": {"input_tokens": 40, "output_tokens": 20},
+            },
+        )
+        rubric = VerificationResultRubric(
+            rubric_evaluation_performed=True,
+            llm_trait_scores={"clarity": 4},
+        )
+        result = _make_result(template=template, rubric=rubric)
+        result_set = VerificationResultSet(results=[result])
+
+        summary = result_set.get_summary()
+
+        # Must not raise
+        serialized = json.dumps(summary)
+        parsed = json.loads(serialized)
+        assert parsed["num_results"] == 1
+
+
+@pytest.mark.unit
+class TestIssue119MetricTraitDetectionUsesConfusionLists:
+    """Issue 119: _calculate_rubric_traits uses metric_trait_confusion_lists
+    instead of metric_trait_scores, inconsistent with other trait types."""
+
+    def test_metric_traits_detected_via_scores_not_confusion_lists(self) -> None:
+        """Metric traits should be detected via metric_trait_scores, like other types."""
+        rubric = VerificationResultRubric(
+            rubric_evaluation_performed=True,
+            metric_trait_scores={
+                "entity_detection": {"precision": 0.9, "recall": 0.8, "f1": 0.85},
+            },
+            # No confusion lists set at all
+            metric_trait_confusion_lists=None,
+        )
+        result = _make_result(rubric=rubric)
+        result_set = VerificationResultSet(results=[result])
+
+        summary = result_set.get_summary()
+
+        # The metric trait must be detected even without confusion lists
+        rubric_traits = summary["rubric_traits"]
+        assert rubric_traits is not None
+
+        global_metric_count = rubric_traits["global_traits"]["metric"]["count"]
+        qs_metric_count = rubric_traits["question_specific_traits"]["metric"]["count"]
+        total_metric = global_metric_count + qs_metric_count
+        assert total_metric > 0, (
+            "Metric trait 'entity_detection' was not detected. "
+            "_calculate_rubric_traits should use metric_trait_scores, not metric_trait_confusion_lists."
+        )
+
+    def test_metric_traits_not_detected_when_only_confusion_lists_present(self) -> None:
+        """If metric_trait_scores is None but confusion_lists has data,
+        the old buggy code would detect it but the fix should not, since
+        detection should be based on scores like all other trait types."""
+        rubric = VerificationResultRubric(
+            rubric_evaluation_performed=True,
+            metric_trait_scores=None,
+            metric_trait_confusion_lists={
+                "entity_detection": {"tp": ["a"], "tn": [], "fp": [], "fn": []},
+            },
+        )
+        result = _make_result(rubric=rubric)
+        result_set = VerificationResultSet(results=[result])
+
+        summary = result_set.get_summary()
+
+        rubric_traits = summary["rubric_traits"]
+        assert rubric_traits is not None
+
+        global_metric_count = rubric_traits["global_traits"]["metric"]["count"]
+        qs_metric_count = rubric_traits["question_specific_traits"]["metric"]["count"]
+        total_metric = global_metric_count + qs_metric_count
+        assert total_metric == 0, (
+            "Metric trait was detected from confusion_lists but should only be detected from metric_trait_scores."
+        )

--- a/tests/unit/utils/test_json_extraction_issues.py
+++ b/tests/unit/utils/test_json_extraction_issues.py
@@ -1,0 +1,47 @@
+"""Tests for JSON extraction bug fixes.
+
+Issue 081: extract_json_from_response skips validation when input starts with { or [.
+"""
+
+import pytest
+
+from karenina.utils.json_extraction import extract_json_from_response
+
+
+@pytest.mark.unit
+class TestExtractJsonFromResponseValidation:
+    """Issue 081: early return on brace-starting input must validate with json.loads."""
+
+    def test_valid_json_starting_with_brace_returns_as_is(self):
+        """Valid JSON starting with { should still be returned."""
+        result = extract_json_from_response('{"key": "value"}')
+        assert result == '{"key": "value"}'
+
+    def test_valid_json_array_starting_with_bracket_returns_as_is(self):
+        """Valid JSON starting with [ should still be returned."""
+        result = extract_json_from_response("[1, 2, 3]")
+        assert result == "[1, 2, 3]"
+
+    def test_invalid_json_starting_with_brace_falls_through(self):
+        """Invalid JSON starting with { should not be returned as-is.
+
+        Before the fix, extract_json_from_response would return the raw
+        text without validation when it starts with { or [. After the fix,
+        it should attempt extraction or raise ValueError.
+        """
+        # This is invalid JSON: truncated object
+        invalid = '{"key": "value", "nested": {"broken'
+        with pytest.raises(ValueError, match="Could not extract JSON"):
+            extract_json_from_response(invalid)
+
+    def test_invalid_json_starting_with_bracket_falls_through(self):
+        """Invalid JSON starting with [ should not be returned as-is."""
+        invalid = '[1, 2, "unterminated'
+        with pytest.raises(ValueError, match="Could not extract JSON"):
+            extract_json_from_response(invalid)
+
+    def test_brace_start_with_trailing_text_extracts_json(self):
+        """Input starting with { but containing trailing text should extract the JSON portion."""
+        text = '{"key": "value"} and some extra text here'
+        result = extract_json_from_response(text)
+        assert result == '{"key": "value"}'

--- a/tests/unit/verification/test_evaluator_issues.py
+++ b/tests/unit/verification/test_evaluator_issues.py
@@ -1,0 +1,88 @@
+"""Tests for template evaluator bug fixes.
+
+Issue 052: verify() return type unchecked; truthy non-bool values pass.
+"""
+
+import logging
+
+import pytest
+
+
+@pytest.mark.unit
+class TestVerifyFieldsReturnTypeCheck:
+    """Issue 052: verify_fields should warn when verify() returns non-bool truthy value."""
+
+    def test_verify_fields_warns_on_non_bool_truthy_return(self, caplog):
+        """verify() returning a truthy non-bool (e.g. 'yes') should log a warning."""
+        from karenina.benchmark.verification.evaluators.template.evaluator import TemplateEvaluator
+
+        class FakeAnswer:
+            def verify(self):
+                return "yes"
+
+        evaluator = TemplateEvaluator.__new__(TemplateEvaluator)
+
+        with caplog.at_level(logging.WARNING):
+            result = evaluator.verify_fields(FakeAnswer())
+
+        # The result should still capture the truthy value
+        assert result.success == "yes"
+        # But a warning should have been logged about non-bool return
+        assert any(
+            "non-bool" in record.message.lower() or "not a bool" in record.message.lower() for record in caplog.records
+        ), f"Expected warning about non-bool return, got: {[r.message for r in caplog.records]}"
+
+    def test_verify_fields_no_warning_on_bool_true(self, caplog):
+        """verify() returning True should not produce a warning."""
+        from karenina.benchmark.verification.evaluators.template.evaluator import TemplateEvaluator
+
+        class FakeAnswer:
+            def verify(self):
+                return True
+
+        evaluator = TemplateEvaluator.__new__(TemplateEvaluator)
+
+        with caplog.at_level(logging.WARNING):
+            result = evaluator.verify_fields(FakeAnswer())
+
+        assert result.success is True
+        # No non-bool warning
+        assert not any(
+            "non-bool" in record.message.lower() or "not a bool" in record.message.lower() for record in caplog.records
+        )
+
+    def test_verify_fields_no_warning_on_bool_false(self, caplog):
+        """verify() returning False should not produce a warning."""
+        from karenina.benchmark.verification.evaluators.template.evaluator import TemplateEvaluator
+
+        class FakeAnswer:
+            def verify(self):
+                return False
+
+        evaluator = TemplateEvaluator.__new__(TemplateEvaluator)
+
+        with caplog.at_level(logging.WARNING):
+            result = evaluator.verify_fields(FakeAnswer())
+
+        assert result.success is False
+        assert not any(
+            "non-bool" in record.message.lower() or "not a bool" in record.message.lower() for record in caplog.records
+        )
+
+    def test_verify_fields_warns_on_integer_return(self, caplog):
+        """verify() returning 1 (int, truthy but not bool) should log a warning."""
+        from karenina.benchmark.verification.evaluators.template.evaluator import TemplateEvaluator
+
+        class FakeAnswer:
+            def verify(self):
+                return 1
+
+        evaluator = TemplateEvaluator.__new__(TemplateEvaluator)
+
+        with caplog.at_level(logging.WARNING):
+            result = evaluator.verify_fields(FakeAnswer())
+
+        assert result.success == 1
+        assert any(
+            "non-bool" in record.message.lower() or "not a bool" in record.message.lower() for record in caplog.records
+        )

--- a/tests/unit/verification/test_orchestrator_issues.py
+++ b/tests/unit/verification/test_orchestrator_issues.py
@@ -1,0 +1,145 @@
+"""Tests for StageOrchestrator bug fixes.
+
+Issue 157: rubric_only mode silently excludes sufficiency check.
+Issue 158: DeepJudgmentRubricAutoFailStage always included in rubric_only.
+"""
+
+import logging
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.orchestrator import StageOrchestrator
+from karenina.benchmark.verification.stages.pipeline.deep_judgment_rubric_auto_fail import (
+    DeepJudgmentRubricAutoFailStage,
+)
+from karenina.benchmark.verification.stages.pipeline.sufficiency_check import SufficiencyCheckStage
+from karenina.schemas.entities.rubric import LLMRubricTrait, Rubric
+
+
+def _make_rubric_with_llm_trait() -> Rubric:
+    """Create a minimal rubric with one LLM trait for testing."""
+    return Rubric(
+        llm_traits=[
+            LLMRubricTrait(
+                name="clarity",
+                description="Is the response clear?",
+                kind="boolean",
+            )
+        ]
+    )
+
+
+def _get_stage_names(orchestrator: StageOrchestrator) -> list[str]:
+    """Extract stage names from orchestrator."""
+    return [stage.name for stage in orchestrator.stages]
+
+
+@pytest.mark.unit
+class TestRubricOnlySufficiencyLog:
+    """Issue 157: rubric_only with sufficiency_enabled should log a message."""
+
+    def test_rubric_only_with_sufficiency_enabled_logs_info(self, caplog):
+        """When rubric_only and sufficiency_enabled=True, a log message should be emitted."""
+        rubric = _make_rubric_with_llm_trait()
+
+        with caplog.at_level(logging.INFO):
+            orchestrator = StageOrchestrator.from_config(
+                rubric=rubric,
+                evaluation_mode="rubric_only",
+                sufficiency_enabled=True,
+            )
+
+        # Sufficiency stage should NOT be in the pipeline
+        assert not any(isinstance(s, SufficiencyCheckStage) for s in orchestrator.stages), (
+            "SufficiencyCheckStage should not be in rubric_only pipeline"
+        )
+
+        # But an info log should have been emitted explaining the skip
+        assert any(
+            "sufficiency" in record.message.lower() and "rubric_only" in record.message.lower()
+            for record in caplog.records
+        ), (
+            f"Expected info log about sufficiency being skipped in rubric_only mode, "
+            f"got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_rubric_only_without_sufficiency_no_log(self, caplog):
+        """When rubric_only and sufficiency_enabled=False, no sufficiency log should be emitted."""
+        rubric = _make_rubric_with_llm_trait()
+
+        with caplog.at_level(logging.INFO):
+            StageOrchestrator.from_config(
+                rubric=rubric,
+                evaluation_mode="rubric_only",
+                sufficiency_enabled=False,
+            )
+
+        # No sufficiency-related log expected
+        assert not any(
+            "sufficiency" in record.message.lower() and "rubric_only" in record.message.lower()
+            for record in caplog.records
+        )
+
+
+@pytest.mark.unit
+class TestRubricOnlyDeepJudgmentGating:
+    """Issue 158: DeepJudgmentRubricAutoFailStage should be gated on deep_judgment_enabled."""
+
+    def test_rubric_only_includes_deep_judgment_rubric_without_flag(self):
+        """Before fix: DeepJudgmentRubricAutoFailStage is always included in rubric_only."""
+        rubric = _make_rubric_with_llm_trait()
+
+        orchestrator = StageOrchestrator.from_config(
+            rubric=rubric,
+            evaluation_mode="rubric_only",
+            deep_judgment_enabled=False,
+        )
+
+        has_dj_rubric = any(isinstance(s, DeepJudgmentRubricAutoFailStage) for s in orchestrator.stages)
+        # After fix, it should NOT be present when deep_judgment_enabled=False
+        assert not has_dj_rubric, (
+            "DeepJudgmentRubricAutoFailStage should not be in pipeline when deep_judgment_enabled=False"
+        )
+
+    def test_rubric_only_includes_deep_judgment_rubric_with_flag(self):
+        """When deep_judgment_enabled=True, DeepJudgmentRubricAutoFailStage should be present."""
+        rubric = _make_rubric_with_llm_trait()
+
+        orchestrator = StageOrchestrator.from_config(
+            rubric=rubric,
+            evaluation_mode="rubric_only",
+            deep_judgment_enabled=True,
+        )
+
+        has_dj_rubric = any(isinstance(s, DeepJudgmentRubricAutoFailStage) for s in orchestrator.stages)
+        assert has_dj_rubric, "DeepJudgmentRubricAutoFailStage should be in pipeline when deep_judgment_enabled=True"
+
+    def test_template_and_rubric_deep_judgment_gating_consistent(self):
+        """template_and_rubric mode should also gate DeepJudgmentRubricAutoFailStage.
+
+        This ensures the fix is consistent across both modes.
+        """
+        rubric = _make_rubric_with_llm_trait()
+
+        # Without deep_judgment_enabled
+        orchestrator_off = StageOrchestrator.from_config(
+            rubric=rubric,
+            evaluation_mode="template_and_rubric",
+            deep_judgment_enabled=False,
+        )
+        has_dj_rubric_off = any(isinstance(s, DeepJudgmentRubricAutoFailStage) for s in orchestrator_off.stages)
+
+        # With deep_judgment_enabled
+        orchestrator_on = StageOrchestrator.from_config(
+            rubric=rubric,
+            evaluation_mode="template_and_rubric",
+            deep_judgment_enabled=True,
+        )
+        has_dj_rubric_on = any(isinstance(s, DeepJudgmentRubricAutoFailStage) for s in orchestrator_on.stages)
+
+        assert not has_dj_rubric_off, (
+            "template_and_rubric should not include DeepJudgmentRubricAutoFailStage when deep_judgment_enabled=False"
+        )
+        assert has_dj_rubric_on, (
+            "template_and_rubric should include DeepJudgmentRubricAutoFailStage when deep_judgment_enabled=True"
+        )

--- a/tests/unit/verification/test_template_parsing_helpers_issues.py
+++ b/tests/unit/verification/test_template_parsing_helpers_issues.py
@@ -1,0 +1,171 @@
+"""Tests for template parsing helpers bug fixes.
+
+Issue 098: _extract_attribute_descriptions uses regex to parse JSON schema.
+Issue 102: format_excerpts_for_reasoning raises TypeError inconsistently.
+"""
+
+import json
+
+import pytest
+
+from karenina.benchmark.verification.utils.template_parsing_helpers import (
+    _extract_attribute_descriptions,
+    format_excerpts_for_reasoning,
+)
+
+
+@pytest.mark.unit
+class TestExtractAttributeDescriptionsJsonParsing:
+    """Issue 098: replace regex with json.loads + dict navigation."""
+
+    def test_simple_schema_extracts_descriptions(self):
+        """Basic schema with descriptions should work."""
+        schema = json.dumps(
+            {
+                "properties": {
+                    "drug_target": {
+                        "description": "The target protein",
+                        "type": "string",
+                    },
+                    "mechanism": {
+                        "description": "Mechanism of action",
+                        "type": "string",
+                    },
+                }
+            }
+        )
+        result = _extract_attribute_descriptions(schema, ["drug_target", "mechanism"])
+        assert result == {
+            "drug_target": "The target protein",
+            "mechanism": "Mechanism of action",
+        }
+
+    def test_description_with_escaped_quotes(self):
+        """Descriptions containing escaped quotes should be extracted correctly.
+
+        The old regex pattern [^}]* would fail when descriptions contain
+        escaped quotes because the regex cannot distinguish escaped quotes
+        from the closing brace boundary.
+        """
+        schema = json.dumps(
+            {
+                "properties": {
+                    "answer": {
+                        "description": 'The "correct" answer to the question',
+                        "type": "string",
+                    }
+                }
+            }
+        )
+        result = _extract_attribute_descriptions(schema, ["answer"])
+        assert result == {"answer": 'The "correct" answer to the question'}
+
+    def test_nested_objects_in_schema(self):
+        """Schemas with nested objects should be parsed correctly.
+
+        The old regex [^}]* fails on nested objects because the first }
+        from the nested object terminates the match prematurely.
+        """
+        schema = json.dumps(
+            {
+                "properties": {
+                    "result": {
+                        "description": "The result value",
+                        "type": "object",
+                        "properties": {
+                            "sub_field": {"type": "string"},
+                        },
+                    }
+                }
+            }
+        )
+        result = _extract_attribute_descriptions(schema, ["result"])
+        assert result == {"result": "The result value"}
+
+    def test_missing_attribute_returns_fallback(self):
+        """Attributes not in schema should get fallback description."""
+        schema = json.dumps({"properties": {}})
+        result = _extract_attribute_descriptions(schema, ["missing_field"])
+        assert result == {"missing_field": "Evidence for missing_field"}
+
+    def test_invalid_json_schema_returns_fallbacks(self):
+        """Invalid JSON schema string should produce fallback descriptions."""
+        result = _extract_attribute_descriptions("not valid json", ["field_a"])
+        assert result == {"field_a": "Evidence for field_a"}
+
+    def test_attribute_without_description_key(self):
+        """Attribute present but lacking a description key should get fallback."""
+        schema = json.dumps(
+            {
+                "properties": {
+                    "score": {
+                        "type": "integer",
+                    }
+                }
+            }
+        )
+        result = _extract_attribute_descriptions(schema, ["score"])
+        assert result == {"score": "Evidence for score"}
+
+
+@pytest.mark.unit
+class TestFormatExcerptsForReasoningTypeError:
+    """Issue 102: format_excerpts_for_reasoning should not raise TypeError."""
+
+    def test_non_list_search_results_returns_string_not_raises(self):
+        """When search_results is not a list, return a string with a warning instead of raising.
+
+        Before the fix, passing a non-list search_results would raise TypeError.
+        After the fix, it should log a warning and return a string.
+        """
+        excerpts = {
+            "drug_target": [
+                {
+                    "text": "some excerpt",
+                    "confidence": "high",
+                    "similarity_score": 0.9,
+                    "search_results": "this is not a list",
+                }
+            ]
+        }
+        # Should NOT raise TypeError
+        result = format_excerpts_for_reasoning(excerpts)
+        assert isinstance(result, str)
+        assert "drug_target" in result
+
+    def test_dict_search_results_returns_string_not_raises(self):
+        """When search_results is a dict instead of list, should not raise."""
+        excerpts = {
+            "mechanism": [
+                {
+                    "text": "some text",
+                    "confidence": "medium",
+                    "similarity_score": 0.5,
+                    "search_results": {"key": "value"},
+                }
+            ]
+        }
+        result = format_excerpts_for_reasoning(excerpts)
+        assert isinstance(result, str)
+        assert "mechanism" in result
+
+    def test_valid_list_search_results_still_works(self):
+        """Valid list search_results should continue to work."""
+        excerpts = {
+            "answer": [
+                {
+                    "text": "some text",
+                    "confidence": "high",
+                    "similarity_score": 0.95,
+                    "search_results": [{"title": "Result 1", "content": "Content 1", "url": "http://example.com"}],
+                }
+            ]
+        }
+        result = format_excerpts_for_reasoning(excerpts)
+        assert isinstance(result, str)
+        assert "Result 1" in result
+
+    def test_empty_excerpts_returns_default(self):
+        """Empty dict should return default message (existing behavior)."""
+        result = format_excerpts_for_reasoning({})
+        assert result == "(No excerpts extracted)"

--- a/tests/unit/verification/test_verify_template_issues.py
+++ b/tests/unit/verification/test_verify_template_issues.py
@@ -1,0 +1,141 @@
+"""Tests for VerifyTemplateStage bug fixes.
+
+Issue 085: Regex-only verify() exception treated as fatal vs non-fatal in standard path.
+"""
+
+import logging
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import ArtifactKeys, VerificationContext
+from karenina.benchmark.verification.stages.pipeline.verify_template import VerifyTemplateStage
+from karenina.schemas.config import ModelConfig
+
+
+def _make_context(**overrides) -> VerificationContext:
+    """Create a minimal VerificationContext for testing."""
+    defaults = {
+        "question_id": "q1",
+        "template_id": "t1",
+        "question_text": "What is X?",
+        "template_code": "class Answer: ...",
+        "answering_model": ModelConfig(id="test-model", model_name="test-model", interface="langchain"),
+        "parsing_model": ModelConfig(id="test-model", model_name="test-model", interface="langchain"),
+    }
+    defaults.update(overrides)
+    return VerificationContext(**defaults)
+
+
+@pytest.mark.unit
+class TestVerifyTemplateRegexOnlyExceptionHandling:
+    """Issue 085: Regex-only path should handle verify() exceptions non-fatally."""
+
+    def test_regex_only_verify_exception_is_non_fatal(self, caplog):
+        """When verify() raises in the regex-only path, it should NOT mark_error (fatal).
+
+        Before the fix, the exception would propagate to the outer try/except
+        which calls context.mark_error(), making it fatal. After the fix, the
+        exception is caught inline and field_verification_result is set to False.
+        """
+
+        class FakeAnswer:
+            _raw_trace = None
+
+            def verify(self):
+                raise ValueError("something went wrong in verify")
+
+            def verify_regex(self, _raw_response):
+                return {"success": True, "results": {}, "details": {}}
+
+        stage = VerifyTemplateStage()
+        context = _make_context()
+
+        # Set up artifacts: parsed_answer and raw_llm_response present, no evaluator (regex-only)
+        context.set_artifact(ArtifactKeys.PARSED_ANSWER, FakeAnswer())
+        context.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "some response text")
+        # No TEMPLATE_EVALUATOR set: triggers regex-only path
+
+        with caplog.at_level(logging.WARNING):
+            stage.execute(context)
+
+        # Should NOT have marked a fatal error
+        assert context.error is None, f"Expected non-fatal handling but got fatal error: {context.error}"
+        # Field verification result should be False (exception treated as failure)
+        field_result = context.get_artifact(ArtifactKeys.FIELD_VERIFICATION_RESULT)
+        assert field_result is False
+
+        # Combined verify_result should be False (field failed)
+        verify_result = context.get_artifact(ArtifactKeys.VERIFY_RESULT)
+        assert verify_result is False
+
+        # Warning should have been logged
+        assert any("field verification error" in record.message.lower() for record in caplog.records), (
+            f"Expected warning about field verification error, got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_standard_path_verify_exception_is_non_fatal(self, caplog):
+        """Standard path already handles verify() exceptions non-fatally via evaluator.
+
+        This test confirms the existing behavior is preserved.
+        """
+        from karenina.benchmark.verification.evaluators.template.results import (
+            FieldVerificationResult,
+            RegexVerificationResult,
+        )
+
+        class FakeEvaluator:
+            def verify_fields(self, _parsed_answer):
+                result = FieldVerificationResult()
+                result.error = "Field verification failed: something went wrong"
+                # success remains False
+                return result
+
+            def verify_regex(self, _parsed_answer, _raw_response):
+                result = RegexVerificationResult()
+                result.success = True
+                result.results = {}
+                result.details = {}
+                return result
+
+        class FakeAnswer:
+            _raw_trace = None
+
+        stage = VerifyTemplateStage()
+        context = _make_context()
+
+        context.set_artifact(ArtifactKeys.PARSED_ANSWER, FakeAnswer())
+        context.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "some response text")
+        context.set_artifact(ArtifactKeys.TEMPLATE_EVALUATOR, FakeEvaluator())
+
+        with caplog.at_level(logging.WARNING):
+            stage.execute(context)
+
+        # Should NOT have marked a fatal error
+        assert context.error is None
+        # Field verification result should be False
+        field_result = context.get_artifact(ArtifactKeys.FIELD_VERIFICATION_RESULT)
+        assert field_result is False
+
+    def test_regex_only_verify_success_works(self):
+        """Regex-only path with successful verify() should work normally."""
+
+        class FakeAnswer:
+            _raw_trace = None
+
+            def verify(self):
+                return True
+
+            def verify_regex(self, _raw_response):
+                return {"success": True, "results": {"field1": True}, "details": {}}
+
+        stage = VerifyTemplateStage()
+        context = _make_context()
+
+        context.set_artifact(ArtifactKeys.PARSED_ANSWER, FakeAnswer())
+        context.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "some response text")
+
+        stage.execute(context)
+
+        assert context.error is None
+        assert context.get_artifact(ArtifactKeys.FIELD_VERIFICATION_RESULT) is True
+        assert context.get_artifact(ArtifactKeys.VERIFY_RESULT) is True


### PR DESCRIPTION
## Summary

- **Schemas**: Prevent shared ModelConfig mutation via deep-copy, type `db_config` with validator, add verification cache invalidation, warn on unknown regex flags
- **Results**: Convert tuple dict keys to strings for JSON serialization, fix metric trait detection (scores not confusion_lists), fix question_count float type, remove CSV double-escaping
- **Validation**: Add JSON validation on brace-starting input, replace regex with `json.loads()` for schema parsing, normalize error handling to warnings
- **Pipeline**: Check `verify()` return type, normalize regex-only exception handling to non-fatal, log sufficiency skip in rubric_only mode, gate `DeepJudgmentRubricAutoFailStage` on config flag
- **Core**: Prevent duplicate question IDs in checkpoint, fix tool message content duplication, handle dict-format rubrics in validation, strip doubled AI message prefix

## Test plan

- [x] 65 new tests across 16 test files, all following TDD (written before fixes)
- [x] Full test suite passes: 3823 passed, 30 skipped, 0 failures
- [x] All 19 issues verified against original issue files and reproduction scripts from `automated_experiments/iterations/`
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy, vulture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)