### PR TITLE
fix: adapter & port protocol hygiene (Chunk 10)

### DIFF
--- a/docs/advanced-adapters/available-adapters.md
+++ b/docs/advanced-adapters/available-adapters.md
@@ -190,6 +190,8 @@ The agent adapter uses `create_deep_agent()` from the `deepagents` package, whic
 - Dual trace output: both a raw trace string and structured `trace_messages` list
 - Usage metadata extraction from `AIMessage.response_metadata`
 - Recursion limit detection from LangGraph state (`is_last_step`)
+- MCP server support via `langchain-mcp-adapters` (converts `MCPServerConfig` to MCP tools using `AsyncExitStack` for session lifetime management)
+- Static tool support (karenina `Tool` objects converted to LangChain tools and passed to `create_deep_agent`)
 
 Extra configuration can be passed through `AgentConfig.extra`, which forwards arbitrary keyword arguments to `create_deep_agent()`.
 

--- a/docs/advanced-adapters/mcp-integration.md
+++ b/docs/advanced-adapters/mcp-integration.md
@@ -42,7 +42,28 @@ The `karenina.utils.mcp` module provides adapter-agnostic utilities for MCP serv
 | `connect_all_mcp_servers(exit_stack, mcp_servers)` | Connect to all configured servers in parallel. Returns `dict[str, ClientSession]`. |
 | `get_all_mcp_tools(sessions)` | Call `list_tools()` on each session. Returns `list[tuple[server_name, session, mcp_tool]]`. |
 
-These utilities use the core `mcp` Python package (`mcp.client.streamable_http.streamablehttp_client`) for HTTP transport. The Claude Tool adapter reuses these directly; other adapters have their own connection mechanisms.
+These utilities use the core `mcp` Python package (`mcp.client.streamable_http.streamablehttp_client`) for HTTP transport. The Claude Tool and Deep Agents adapters reuse these directly; other adapters have their own connection mechanisms.
+
+### AsyncExitStack Pattern
+
+MCP sessions must remain open for the duration of the agent loop. The correct pattern uses `AsyncExitStack` to manage session lifetimes, with cleanup deferred to the adapter's `aclose()` method:
+
+```python
+# Correct: sessions stay alive until aclose()
+self._exit_stack = AsyncExitStack()
+sessions = await connect_all_mcp_servers(self._exit_stack, mcp_servers)
+tools = await get_all_mcp_tools(sessions)
+# ... agent uses tools ...
+# In aclose(): await self._exit_stack.aclose()
+
+# Wrong: sessions close before the agent can use them
+async with AsyncExitStack() as stack:
+    sessions = await connect_all_mcp_servers(stack, mcp_servers)
+    tools = await get_all_mcp_tools(sessions)
+# sessions are dead here, but tools still reference them
+```
+
+This pattern applies to any adapter that manages MCP sessions directly (Claude Tool, Deep Agents). The Claude Agent SDK handles session management internally via its own runtime.
 
 ### Tool Description Management (`utils/mcp/tools.py`)
 
@@ -115,6 +136,34 @@ Tool filtering and description overrides apply at steps 3-4 of the execution flo
 
 - Middleware stack: summarization, prompt caching, retry logic via `AgentMiddlewareConfig`
 - Partial state recovery on recursion limit via `InMemorySaver` checkpointer
+- Multi-provider support (any LangChain-compatible LLM)
+
+### Deep Agents Adapter
+
+**Transport**: HTTP/SSE only (via `langchain-mcp-adapters`, same as the LangChain adapter)
+
+**Key classes**:
+
+- `DeepAgentsAgentAdapter` — The AgentPort implementation
+- Uses `convert_mcp_to_tools()` from the adapter's `mcp.py` module
+
+**Connection flow**:
+
+1. `convert_mcp_to_tools()` accepts `MCPServerConfig` dicts and an `AsyncExitStack`.
+2. Converts configs to URL strings, creates `MultiServerMCPClient`, fetches tools, and applies filtering/overrides.
+3. The `AsyncExitStack` is stored on the adapter and cleaned up in `aclose()`, ensuring sessions remain alive for the agent's entire run.
+
+**Agent execution**:
+
+1. MCP tools (as LangChain Tool objects) and static tools are merged and passed to `create_deep_agent(tools=...)`.
+2. The deep agent runtime handles tool calling internally as part of its planning loop.
+
+**Cleanup**: The adapter's `aclose()` method closes the `AsyncExitStack`, which tears down all MCP sessions.
+
+**Unique features**:
+
+- Uses the `AsyncExitStack` pattern for correct MCP session lifetime (see above)
+- Combines MCP tools with static tools in a single tool list for the deep agent
 - Multi-provider support (any LangChain-compatible LLM)
 
 ### Claude Agent SDK Adapter
@@ -286,12 +335,12 @@ The verification pipeline uses `trace_messages` (structured) by default. The `ra
 
 ## Transport Protocol Comparison
 
-| Transport | LangChain | Claude Agent SDK | Claude Tool |
-|-----------|-----------|-----------------|-------------|
-| **HTTP/SSE** | Via langchain-mcp-adapters `MultiServerMCPClient` | Native SDK support (`type="http"`) | Via core `mcp` package `streamablehttp_client` |
-| **Stdio** | Not supported (URL-based only) | Native SDK support (`command` + `args`) | Not supported (HTTP/SSE only) |
-| **Connection library** | langchain-mcp-adapters | Claude Agent SDK | mcp (Python package) |
-| **Cleanup** | `cleanup_mcp_client()` with fallback strategies | SDK-managed (context manager) | `AsyncExitStack` with registered cleanup |
+| Transport | LangChain | Deep Agents | Claude Agent SDK | Claude Tool |
+|-----------|-----------|-------------|-----------------|-------------|
+| **HTTP/SSE** | Via langchain-mcp-adapters `MultiServerMCPClient` | Via langchain-mcp-adapters `MultiServerMCPClient` | Native SDK support (`type="http"`) | Via core `mcp` package `streamablehttp_client` |
+| **Stdio** | Not supported (URL-based only) | Not supported (URL-based only) | Native SDK support (`command` + `args`) | Not supported (HTTP/SSE only) |
+| **Connection library** | langchain-mcp-adapters | langchain-mcp-adapters | Claude Agent SDK | mcp (Python package) |
+| **Cleanup** | `cleanup_mcp_client()` with fallback strategies | `AsyncExitStack` via `aclose()` | SDK-managed (context manager) | `AsyncExitStack` with registered cleanup |
 
 ---
 
@@ -302,6 +351,7 @@ Each adapter handles the agent exceeding its turn limit differently:
 | Adapter | Mechanism | Behavior |
 |---------|-----------|----------|
 | **LangChain** | Catches `GraphRecursionError` | Extracts partial state from `InMemorySaver` checkpointer. Returns what the agent produced so far. |
+| **Deep Agents** | Catches `GraphRecursionError` | Same LangGraph mechanism as LangChain. Returns partial state with `limit_reached=True`. |
 | **Claude Tool** | Turn counter in `_execute_agent_loop()` | Compares `turn` count against `config.max_turns`. Breaks the loop and returns partial results. |
 | **Claude Agent SDK** | `ResultMessage.subtype` field | The SDK signals limit reached via the result message. Sets `limit_reached=True` on `AgentResult`. |
 
@@ -319,6 +369,8 @@ In all cases, the pipeline's **RecursionLimitAutoFail** stage (Stage 3) checks `
 | `ports/messages.py` | Unified Message type and content blocks |
 | `adapters/langchain/mcp.py` | LangChain MCP client and tool loading |
 | `adapters/langchain/agent.py` | LangChain agent adapter with LangGraph |
+| `adapters/langchain_deep_agents/mcp.py` | Deep Agents MCP tool conversion with AsyncExitStack |
+| `adapters/langchain_deep_agents/agent.py` | Deep Agents agent adapter with create_deep_agent |
 | `adapters/claude_agent_sdk/mcp.py` | Claude SDK MCP config conversion |
 | `adapters/claude_agent_sdk/agent.py` | Claude SDK agent adapter |
 | `adapters/claude_tool/mcp.py` | Claude Tool MCP session management |

--- a/docs/advanced-adapters/ports.md
+++ b/docs/advanced-adapters/ports.md
@@ -34,6 +34,8 @@ class LLMPort(Protocol):
     def with_structured_output(
         self, schema: type[BaseModel], *, max_retries: int | None = None
     ) -> "LLMPort": ...
+
+    async def aclose(self) -> None: ...
 ```
 
 ### Methods
@@ -42,8 +44,9 @@ class LLMPort(Protocol):
 |--------|-------------|
 | `ainvoke(messages)` | Async invocation — primary API. Takes a list of `Message` objects, returns `LLMResponse`. |
 | `invoke(messages)` | Sync wrapper around `ainvoke()`. Uses `asyncio.run()` internally. |
-| `with_structured_output(schema, *, max_retries=None)` | Returns a new `LLMPort` configured for structured output using the provided Pydantic schema. |
+| `with_structured_output(schema, *, max_retries=None)` | Returns a new `LLMPort` configured for structured output using the provided Pydantic schema. Not all adapters support `max_retries`; those that do not will log a warning. |
 | `capabilities` | Property returning `PortCapabilities` declaring adapter feature support. |
+| `aclose()` | Release adapter resources. Required; must be safe to call multiple times. |
 
 ### LLMResponse
 
@@ -97,6 +100,8 @@ class ParserPort(Protocol):
     def parse_to_pydantic(
         self, messages: list[Message], schema: type[T]
     ) -> ParsePortResult[T]: ...
+
+    async def aclose(self) -> None: ...
 ```
 
 ### Methods
@@ -106,6 +111,7 @@ class ParserPort(Protocol):
 | `aparse_to_pydantic(messages, schema)` | Async parsing — primary API. Receives pre-assembled prompt messages and a Pydantic schema, returns `ParsePortResult[T]`. |
 | `parse_to_pydantic(messages, schema)` | Sync wrapper around `aparse_to_pydantic()`. Uses `asyncio.run()` internally. |
 | `capabilities` | Property returning `PortCapabilities` declaring adapter feature support. |
+| `aclose()` | Release adapter resources. Required; must be safe to call multiple times. |
 
 ### ParsePortResult
 
@@ -173,6 +179,9 @@ The most complex port. Executes multi-turn agent loops with tool use and MCP ser
 from karenina.ports.agent import AgentPort, AgentConfig, AgentResult, Tool, MCPServerConfig
 
 class AgentPort(Protocol):
+    @property
+    def capabilities(self) -> PortCapabilities: ...
+
     async def arun(
         self,
         messages: list[Message],
@@ -188,17 +197,18 @@ class AgentPort(Protocol):
         mcp_servers: dict[str, MCPServerConfig] | None = None,
         config: AgentConfig | None = None,
     ) -> AgentResult: ...
+
+    async def aclose(self) -> None: ...
 ```
 
 ### Methods
 
 | Method | Description |
 |--------|-------------|
+| `capabilities` | Property returning `PortCapabilities` declaring adapter feature support. |
 | `arun(messages, tools=None, mcp_servers=None, config=None)` | Async agent execution — primary API. Runs an agent loop with optional tools and MCP servers. |
 | `run(messages, tools=None, mcp_servers=None, config=None)` | Sync wrapper around `arun()`. Creates a new event loop — do not call from within an existing async context. |
-
-!!! note "No capabilities property"
-    Unlike LLMPort and ParserPort, AgentPort does not expose a `capabilities` property. Agent capabilities are determined by the adapter implementation and MCP server configuration.
+| `aclose()` | Release adapter resources (MCP sessions, SDK clients). Required; must be safe to call multiple times. |
 
 ### AgentConfig
 

--- a/docs/advanced-adapters/writing-adapters.md
+++ b/docs/advanced-adapters/writing-adapters.md
@@ -46,7 +46,7 @@ Adapter classes use **duck typing** — they implement the port method signature
 
 ### Implementing LLMPort
 
-The simplest port. Implement `ainvoke`, `invoke`, `with_structured_output`, and a `capabilities` property:
+The simplest port. Implement `ainvoke`, `invoke`, `with_structured_output`, `aclose`, and a `capabilities` property:
 
 ```python
 from __future__ import annotations
@@ -118,7 +118,19 @@ class MyProviderLLMAdapter:
         If your provider doesn't support native structured output,
         return self unchanged — the pipeline will handle JSON parsing.
         """
+        if max_retries is not None:
+            logger.warning(
+                "%s does not support max_retries (got %d), ignoring",
+                type(self).__name__, max_retries,
+            )
         return self
+
+    async def aclose(self) -> None:
+        """Release adapter resources.
+
+        Required protocol method. Implement even if the adapter holds
+        no resources (as a no-op). Must be safe to call multiple times.
+        """
 
     def _convert_messages(self, messages: list[Message]) -> list[dict]:
         """Convert karenina Messages to provider format."""
@@ -195,6 +207,12 @@ class MyProviderParserAdapter:
         """Sync wrapper."""
         import asyncio
         return asyncio.run(self.aparse_to_pydantic(messages, schema))
+
+    async def aclose(self) -> None:
+        """Release adapter resources.
+
+        Required protocol method. Must be safe to call multiple times.
+        """
 ```
 
 ### Implementing AgentPort
@@ -203,6 +221,7 @@ The most complex port — handles multi-turn execution with optional tools and M
 
 ```python
 from karenina.ports.agent import AgentConfig, AgentResult
+from karenina.ports.capabilities import PortCapabilities
 from karenina.ports.messages import Message
 from karenina.ports.usage import UsageMetadata
 from karenina.schemas.config import ModelConfig
@@ -216,6 +235,17 @@ class MyProviderAgentAdapter:
 
     def __init__(self, model_config: ModelConfig) -> None:
         self._config = model_config
+
+    @property
+    def capabilities(self) -> PortCapabilities:
+        """Declare adapter capabilities.
+
+        Required on all three ports (AgentPort, LLMPort, ParserPort).
+        """
+        return PortCapabilities(
+            supports_system_prompt=True,
+            supports_structured_output=False,
+        )
 
     async def arun(
         self,
@@ -249,6 +279,12 @@ class MyProviderAgentAdapter:
         """Sync wrapper."""
         import asyncio
         return asyncio.run(self.arun(messages, tools, mcp_servers, config))
+
+    async def aclose(self) -> None:
+        """Release adapter resources (MCP sessions, SDK clients, etc.).
+
+        Required protocol method. Must be safe to call multiple times.
+        """
 ```
 
 ---
@@ -556,7 +592,9 @@ config = VerificationConfig(
 
 **Usage tracking** — Always populate `UsageMetadata` with at least `input_tokens` and `output_tokens`. The pipeline uses these for cost tracking and reporting.
 
-**Adapter cleanup** — If your adapter holds resources (connections, sessions), implement an `aclose()` method. The registry calls `cleanup_all_adapters()` at shutdown to close tracked instances.
+**Adapter cleanup** — `aclose()` is a required protocol method on all three ports. Every adapter must implement it. If the adapter holds no resources, implement it as an empty async method. For adapters that manage MCP sessions, use `AsyncExitStack` to keep sessions alive across the agent loop and clean them up in `aclose()`. The registry calls `cleanup_all_adapters()` at shutdown.
+
+**max_retries varies by adapter** — The `with_structured_output(schema, max_retries=N)` parameter is not universally supported. If your adapter does not support it, emit `logger.warning()` when it is passed so callers know the value is being ignored.
 
 ---
 

--- a/docs/superpowers/plans/2026-03-23-adapter-hygiene.md
+++ b/docs/superpowers/plans/2026-03-23-adapter-hygiene.md
@@ -1,0 +1,1393 @@
+# Adapter & Port Protocol Hygiene Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 15 issues across 4 adapters, 3 port protocols, and cross-adapter behavior: fragile heuristics, missing protocol methods, operator precedence bugs, import-time side effects, and dead MCP integration code.
+
+**Architecture:** Sequential dependency-ordered fixes. First wire up Deep Agents MCP/tools (095 -> 091/092), then formalize port protocols (138 -> 139), then fix independent issues in any order. Each task produces a commit.
+
+**Tech Stack:** Python 3.13, Pydantic v2, asyncio (AsyncExitStack), pytest, LangChain, Claude Agent SDK
+
+**Spec:** `docs/superpowers/specs/2026-03-23-adapter-hygiene-design.md`
+
+---
+
+## File Structure
+
+No new source files created. All changes are modifications to existing files.
+
+**Source files modified:**
+
+| File | Issues | Changes |
+|------|--------|---------|
+| `src/karenina/adapters/langchain_deep_agents/llm.py` | 095, 142 | Add `aclose()`, add `max_retries` warning in `with_structured_output()` |
+| `src/karenina/adapters/langchain_deep_agents/agent.py` | 091 | Wire tools/mcp_servers into `arun()` via AsyncExitStack |
+| `src/karenina/adapters/langchain_deep_agents/mcp.py` | 092 | Accept `AsyncExitStack`, fix session lifetime |
+| `src/karenina/adapters/langchain_deep_agents/errors.py` | 093 | Fix operator precedence on line 40 |
+| `src/karenina/adapters/langchain_deep_agents/prompts/rubric.py` | 094 | Add `rubric_dynamic_presence_check` to `_RUBRIC_TASKS` |
+| `src/karenina/adapters/langchain/trace.py` | 067 | Remove `_detect_tool_error` heuristic |
+| `src/karenina/adapters/claude_agent_sdk/agent.py` | 068, 069 | Route errors through `wrap_sdk_error()`, fix MCP config detection |
+| `src/karenina/adapters/claude_agent_sdk/errors.py` | 068 | Add turn-limit case to `wrap_sdk_error()` |
+| `src/karenina/adapters/claude_agent_sdk/llm.py` | 142 | Add `max_retries` warning in `with_structured_output()` |
+| `src/karenina/adapters/claude_tool/llm.py` | 090 | Remove module-level `load_dotenv()` |
+| `src/karenina/adapters/claude_tool/agent.py` | 090 | Remove module-level `load_dotenv()` |
+| `src/karenina/benchmark/verification/evaluators/template/deep_judgment.py` | 086 | Replace `PydanticOutputParser` with native Pydantic v2 |
+| `src/karenina/benchmark/verification/evaluators/template/evaluator.py` | 086 | Remove unused `PydanticOutputParser` import |
+| `src/karenina/ports/errors.py` | 068 | Add `limit_reached` attribute to `AgentExecutionError` |
+| `src/karenina/ports/llm.py` | 138, 142 | Add `aclose()` to protocol, update `with_structured_output` docstring |
+| `src/karenina/ports/agent.py` | 138, 139 | Add `aclose()` and `capabilities` to protocol |
+| `src/karenina/ports/parser.py` | 138 | Add `aclose()` to protocol |
+
+**Test files modified or created:**
+
+| File | Tests for |
+|------|-----------|
+| `tests/unit/adapters/langchain_deep_agents/test_llm.py` | 095 (aclose), 142 (max_retries warning) |
+| `tests/unit/adapters/langchain_deep_agents/test_agent.py` | 091 (MCP/tools wiring) |
+| `tests/unit/adapters/langchain_deep_agents/test_mcp.py` | 092 (session lifetime) |
+| `tests/unit/adapters/langchain_deep_agents/test_errors.py` (CREATE) | 093 (operator precedence) |
+| `tests/unit/adapters/langchain_deep_agents/test_rubric_registration.py` (CREATE) | 094 (task registration) |
+| `tests/unit/adapters/langchain/test_trace.py` (CREATE or find existing) | 067 (heuristic removal) |
+| `tests/unit/adapters/claude_sdk/test_errors.py` | 068 (turn-limit wrapping) |
+| `tests/unit/adapters/claude_sdk/test_mcp_config.py` | 069 (format detection) |
+| `tests/unit/adapters/claude_tool/test_llm_adapter.py` | 090 (no load_dotenv side effect) |
+| `tests/unit/adapters/conformance/test_llm_port.py` | 138 (aclose on protocol) |
+| `tests/unit/adapters/conformance/test_agent_port.py` | 138, 139 (aclose + capabilities) |
+| `tests/unit/adapters/conformance/test_parser_port.py` | 138 (aclose on protocol) |
+
+---
+
+### Task 1: Add `aclose()` to `DeepAgentsLLMAdapter` (Issue 095)
+
+**Files:**
+- Modify: `src/karenina/adapters/langchain_deep_agents/llm.py:189` (end of class)
+- Test: `tests/unit/adapters/langchain_deep_agents/test_llm.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/adapters/langchain_deep_agents/test_llm.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_aclose_exists_and_is_noop(self, deep_agents_model_config):
+    """aclose() should exist and complete without error."""
+    adapter = DeepAgentsLLMAdapter(deep_agents_model_config)
+    await adapter.aclose()  # Should not raise
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain_deep_agents/test_llm.py::TestDeepAgentsLLMAdapter::test_aclose_exists_and_is_noop -v`
+Expected: FAIL with `AttributeError: 'DeepAgentsLLMAdapter' object has no attribute 'aclose'`
+
+- [ ] **Step 3: Implement `aclose()`**
+
+Add at end of `DeepAgentsLLMAdapter` class in `src/karenina/adapters/langchain_deep_agents/llm.py` (after `with_structured_output`):
+
+```python
+async def aclose(self) -> None:
+    """Close underlying resources.
+
+    No resources to clean up: the LangChain model is created fresh
+    per ainvoke() call. Provided for interface consistency with other
+    adapters.
+    """
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain_deep_agents/test_llm.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/karenina/adapters/langchain_deep_agents/llm.py tests/unit/adapters/langchain_deep_agents/test_llm.py
+git commit -m "fix(deep-agents): add aclose() to DeepAgentsLLMAdapter (095)"
+```
+
+---
+
+### Task 2: Fix `convert_mcp_to_tools()` session lifetime (Issue 092)
+
+**Files:**
+- Modify: `src/karenina/adapters/langchain_deep_agents/mcp.py:73-94`
+- Test: `tests/unit/adapters/langchain_deep_agents/test_mcp.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/adapters/langchain_deep_agents/test_mcp.py`:
+
+```python
+from contextlib import AsyncExitStack
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.unit
+class TestConvertMcpToToolsSessionLifetime:
+    """Test that convert_mcp_to_tools keeps sessions alive via exit_stack."""
+
+    @pytest.mark.asyncio
+    async def test_sessions_remain_open_after_return(self):
+        """Tools returned by convert_mcp_to_tools should have live sessions.
+
+        The function should register sessions with the exit_stack rather than
+        closing them when the function returns.
+        """
+        from karenina.adapters.langchain_deep_agents.mcp import convert_mcp_to_tools
+
+        mock_tool = MagicMock(name="mock_tool")
+        mock_client = AsyncMock()
+        mock_client.get_tools = AsyncMock(return_value=[mock_tool])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "karenina.adapters.langchain_deep_agents.mcp.MultiServerMCPClient",
+            return_value=mock_client,
+        ):
+            async with AsyncExitStack() as exit_stack:
+                tools = await convert_mcp_to_tools(
+                    {"test": {"type": "http", "url": "http://localhost:8080"}},
+                    exit_stack,
+                )
+                assert len(tools) == 1
+                # Client should NOT have been closed yet (exit_stack still open)
+                mock_client.__aexit__.assert_not_called()
+
+            # After exit_stack closes, client should be cleaned up
+            mock_client.__aexit__.assert_called_once()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain_deep_agents/test_mcp.py::TestConvertMcpToToolsSessionLifetime -v`
+Expected: FAIL (signature mismatch or session closed prematurely)
+
+- [ ] **Step 3: Implement the fix**
+
+Replace `convert_mcp_to_tools()` in `src/karenina/adapters/langchain_deep_agents/mcp.py` (lines 73-94):
+
+```python
+async def convert_mcp_to_tools(
+    mcp_servers: dict[str, Any] | None,
+    exit_stack: AsyncExitStack,
+) -> list[Any]:
+    """Convert MCP server configs to LangChain tools via langchain-mcp-adapters.
+
+    Creates a MultiServerMCPClient registered with the provided exit_stack
+    so that MCP sessions remain open for the lifetime of the caller's
+    exit_stack context.
+
+    Args:
+        mcp_servers: Dict mapping server names to MCPServerConfig.
+        exit_stack: AsyncExitStack managing session lifecycles. Sessions
+            remain open until the exit stack closes.
+
+    Returns:
+        List of LangChain BaseTool instances from all MCP servers.
+    """
+    server_params = build_mcp_server_params(mcp_servers)
+    if not server_params:
+        return []
+
+    from langchain_mcp_adapters.client import MultiServerMCPClient
+
+    client = MultiServerMCPClient(server_params)  # type: ignore[arg-type,misc]
+    await exit_stack.enter_async_context(client)
+    return await client.get_tools()
+```
+
+Add the import at top of file:
+
+```python
+from contextlib import AsyncExitStack
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain_deep_agents/test_mcp.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/karenina/adapters/langchain_deep_agents/mcp.py tests/unit/adapters/langchain_deep_agents/test_mcp.py
+git commit -m "fix(deep-agents): fix MCP session lifetime with AsyncExitStack (092)"
+```
+
+---
+
+### Task 3: Wire up MCP/tools in Deep Agents `arun()` (Issue 091)
+
+**Files:**
+- Modify: `src/karenina/adapters/langchain_deep_agents/agent.py:128-240`
+- Test: `tests/unit/adapters/langchain_deep_agents/test_agent.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/adapters/langchain_deep_agents/test_agent.py`:
+
+```python
+@pytest.mark.unit
+class TestDeepAgentsMCPToolsWiring:
+    """Test that arun() passes tools and MCP-derived tools to the agent."""
+
+    @pytest.mark.asyncio
+    async def test_explicit_tools_passed_to_agent(self, deep_agents_model_config, monkeypatch):
+        """Explicit tools should be forwarded to create_deep_agent."""
+        from karenina.ports import AgentConfig, Message, Tool
+
+        captured_kwargs = {}
+
+        def mock_create_deep_agent(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_agent = AsyncMock()
+            mock_agent.ainvoke = AsyncMock(return_value={
+                "messages": [MagicMock(content="Done", type="ai")],
+                "is_last_step": False,
+            })
+            return mock_agent
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+            mock_create_deep_agent,
+        )
+        # Mock trace/usage extraction to avoid LangChain imports
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.deep_agents_messages_to_raw_trace",
+            lambda msgs: "trace",
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.extract_deep_agents_usage",
+            lambda msgs, model: UsageMetadata(model=model),
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.extract_actual_model",
+            lambda msgs: None,
+        )
+
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        test_tool = Tool(name="test_tool", description="A test tool", input_schema={})
+
+        await adapter.arun(
+            messages=[Message.user("Hello")],
+            tools=[test_tool],
+            config=AgentConfig(max_turns=5),
+        )
+
+        assert "tools" in captured_kwargs
+        assert len(captured_kwargs["tools"]) >= 1
+```
+
+(Also add necessary imports at top: `from unittest.mock import AsyncMock, MagicMock` and `from karenina.ports.usage import UsageMetadata`)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain_deep_agents/test_agent.py::TestDeepAgentsMCPToolsWiring -v`
+Expected: FAIL (tools not passed to create_deep_agent because of `# noqa: ARG002`)
+
+- [ ] **Step 3: Implement the wiring**
+
+Modify `arun()` in `src/karenina/adapters/langchain_deep_agents/agent.py`:
+
+1. Add import at top of file: `from contextlib import AsyncExitStack`
+
+2. Remove `# noqa: ARG002` comments from lines 131-132:
+```python
+    tools: list[Tool] | None = None,
+    mcp_servers: dict[str, MCPServerConfig] | None = None,
+```
+
+3. Replace the agent execution block (lines 199-240) with the AsyncExitStack pattern. After `agent_kwargs` is built (line 197), before creating the agent:
+
+```python
+        # Convert MCP servers to LangChain tools and combine with explicit tools
+        all_tools: list[Any] = []
+        if tools:
+            all_tools.extend(tools)
+
+        # Use AsyncExitStack for persistent MCP sessions. Sessions stay alive
+        # for all tool calls during agent execution. Exceptions are captured
+        # inside the block and re-raised after clean exit, because MCP session
+        # cleanup can wrap errors in ExceptionGroup if an exception propagates
+        # through the exit stack.
+        deferred_error: Exception | None = None
+
+        async with AsyncExitStack() as exit_stack:
+            # Convert MCP servers to LangChain tools
+            if mcp_servers:
+                from .mcp import convert_mcp_to_tools
+
+                try:
+                    mcp_tools = await convert_mcp_to_tools(mcp_servers, exit_stack)
+                    all_tools.extend(mcp_tools)
+                    logger.info(
+                        "Loaded %d MCP tools from %d servers",
+                        len(mcp_tools),
+                        len(mcp_servers),
+                    )
+                except Exception as e:
+                    logger.warning("Failed to load MCP tools: %s", e)
+                    deferred_error = AgentExecutionError(
+                        f"Failed to initialize MCP tools: {e}"
+                    )
+                    deferred_error.__cause__ = e
+
+            if deferred_error is None:
+                # Pass tools to agent if any were collected
+                if all_tools:
+                    agent_kwargs["tools"] = all_tools
+
+                # Create the agent
+                agent = _create_deep_agent(**agent_kwargs)
+
+                # Build invocation input
+                invoke_input: dict[str, Any] = {
+                    "messages": [{"role": "user", "content": prompt_string}],
+                }
+
+                # LangGraph config for recursion limit
+                # Each tool call + response = 2 steps, so double max_turns
+                langgraph_config: dict[str, Any] = {
+                    "recursion_limit": config.max_turns * 2,
+                }
+
+                # Execute agent
+                result: dict[str, Any] = {}
+                limit_reached = False
+
+                async def execute_agent() -> None:
+                    nonlocal result, limit_reached
+                    result = await agent.ainvoke(invoke_input, config=langgraph_config)
+                    if result.get("is_last_step", False):
+                        limit_reached = True
+
+                try:
+                    if config.timeout:
+                        await asyncio.wait_for(execute_agent(), timeout=config.timeout)
+                    else:
+                        await execute_agent()
+
+                except TimeoutError as e:
+                    deferred_error = AgentTimeoutError(
+                        f"Agent execution timed out after {config.timeout}s"
+                    )
+                    deferred_error.__cause__ = e
+                except Exception as e:
+                    mapped_error, was_limit = wrap_deep_agents_error(e)
+                    if was_limit:
+                        limit_reached = True
+                        logger.warning("Agent hit turn limit: %s", e)
+                    else:
+                        deferred_error = mapped_error
+                        deferred_error.__cause__ = e
+
+        # exit_stack closed: MCP sessions cleaned up
+
+        if deferred_error is not None:
+            raise deferred_error
+```
+
+Also add `AgentExecutionError` to the imports from `karenina.ports` at the top of the file (line 21-30).
+
+4. The rest of the method (extract messages, build traces, etc.) stays the same but now uses the `result` and `limit_reached` variables that were set inside the exit_stack block.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain_deep_agents/test_agent.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Run broader adapter tests**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain_deep_agents/ -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/karenina/adapters/langchain_deep_agents/agent.py tests/unit/adapters/langchain_deep_agents/test_agent.py
+git commit -m "feat(deep-agents): wire up MCP/tools support in arun() (091)"
+```
+
+---
+
+### Task 4: Add `aclose()` to port protocols (Issue 138)
+
+**Files:**
+- Modify: `src/karenina/ports/llm.py:129` (end of LLMPort)
+- Modify: `src/karenina/ports/agent.py:313` (end of AgentPort)
+- Modify: `src/karenina/ports/parser.py:133` (end of ParserPort)
+- Test: `tests/unit/adapters/conformance/test_llm_port.py`, `test_agent_port.py`, `test_parser_port.py`
+
+- [ ] **Step 1: Add `aclose()` to all three protocols**
+
+In `src/karenina/ports/llm.py`, add after `with_structured_output` (before end of class):
+
+```python
+    async def aclose(self) -> None:
+        """Close underlying resources.
+
+        Implementations should release any held resources (HTTP connections,
+        file handles, MCP sessions). Safe to call multiple times. The default
+        is a no-op for adapters with no resources to clean up.
+        """
+        ...
+```
+
+In `src/karenina/ports/agent.py`, add after `run` (before end of class):
+
+```python
+    async def aclose(self) -> None:
+        """Close underlying resources.
+
+        Implementations should release any held resources (HTTP connections,
+        file handles, MCP sessions). Safe to call multiple times. The default
+        is a no-op for adapters with no resources to clean up.
+        """
+        ...
+```
+
+In `src/karenina/ports/parser.py`, add after `parse_to_pydantic` (before end of class):
+
+```python
+    async def aclose(self) -> None:
+        """Close underlying resources.
+
+        Implementations should release any held resources (HTTP connections,
+        file handles, MCP sessions). Safe to call multiple times. The default
+        is a no-op for adapters with no resources to clean up.
+        """
+        ...
+```
+
+- [ ] **Step 2: Run conformance tests**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/conformance/ -v`
+Expected: All PASS (all adapters already implement aclose)
+
+- [ ] **Step 3: Run mypy on ports**
+
+Run: `cd karenina && uv run mypy src/karenina/ports/`
+Expected: No new errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/karenina/ports/llm.py src/karenina/ports/agent.py src/karenina/ports/parser.py
+git commit -m "fix(ports): add aclose() to LLMPort, AgentPort, ParserPort protocols (138)"
+```
+
+---
+
+### Task 5: Add `capabilities` to `AgentPort` (Issue 139)
+
+**Files:**
+- Modify: `src/karenina/ports/agent.py:248` (before `arun` in AgentPort)
+- Test: `tests/unit/adapters/conformance/test_agent_port.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/adapters/conformance/test_agent_port.py`:
+
+```python
+def test_agent_port_has_capabilities(self, agent_adapter):
+    """AgentPort should expose a capabilities property."""
+    caps = agent_adapter.capabilities
+    assert isinstance(caps, PortCapabilities)
+```
+
+(Add `from karenina.ports.capabilities import PortCapabilities` import if missing.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/conformance/test_agent_port.py::TestAgentPortConformance::test_agent_port_has_capabilities -v`
+Expected: FAIL (AgentPort has no capabilities property)
+
+- [ ] **Step 3: Add `capabilities` to AgentPort**
+
+In `src/karenina/ports/agent.py`, add the import at top: `from karenina.ports.capabilities import PortCapabilities`
+
+Add before `arun` method in AgentPort class:
+
+```python
+    @property
+    def capabilities(self) -> PortCapabilities:
+        """Declare what prompt features this agent adapter supports.
+
+        Returns:
+            PortCapabilities with adapter-specific feature flags.
+            Defaults to PortCapabilities() (system prompts supported,
+            structured output not supported).
+        """
+        return PortCapabilities()
+```
+
+- [ ] **Step 4: Add `capabilities` to `DeepAgentsAgentAdapter`**
+
+Check if `DeepAgentsAgentAdapter` already has a `capabilities` property. If not, add one to `src/karenina/adapters/langchain_deep_agents/agent.py`.
+
+Add the import at module level (near the existing ports imports):
+
+```python
+from karenina.ports.capabilities import PortCapabilities
+```
+
+Add the property to the class:
+
+```python
+    @property
+    def capabilities(self) -> PortCapabilities:
+        """Declare adapter capabilities.
+
+        Returns:
+            PortCapabilities with system_prompt=True.
+        """
+        return PortCapabilities(supports_system_prompt=True)
+```
+
+- [ ] **Step 5: Write test for Deep Agents agent capabilities**
+
+Add to `tests/unit/adapters/langchain_deep_agents/test_agent.py`:
+
+```python
+@pytest.mark.unit
+class TestDeepAgentsAgentCapabilities:
+    def test_capabilities_returns_port_capabilities(self, deep_agents_model_config):
+        """DeepAgentsAgentAdapter should expose a capabilities property."""
+        from karenina.ports.capabilities import PortCapabilities
+
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        caps = adapter.capabilities
+        assert isinstance(caps, PortCapabilities)
+        assert caps.supports_system_prompt is True
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/conformance/ tests/unit/adapters/langchain_deep_agents/test_agent.py -v`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/karenina/ports/agent.py src/karenina/adapters/langchain_deep_agents/agent.py tests/unit/adapters/langchain_deep_agents/test_agent.py
+git commit -m "fix(ports): add capabilities property to AgentPort protocol (139)"
+```
+
+---
+
+### Task 6: Centralize SDK error translation (Issue 068)
+
+**Files:**
+- Modify: `src/karenina/adapters/claude_agent_sdk/errors.py:128-134` (before generic fallback)
+- Modify: `src/karenina/adapters/claude_agent_sdk/agent.py:365-373`
+- Test: `tests/unit/adapters/claude_sdk/test_errors.py`
+
+- [ ] **Step 1: Write tests for the new turn-limit case**
+
+Add to `tests/unit/adapters/claude_sdk/test_errors.py`:
+
+```python
+def test_turn_limit_error_by_type_name(self) -> None:
+    """MaxTurnsExceeded exception should map to AgentExecutionError with limit flag."""
+    mock_error = MagicMock()
+    mock_error.__class__.__name__ = "MaxTurnsExceededException"
+
+    result = wrap_sdk_error(mock_error)
+
+    assert isinstance(result, AgentExecutionError)
+    assert result.limit_reached is True
+
+def test_turn_limit_error_by_message(self) -> None:
+    """Exception with 'max_turns' in message should map to limit error."""
+    error = RuntimeError("Agent exceeded max_turns limit")
+
+    result = wrap_sdk_error(error)
+
+    assert isinstance(result, AgentExecutionError)
+    assert result.limit_reached is True
+
+def test_recursion_in_message(self) -> None:
+    """Exception with 'recursion' in message should map to limit error."""
+    error = RuntimeError("Hit recursion limit after 50 turns")
+
+    result = wrap_sdk_error(error)
+
+    assert isinstance(result, AgentExecutionError)
+    assert result.limit_reached is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/claude_sdk/test_errors.py::TestWrapSdkError::test_turn_limit_error_by_type_name -v`
+Expected: FAIL (no limit_reached attribute or wrong error type)
+
+- [ ] **Step 3: Add `limit_reached` attribute to `AgentExecutionError`**
+
+`AgentExecutionError` currently has only `message` and `stderr`. Add `limit_reached` to `src/karenina/ports/errors.py`:
+
+```python
+class AgentExecutionError(PortError):
+    """Raised when an agent fails during execution.
+
+    ...existing docstring...
+
+    Args:
+        message: Human-readable description of the error.
+        stderr: Standard error output from the failed process, if available.
+        limit_reached: True if the error was caused by hitting a turn/recursion limit.
+    """
+
+    def __init__(
+        self, message: str, stderr: str | None = None, limit_reached: bool = False
+    ) -> None:
+        super().__init__(message)
+        self.stderr = stderr
+        self.limit_reached = limit_reached
+```
+
+The default `limit_reached=False` is backward-compatible with all existing callers.
+
+- [ ] **Step 4: Implement the turn-limit case in `wrap_sdk_error()`**
+
+In `src/karenina/adapters/claude_agent_sdk/errors.py`, add before the generic fallback (before line 129):
+
+```python
+    # Turn/recursion limit errors (by exception type name)
+    if exc_type_name in ("MaxTurnsExceededException", "MaxTurnsExceeded"):
+        return AgentExecutionError(
+            message=f"Agent hit turn limit: {e}",
+            limit_reached=True,
+        )
+
+    # Turn/recursion limit errors (by message content, last resort)
+    error_lower = str(e).lower()
+    if "recursion" in error_lower or "limit" in error_lower or "max_turns" in error_lower:
+        return AgentExecutionError(
+            message=f"Agent hit turn limit: {e}",
+            limit_reached=True,
+        )
+
+- [ ] **Step 5: Update `arun()` in `agent.py` to use `wrap_sdk_error()`**
+
+Replace lines 365-373 in `src/karenina/adapters/claude_agent_sdk/agent.py`:
+
+```python
+        except Exception as e:
+            from .errors import wrap_sdk_error
+
+            translated = wrap_sdk_error(e)
+            if getattr(translated, "limit_reached", False):
+                limit_reached = True
+                logger.warning("Agent hit turn limit: %s", e)
+            else:
+                raise translated from e
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/claude_sdk/test_errors.py -v`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/karenina/ports/errors.py src/karenina/adapters/claude_agent_sdk/errors.py src/karenina/adapters/claude_agent_sdk/agent.py tests/unit/adapters/claude_sdk/test_errors.py
+git commit -m "fix(claude-sdk): centralize turn-limit detection via wrap_sdk_error (068)"
+```
+
+---
+
+### Task 7: Fix operator precedence in Deep Agents errors (Issue 093)
+
+**Files:**
+- Modify: `src/karenina/adapters/langchain_deep_agents/errors.py:40`
+- Test: `tests/unit/adapters/langchain_deep_agents/test_errors.py` (CREATE)
+
+- [ ] **Step 1: Create test file and write the failing test**
+
+Create `tests/unit/adapters/langchain_deep_agents/test_errors.py`:
+
+```python
+"""Tests for Deep Agents error wrapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.adapters.langchain_deep_agents.errors import wrap_deep_agents_error
+from karenina.ports.errors import AgentExecutionError, AgentResponseError
+
+
+@pytest.mark.unit
+class TestWrapDeepAgentsError:
+    def test_parse_alone_does_not_trigger_response_error(self):
+        """'parse' alone should NOT map to AgentResponseError (093 regression)."""
+        error = RuntimeError("failed to parse MCP configuration")
+        mapped, was_limit = wrap_deep_agents_error(error)
+
+        # Should be generic execution error, NOT AgentResponseError
+        assert not isinstance(mapped, AgentResponseError)
+        assert isinstance(mapped, AgentExecutionError)
+
+    def test_parse_output_triggers_response_error(self):
+        """'parse' + 'output' should map to AgentResponseError."""
+        error = RuntimeError("failed to parse output from agent")
+        mapped, was_limit = wrap_deep_agents_error(error)
+
+        assert isinstance(mapped, AgentResponseError)
+        assert was_limit is False
+
+    def test_output_format_triggers_response_error(self):
+        """'output' + 'format' should map to AgentResponseError."""
+        error = RuntimeError("output format error in response")
+        mapped, was_limit = wrap_deep_agents_error(error)
+
+        assert isinstance(mapped, AgentResponseError)
+        assert was_limit is False
+
+    def test_recursion_limit_detected(self):
+        """Recursion limit errors should set limit_reached=True."""
+        error = RuntimeError("Hit recursion limit")
+        mapped, was_limit = wrap_deep_agents_error(error)
+
+        assert isinstance(mapped, AgentExecutionError)
+        assert was_limit is True
+```
+
+- [ ] **Step 2: Run test to verify the precedence bug**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain_deep_agents/test_errors.py::TestWrapDeepAgentsError::test_parse_alone_does_not_trigger_response_error -v`
+Expected: FAIL (currently "parse" alone triggers AgentResponseError)
+
+- [ ] **Step 3: Fix the operator precedence**
+
+In `src/karenina/adapters/langchain_deep_agents/errors.py`, change line 40 from:
+
+```python
+    if "parse" in error_str or "output" in error_str and "format" in error_str:
+```
+
+to:
+
+```python
+    if ("parse" in error_str and "output" in error_str) or ("output" in error_str and "format" in error_str):
+```
+
+- [ ] **Step 4: Run all error tests**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain_deep_agents/test_errors.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/karenina/adapters/langchain_deep_agents/errors.py tests/unit/adapters/langchain_deep_agents/test_errors.py
+git commit -m "fix(deep-agents): fix operator precedence in error classification (093)"
+```
+
+---
+
+### Task 8: Remove `_detect_tool_error` heuristic (Issue 067)
+
+**Files:**
+- Modify: `src/karenina/adapters/langchain/trace.py:215,224-249`
+- Test: find or create trace test
+
+- [ ] **Step 1: Find existing trace tests**
+
+Check: `tests/unit/adapters/langchain/` for trace-related tests. Look for tests that call `_detect_tool_error` or `langchain_messages_to_trace_messages`.
+
+- [ ] **Step 2: Write a test verifying false positives are gone**
+
+Add a test (to existing trace test file or create `tests/unit/adapters/langchain/test_trace_tool_error.py`):
+
+```python
+"""Test that tool error detection no longer produces false positives."""
+
+import pytest
+
+
+@pytest.mark.unit
+class TestToolErrorDetectionRemoved:
+    def test_legitimate_tool_output_not_flagged(self):
+        """Tool output containing 'error' in legitimate context should not be flagged."""
+        from karenina.adapters.langchain.trace import _detect_tool_error
+
+        # These should all return False (no false positives)
+        assert _detect_tool_error("No errors found in the analysis") is False
+        assert _detect_tool_error("timeout set to 30 seconds") is False
+        assert _detect_tool_error("The exception handling looks correct") is False
+        assert _detect_tool_error("Search failed to find any results") is False
+```
+
+- [ ] **Step 3: Run to confirm the false positives exist**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain/test_trace_tool_error.py -v`
+Expected: FAIL (current heuristic flags these as errors)
+
+- [ ] **Step 4: Remove the heuristic**
+
+In `src/karenina/adapters/langchain/trace.py`:
+
+Replace the `_detect_tool_error` function (lines 224-249) with:
+
+```python
+def _detect_tool_error(content: str) -> bool:
+    """Check whether tool output represents an error.
+
+    LangChain ToolMessage has no structural error indicator, so this
+    always returns False. The previous heuristic (substring matching on
+    keywords like 'error', 'failed') produced too many false positives
+    on legitimate tool output.
+
+    Args:
+        content: The tool result content string.
+
+    Returns:
+        Always False. Retained for backward compatibility with callers.
+    """
+    return False
+```
+
+- [ ] **Step 5: Run test to verify**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain/test_trace_tool_error.py -v`
+Expected: All PASS
+
+- [ ] **Step 6: Run broader trace tests**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain/ -v`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/karenina/adapters/langchain/trace.py tests/unit/adapters/langchain/test_trace_tool_error.py
+git commit -m "fix(langchain): remove false-positive-prone tool error heuristic (067)"
+```
+
+---
+
+### Task 9: Replace `PydanticOutputParser` with native Pydantic v2 (Issue 086)
+
+**Files:**
+- Modify: `src/karenina/benchmark/verification/evaluators/template/deep_judgment.py:133-136`
+- Modify: `src/karenina/benchmark/verification/evaluators/template/evaluator.py:392,415-416`
+- Create+Delete: `scripts/compare_schema_formats.py` (temporary)
+
+- [ ] **Step 1: Write comparison script**
+
+Create `scripts/compare_schema_formats.py`:
+
+```python
+"""Compare PydanticOutputParser vs model_json_schema output formats.
+
+Run: cd karenina && uv run python scripts/compare_schema_formats.py
+"""
+
+import json
+
+from pydantic import BaseModel, Field
+
+
+class SampleAnswer(BaseModel):
+    """Sample answer template for comparison."""
+
+    gene_name: str = Field(description="Name of the gene")
+    is_oncogene: bool = Field(description="Whether the gene is an oncogene")
+    confidence: float = Field(description="Confidence score between 0 and 1")
+
+
+# Method 1: PydanticOutputParser
+try:
+    from langchain_core.output_parsers import PydanticOutputParser
+
+    parser = PydanticOutputParser(pydantic_object=SampleAnswer)
+    langchain_output = parser.get_format_instructions()
+    print("=== PydanticOutputParser.get_format_instructions() ===")
+    print(langchain_output)
+    print()
+except ImportError:
+    print("langchain_core not installed, skipping PydanticOutputParser")
+    langchain_output = None
+
+# Method 2: model_json_schema
+schema = SampleAnswer.model_json_schema()
+pydantic_output = json.dumps(schema, indent=2)
+print("=== json.dumps(model_json_schema(), indent=2) ===")
+print(pydantic_output)
+print()
+
+# Method 3: model_fields
+print("=== model_fields ===")
+for name, field in SampleAnswer.model_fields.items():
+    print(f"  {name}: {field.annotation.__name__} - {field.description}")
+```
+
+- [ ] **Step 2: Run the comparison script**
+
+Run: `cd karenina && uv run python scripts/compare_schema_formats.py`
+
+Examine the output. If `model_json_schema()` provides equivalent information (field names, types, descriptions), proceed with replacement. Otherwise, use `model_fields` approach.
+
+- [ ] **Step 3: Replace in `deep_judgment.py`**
+
+In `src/karenina/benchmark/verification/evaluators/template/deep_judgment.py`, replace lines 133-136:
+
+```python
+# Before:
+from langchain_core.output_parsers import PydanticOutputParser
+temp_parser = PydanticOutputParser(pydantic_object=RawAnswer)
+json_schema = temp_parser.get_format_instructions()
+```
+
+With:
+
+```python
+import json as _json
+json_schema = _json.dumps(RawAnswer.model_json_schema(), indent=2)
+```
+
+(Use `_json` alias to avoid shadowing any local `json` variable. Check for conflicts first.)
+
+- [ ] **Step 4: Remove from `evaluator.py`**
+
+In `src/karenina/benchmark/verification/evaluators/template/evaluator.py`:
+- Remove the `from langchain_core.output_parsers import PydanticOutputParser` import (line 392)
+- Remove `parser = PydanticOutputParser(pydantic_object=self.answer_class)` (line 415)
+- Remove `format_instructions = parser.get_format_instructions()` (line 416)
+- Check if `format_instructions` is passed anywhere. If it's passed to `deep_judgment_parse()`, remove that parameter too (deep_judgment.py generates its own now).
+
+- [ ] **Step 5: Run deep judgment tests**
+
+Run: `cd karenina && uv run pytest tests/ -x -q -k "deep_judgment"`
+Expected: All PASS
+
+- [ ] **Step 6: Delete comparison script**
+
+```bash
+rm scripts/compare_schema_formats.py
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/karenina/benchmark/verification/evaluators/template/deep_judgment.py src/karenina/benchmark/verification/evaluators/template/evaluator.py
+git commit -m "fix(evaluators): replace PydanticOutputParser with native Pydantic v2 (086)"
+```
+
+---
+
+### Task 10: Remove module-level `load_dotenv()` (Issue 090)
+
+**Files:**
+- Modify: `src/karenina/adapters/claude_tool/llm.py:20,32`
+- Modify: `src/karenina/adapters/claude_tool/agent.py:23,52`
+
+- [ ] **Step 1: Write test verifying no import side effect**
+
+Add to `tests/unit/adapters/claude_tool/test_llm_adapter.py` (or create a new file):
+
+```python
+@pytest.mark.unit
+class TestNoLoadDotenvSideEffect:
+    def test_importing_llm_does_not_call_load_dotenv(self, monkeypatch):
+        """Importing claude_tool.llm should not call load_dotenv()."""
+        import importlib
+
+        call_count = 0
+        original_load = None
+
+        def tracking_load(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+
+        monkeypatch.setattr("dotenv.load_dotenv", tracking_load)
+
+        import karenina.adapters.claude_tool.llm
+        importlib.reload(karenina.adapters.claude_tool.llm)
+
+        assert call_count == 0, "load_dotenv() was called during module import"
+```
+
+- [ ] **Step 2: Remove `load_dotenv` from both files**
+
+In `src/karenina/adapters/claude_tool/llm.py`:
+- Remove `from dotenv import load_dotenv` (line 20)
+- Remove `load_dotenv()` (line 32)
+- Remove the comment above it
+
+In `src/karenina/adapters/claude_tool/agent.py`:
+- Remove `from dotenv import load_dotenv` (line 23)
+- Remove `load_dotenv()` (line 52)
+- Remove the comment above it
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/claude_tool/ -v`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/karenina/adapters/claude_tool/llm.py src/karenina/adapters/claude_tool/agent.py tests/unit/adapters/claude_tool/test_llm_adapter.py
+git commit -m "fix(claude-tool): remove module-level load_dotenv() calls (090)"
+```
+
+---
+
+### Task 11: Add missing rubric task registration (Issue 094)
+
+**Files:**
+- Modify: `src/karenina/adapters/langchain_deep_agents/prompts/rubric.py:35-41`
+- Test: `tests/unit/adapters/langchain_deep_agents/test_rubric_registration.py` (CREATE)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/adapters/langchain_deep_agents/test_rubric_registration.py`:
+
+```python
+"""Tests for Deep Agents rubric task registration."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+class TestRubricTaskRegistration:
+    def test_rubric_dynamic_presence_check_registered(self):
+        """Deep Agents should register rubric_dynamic_presence_check like other adapters."""
+        from karenina.adapters.langchain_deep_agents.prompts.rubric import _RUBRIC_TASKS
+
+        assert "rubric_dynamic_presence_check" in _RUBRIC_TASKS
+
+    def test_rubric_task_count_matches_other_adapters(self):
+        """Deep Agents should register the same number of rubric tasks as Claude Tool."""
+        from karenina.adapters.langchain_deep_agents.prompts.rubric import _RUBRIC_TASKS
+
+        assert len(_RUBRIC_TASKS) == 6
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain_deep_agents/test_rubric_registration.py -v`
+Expected: FAIL (only 5 tasks, missing rubric_dynamic_presence_check)
+
+- [ ] **Step 3: Add the missing task**
+
+In `src/karenina/adapters/langchain_deep_agents/prompts/rubric.py`, add to `_RUBRIC_TASKS` list:
+
+```python
+_RUBRIC_TASKS = [
+    "rubric_llm_trait_batch",
+    "rubric_llm_trait_single",
+    "rubric_literal_trait_batch",
+    "rubric_literal_trait_single",
+    "rubric_metric_trait",
+    "rubric_dynamic_presence_check",
+]
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain_deep_agents/test_rubric_registration.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/karenina/adapters/langchain_deep_agents/prompts/rubric.py tests/unit/adapters/langchain_deep_agents/test_rubric_registration.py
+git commit -m "fix(deep-agents): add missing rubric_dynamic_presence_check registration (094)"
+```
+
+---
+
+### Task 12: Fix MCP config format detection (Issue 069)
+
+**Files:**
+- Modify: `src/karenina/adapters/claude_agent_sdk/agent.py` (`_convert_mcp_servers` method)
+- Test: `tests/unit/adapters/claude_sdk/test_mcp_config.py`
+
+- [ ] **Step 1: Write test for the false positive**
+
+Add to `tests/unit/adapters/claude_sdk/test_mcp_config.py`:
+
+```python
+@pytest.mark.unit
+class TestMCPConfigFormatDetection:
+    def test_custom_config_with_type_key_not_mistaken_for_sdk(self):
+        """A config with a 'type' key for karenina purposes should be converted, not passed through."""
+        # MCPHttpServerConfig has 'type': 'http' and 'url' - this IS karenina format
+        mcp_config = {
+            "my_server": {"type": "http", "url": "http://localhost:8080"}
+        }
+        # Should be recognized as karenina format and converted
+        # (not passed through as-is just because 'type' key exists)
+```
+
+**Note:** The implementer should check the current behavior of `_convert_mcp_servers()` with this input and verify the test catches the issue before fixing.
+
+- [ ] **Step 2: Implement proper format detection**
+
+Replace the format-sniffing logic in `_convert_mcp_servers()` with isinstance checks:
+
+```python
+from karenina.ports.agent import MCPHttpServerConfig, MCPStdioServerConfig
+
+# Check if config values match karenina's MCPServerConfig format
+first_config = next(iter(mcp_servers.values()), {})
+if isinstance(first_config, dict):
+    # Check for karenina TypedDict fields
+    is_karenina_stdio = "command" in first_config and first_config.get("type", "stdio") == "stdio"
+    is_karenina_http = "url" in first_config and first_config.get("type") in ("http", "sse")
+
+    if is_karenina_stdio or is_karenina_http:
+        # Karenina format: convert to SDK format
+        return convert_mcp_config(mcp_servers)
+
+# Assume already SDK format
+return mcp_servers
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/claude_sdk/test_mcp_config.py -v`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/karenina/adapters/claude_agent_sdk/agent.py tests/unit/adapters/claude_sdk/test_mcp_config.py
+git commit -m "fix(claude-sdk): use proper format detection for MCP config (069)"
+```
+
+---
+
+### Task 13: Warn when `max_retries` is ignored (Issue 142)
+
+**Files:**
+- Modify: `src/karenina/adapters/claude_agent_sdk/llm.py` (with_structured_output)
+- Modify: `src/karenina/adapters/langchain_deep_agents/llm.py:171-189` (with_structured_output)
+- Modify: `src/karenina/ports/llm.py:108-129` (docstring)
+- Test: `tests/unit/adapters/langchain_deep_agents/test_llm.py`, `tests/unit/adapters/claude_sdk/test_errors.py` or similar
+
+- [ ] **Step 1: Write tests**
+
+Add to `tests/unit/adapters/langchain_deep_agents/test_llm.py`:
+
+```python
+def test_with_structured_output_warns_on_max_retries(self, deep_agents_model_config, caplog):
+    """with_structured_output should warn when max_retries is provided."""
+    import logging
+
+    from pydantic import BaseModel, Field
+
+    class Answer(BaseModel):
+        value: str = Field(description="The answer")
+
+    adapter = DeepAgentsLLMAdapter(deep_agents_model_config)
+
+    with caplog.at_level(logging.WARNING):
+        adapter.with_structured_output(Answer, max_retries=5)
+
+    assert "max_retries" in caplog.text
+    assert "ignored" in caplog.text.lower()
+```
+
+- [ ] **Step 2: Add warning to Deep Agents adapter**
+
+In `src/karenina/adapters/langchain_deep_agents/llm.py`, modify `with_structured_output()`:
+
+```python
+def with_structured_output(
+    self,
+    schema: type[BaseModel],
+    *,
+    max_retries: int | None = None,
+) -> DeepAgentsLLMAdapter:
+    """Return a new adapter configured for structured output.
+
+    Args:
+        schema: A Pydantic model class defining the output structure.
+        max_retries: Not supported by this adapter. A warning is emitted
+            if a non-None value is provided.
+
+    Returns:
+        A new DeepAgentsLLMAdapter configured with the schema.
+    """
+    if max_retries is not None:
+        logger.warning(
+            "max_retries=%d ignored by langchain_deep_agents adapter; "
+            "retry behavior is managed internally by LangChain",
+            max_retries,
+        )
+    return DeepAgentsLLMAdapter(
+        self._config,
+        _structured_schema=schema,
+    )
+```
+
+Remove the `# noqa: ARG002` comment since the parameter is now used (for the warning check).
+
+- [ ] **Step 3: Add warning to Claude SDK adapter**
+
+Same pattern in `src/karenina/adapters/claude_agent_sdk/llm.py`:
+
+```python
+if max_retries is not None:
+    logger.warning(
+        "max_retries=%d ignored by claude_agent_sdk adapter; "
+        "retry behavior is managed internally by the SDK via max_turns",
+        max_retries,
+    )
+```
+
+Remove the `# noqa: ARG002` comment.
+
+- [ ] **Step 4: Update LLMPort docstring**
+
+In `src/karenina/ports/llm.py`, update the `with_structured_output` docstring (line 117):
+
+```python
+        Args:
+            schema: A Pydantic model class defining the output structure.
+            max_retries: Maximum retry attempts on validation failure.
+                Not all adapters support this parameter. LangChain and Claude
+                Tool adapters respect it; Claude SDK and Deep Agents adapters
+                ignore it (with a warning). Check adapter documentation for
+                details.
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd karenina && uv run pytest tests/unit/adapters/langchain_deep_agents/test_llm.py tests/unit/adapters/claude_sdk/ -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/karenina/adapters/langchain_deep_agents/llm.py src/karenina/adapters/claude_agent_sdk/llm.py src/karenina/ports/llm.py tests/unit/adapters/langchain_deep_agents/test_llm.py
+git commit -m "fix(adapters): warn when max_retries is ignored by adapter (142)"
+```
+
+---
+
+### Task 14: Update adapter creation skills and documentation (Group 6)
+
+**Files:**
+- Modify: `.claude/skills/create-karenina-adapter/SKILL.md`
+- Modify: `.claude/skills/adapter-design/SKILL.md`
+- Modify: `.claude/skills/adapter-implement/SKILL.md`
+- Modify: `.claude/skills/adapter-test/SKILL.md`
+- Modify: `.claude/skills/adapter-review/SKILL.md`
+- Modify: `docs/advanced-adapters/writing-adapters.md`
+- Modify: `docs/advanced-adapters/ports.md`
+- Modify: `docs/advanced-adapters/available-adapters.md`
+- Modify: `docs/advanced-adapters/mcp-integration.md`
+
+**Note:** These are documentation files. Read each one first, then make targeted updates.
+
+- [ ] **Step 1: Read all 5 adapter skills**
+
+Read each skill file to understand current content before modifying.
+
+- [ ] **Step 2: Update `adapter-implement/SKILL.md`**
+
+Add to the implementation checklist:
+- `aclose()` is now a **required** protocol method on all three ports (LLMPort, AgentPort, ParserPort). Every adapter must implement it. No-op implementations are acceptable for adapters with no resources to clean up.
+- `AgentPort` now requires a `capabilities` property returning `PortCapabilities`, matching LLMPort and ParserPort.
+- For MCP session management, use `AsyncExitStack` pattern (reference: `langchain/agent.py` and `langchain_deep_agents/agent.py`). Never create MCP sessions inside `async with` that closes before tools are used.
+
+- [ ] **Step 3: Update `adapter-design/SKILL.md`**
+
+Add to concept mapping tables:
+- `aclose()` lifecycle method for all three ports
+- `capabilities` property for AgentPort
+
+- [ ] **Step 4: Update `adapter-test/SKILL.md`**
+
+Add cold test:
+- C-new: Verify `hasattr(adapter, "aclose")` is True for all three adapter instances
+- C-new: Verify `isinstance(agent_adapter.capabilities, PortCapabilities)` for agent adapters
+
+- [ ] **Step 5: Update `adapter-review/SKILL.md`**
+
+Add to review checklist:
+- Verify `aclose()` is implemented on all three port implementations
+- Verify `capabilities` property exists on agent adapter
+- Verify `max_retries` warning is emitted in `with_structured_output` if the adapter doesn't support it
+
+- [ ] **Step 6: Update `create-karenina-adapter/SKILL.md`**
+
+Add to deliverables checklist:
+- `aclose()` method on all port implementations
+- `capabilities` property on agent adapter
+
+- [ ] **Step 7: Read and update documentation files**
+
+Read and update each doc file:
+
+**`docs/advanced-adapters/ports.md`:**
+- Update protocol signatures to include `aclose()` on all three ports
+- Add `capabilities` property to AgentPort section
+
+**`docs/advanced-adapters/writing-adapters.md`:**
+- Add `aclose()` as required method in the step-by-step guide
+- Document `AgentPort.capabilities`
+- Note that `max_retries` behavior varies by adapter
+
+**`docs/advanced-adapters/available-adapters.md`:**
+- Update Deep Agents row: MCP and tools support is now wired up
+
+**`docs/advanced-adapters/mcp-integration.md`:**
+- Document `AsyncExitStack` session management pattern
+- Reference Deep Agents as second MCP-capable adapter alongside LangChain
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .claude/skills/ docs/advanced-adapters/
+git commit -m "docs: update adapter skills and documentation for protocol changes"
+```
+
+---
+
+### Task 15: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd karenina && uv run pytest tests/ -x -q`
+Expected: All ~2705 tests PASS
+
+- [ ] **Step 2: Run adapter-specific tests**
+
+Run: `cd karenina && uv run pytest tests/ -x -q -k "adapter"`
+Expected: All PASS
+
+- [ ] **Step 3: Run mypy on ports**
+
+Run: `cd karenina && uv run mypy src/karenina/ports/`
+Expected: No errors
+
+- [ ] **Step 4: Run pre-commit hooks**
+
+Run: `cd karenina && uv run pre-commit run --all-files`
+Expected: All PASS
+
+- [ ] **Step 5: Verify issue-specific checks**
+
+Spot-check key behaviors:
+- `hasattr(DeepAgentsLLMAdapter(...), "aclose")` is True
+- `_detect_tool_error("No errors found")` returns False
+- `wrap_sdk_error(RuntimeError("max_turns exceeded"))` returns error with limit_reached
+- `wrap_deep_agents_error(RuntimeError("failed to parse MCP configuration"))` does NOT return AgentResponseError
+- Deep Agents `_RUBRIC_TASKS` has 6 entries
+
+- [ ] **Step 6: Commit any fixups from verification**
+
+If anything fails, fix and commit with descriptive message.

--- a/docs/superpowers/specs/2026-03-23-adapter-hygiene-design.md
+++ b/docs/superpowers/specs/2026-03-23-adapter-hygiene-design.md
@@ -201,6 +201,31 @@ Replace key-sniffing (`type` or `command` presence) in `_convert_mcp_servers()` 
 - In both adapters' `with_structured_output()`: when `max_retries` is not None, emit `logger.warning("max_retries=%d ignored by %s adapter; retry behavior is managed internally", max_retries, adapter_name)`
 - Update `LLMPort.with_structured_output()` docstring to note adapter support varies
 
+### Group 6: Documentation & Skill Updates
+
+After all code changes are complete and tests pass, review and update the adapter authoring skills and documentation to reflect the new protocol requirements and patterns.
+
+#### Adapter Creation Skills
+
+Five skills in `.claude/skills/` guide new adapter authors through the lifecycle. These must reflect the protocol changes from 138/139 and the MCP session pattern from 091/092:
+
+| Skill | Path | Updates Needed |
+|-------|------|----------------|
+| `create-karenina-adapter` | `.claude/skills/create-karenina-adapter/SKILL.md` | Mention `aclose()` as required protocol method, `capabilities` on all three ports |
+| `adapter-design` | `.claude/skills/adapter-design/SKILL.md` | Add `aclose()` and `AgentPort.capabilities` to concept mapping tables |
+| `adapter-implement` | `.claude/skills/adapter-implement/SKILL.md` | Add `aclose()` to implementation checklist, document AsyncExitStack pattern for MCP session management |
+| `adapter-test` | `.claude/skills/adapter-test/SKILL.md` | Add cold test for `aclose()` protocol conformance, verify `capabilities` on agent adapters |
+| `adapter-review` | `.claude/skills/adapter-review/SKILL.md` | Add `aclose()` and `capabilities` to review checklist |
+
+#### Documentation
+
+| Doc | Path | Updates Needed |
+|-----|------|----------------|
+| `writing-adapters.md` | `docs/advanced-adapters/writing-adapters.md` | Add `aclose()` as required method, document `AgentPort.capabilities`, note `max_retries` adapter-dependent behavior |
+| `ports.md` | `docs/advanced-adapters/ports.md` | Update protocol signatures to include `aclose()`, add `capabilities` to `AgentPort` section |
+| `available-adapters.md` | `docs/advanced-adapters/available-adapters.md` | Update Deep Agents capability matrix (MCP/tools now wired up) |
+| `mcp-integration.md` | `docs/advanced-adapters/mcp-integration.md` | Document AsyncExitStack session pattern, reference Deep Agents as second MCP-capable adapter |
+
 ## Verification
 
 - Run full test suite: `cd karenina && uv run pytest tests/ -x -q`
@@ -230,3 +255,12 @@ Replace key-sniffing (`type` or `command` presence) in `_convert_mcp_servers()` 
 | `ports/llm.py` | 138, 142 |
 | `ports/agent.py` | 138, 139 |
 | `ports/parser.py` | 138 |
+| `.claude/skills/create-karenina-adapter/SKILL.md` | docs |
+| `.claude/skills/adapter-design/SKILL.md` | docs |
+| `.claude/skills/adapter-implement/SKILL.md` | docs |
+| `.claude/skills/adapter-test/SKILL.md` | docs |
+| `.claude/skills/adapter-review/SKILL.md` | docs |
+| `docs/advanced-adapters/writing-adapters.md` | docs |
+| `docs/advanced-adapters/ports.md` | docs |
+| `docs/advanced-adapters/available-adapters.md` | docs |
+| `docs/advanced-adapters/mcp-integration.md` | docs |

--- a/docs/superpowers/specs/2026-03-23-adapter-hygiene-design.md
+++ b/docs/superpowers/specs/2026-03-23-adapter-hygiene-design.md
@@ -32,8 +32,22 @@ Fix fragile heuristics, missing protocol methods, operator precedence bugs, impo
 
 **Decision**: Route through `wrap_sdk_error()`.
 
-- Add a `MaxTurnsExceeded` case to `wrap_sdk_error()` (checking for SDK-specific exception type or structural signal)
-- Replace the string-matching block in `arun()` with a call to `wrap_sdk_error()`
+- Add a turn/recursion limit case to `wrap_sdk_error()` that returns `AgentExecutionError` with `limit_reached=True` metadata
+- In `arun()`, replace the `except Exception` block with:
+
+```python
+except TimeoutError as e:
+    raise AgentTimeoutError(...) from e
+except Exception as e:
+    translated = wrap_sdk_error(e)
+    if isinstance(translated, AgentExecutionError) and getattr(translated, "limit_reached", False):
+        limit_reached = True
+        logger.warning("Agent hit turn limit: %s", e)
+    else:
+        raise translated from e
+```
+
+- `wrap_sdk_error()` checks SDK exception type first, then falls back to string matching as last resort
 - Centralizes all SDK error translation in one place
 
 ### D4: MCP Config Format (069)
@@ -46,9 +60,12 @@ Fix fragile heuristics, missing protocol methods, operator precedence bugs, impo
 
 **Decision**: Use `model_json_schema()` directly, after verifying equivalence.
 
-- Write an auxiliary script to compare `PydanticOutputParser.get_format_instructions()` output with `json.dumps(model_json_schema(), indent=2)`
-- If outputs are functionally equivalent, proceed with the replacement
+- Write an auxiliary script (`scripts/compare_schema_formats.py`) to compare both outputs side by side
+- If outputs are functionally equivalent (same fields, types, descriptions), use `json.dumps(RawAnswer.model_json_schema(), indent=2)`
+- If outputs differ meaningfully, use `RawAnswer.model_fields` to build a format string that preserves the original structure
+- Fallback: if neither approach preserves equivalence, keep `PydanticOutputParser` and document why
 - Drop `langchain_core` import from both `deep_judgment.py` and `evaluator.py`
+- Clean up the auxiliary script after verification
 
 ### D6: MCP Session Pattern (092)
 
@@ -68,8 +85,12 @@ Fix fragile heuristics, missing protocol methods, operator precedence bugs, impo
 
 ## Execution Order
 
+Dependencies require: **095 → 091/092 → 138 → 139** (strict order).
+
+All remaining issues (068, 093, 067, 086, 090, 094, 069, 142) are independent of each other and of 139. They can be done in any order after 138 completes. The linear sequence below is for reviewer convenience:
+
 ```
-095 → 091/092 → 138 → 139 → 068 → 093 → 067 → 086 → 090 → 094 → 069 → 142
+095 → 091/092 → 138 → 139 → {068, 093, 067, 086, 090, 094, 069, 142}
 ```
 
 ## Issue Specifications
@@ -104,7 +125,7 @@ Add `async def aclose(self) -> None` with docstring noting no resources to clean
 
 **Files**: `ports/llm.py`, `ports/agent.py`, `ports/parser.py`
 
-Add `async def aclose(self) -> None: ...` to `LLMPort`, `AgentPort`, and `ParserPort`. The `...` body means implementations must define it. All adapters already have it (including Deep Agents after 095). The registry's `hasattr` check remains as a safety net.
+Add `async def aclose(self) -> None: ...` to `LLMPort`, `AgentPort`, and `ParserPort`. This formalizes the existing convention: all adapters already implement `aclose()` (including Deep Agents after 095). The protocol addition makes the contract explicit for static type checkers and new adapter authors. The registry's `hasattr` check remains as a backward-compatibility safety net for any third-party adapters that may not yet implement the method.
 
 #### 139: Add `capabilities` to `AgentPort`
 

--- a/docs/superpowers/specs/2026-03-23-adapter-hygiene-design.md
+++ b/docs/superpowers/specs/2026-03-23-adapter-hygiene-design.md
@@ -1,0 +1,211 @@
+# Chunk 10: Adapter & Port Protocol Hygiene
+
+**Date**: 2026-03-23
+**Status**: Approved
+**Priority**: MEDIUM
+**Scope**: 15 issues across 4 adapters, 3 port protocols, and cross-adapter behavior
+
+## Summary
+
+Fix fragile heuristics, missing protocol methods, operator precedence bugs, import-time side effects, and dead MCP integration code across the LangChain, Claude SDK, Claude Tool, and Deep Agents adapters, plus the port protocol layer.
+
+## Design Decisions
+
+### D1: Deep Agents MCP/Tools (091/092)
+
+**Decision**: Wire up MCP/tools support for real (not set to False).
+
+- Keep `supports_mcp=True` and `supports_tools=True` in registration
+- Restructure `convert_mcp_to_tools()` to accept an `AsyncExitStack` parameter
+- Mirror the LangChain adapter's `arun()` pattern: `AsyncExitStack`, deferred error capture, persistent MCP sessions
+- Ensures sessions are properly cleaned up on exit (same ExceptionGroup-safe pattern as LangChain)
+
+### D2: Tool Error Detection (067)
+
+**Decision**: Remove the heuristic entirely (structural signals only).
+
+- `_detect_tool_error()` returns `False` always or is removed
+- LangChain `ToolMessage` has no structural error indicator; accept that some tool errors go undetected in traces
+- Eliminates all false positives ("No errors found", "timeout set to 30 seconds")
+
+### D3: SDK Limit Detection (068)
+
+**Decision**: Route through `wrap_sdk_error()`.
+
+- Add a `MaxTurnsExceeded` case to `wrap_sdk_error()` (checking for SDK-specific exception type or structural signal)
+- Replace the string-matching block in `arun()` with a call to `wrap_sdk_error()`
+- Centralizes all SDK error translation in one place
+
+### D4: MCP Config Format (069)
+
+**Decision**: Include in this chunk.
+
+- Replace key-sniffing (`type` or `command` presence) with `isinstance` checks against `MCPServerConfig` TypedDicts from the port layer
+
+### D5: Schema Format Instructions (086)
+
+**Decision**: Use `model_json_schema()` directly, after verifying equivalence.
+
+- Write an auxiliary script to compare `PydanticOutputParser.get_format_instructions()` output with `json.dumps(model_json_schema(), indent=2)`
+- If outputs are functionally equivalent, proceed with the replacement
+- Drop `langchain_core` import from both `deep_judgment.py` and `evaluator.py`
+
+### D6: MCP Session Pattern (092)
+
+**Decision**: Mirror the LangChain adapter's `AsyncExitStack` + deferred error pattern.
+
+- Same session lifecycle and cleanup guarantees as `langchain/agent.py:350-432`
+- `async with AsyncExitStack() as exit_stack` in `arun()`
+- Pass `exit_stack` to MCP conversion function
+- Deferred error capture to prevent ExceptionGroup wrapping during cleanup
+
+### D7: Execution Approach
+
+**Decision**: Sequential by dependency order.
+
+- ~15 focused commits, each reviewable in isolation
+- Respects dependency chain: 095 -> 091/092 -> 138 -> 139
+
+## Execution Order
+
+```
+095 → 091/092 → 138 → 139 → 068 → 093 → 067 → 086 → 090 → 094 → 069 → 142
+```
+
+## Issue Specifications
+
+### Group 1: Deep Agents Foundation
+
+#### 095: Add `aclose()` to `DeepAgentsLLMAdapter`
+
+**File**: `adapters/langchain_deep_agents/llm.py`
+
+Add `async def aclose(self) -> None` with docstring noting no resources to clean up (model created per call). Follows the pattern of all other adapters.
+
+#### 091: Wire up MCP/Tools in Deep Agents Agent
+
+**File**: `adapters/langchain_deep_agents/agent.py`, `adapters/langchain_deep_agents/registration.py`
+
+- Remove `# noqa: ARG002` comments from `tools` and `mcp_servers` params in `arun()`
+- In `arun()`: create `AsyncExitStack`, convert MCP servers to tools via `convert_mcp_to_tools(exit_stack)`, combine with explicitly passed tools, pass combined tools to agent execution
+- Use deferred error capture pattern from LangChain adapter
+
+#### 092: Fix `convert_mcp_to_tools()` Session Lifetime
+
+**File**: `adapters/langchain_deep_agents/mcp.py`
+
+- Change signature: `convert_mcp_to_tools(mcp_servers, exit_stack: AsyncExitStack)`
+- Replace `async with MultiServerMCPClient` with exit_stack-managed session creation
+- Sessions remain open for the duration of the caller's exit_stack
+
+### Group 2: Port Protocols
+
+#### 138: Add `aclose()` to Port Protocols
+
+**Files**: `ports/llm.py`, `ports/agent.py`, `ports/parser.py`
+
+Add `async def aclose(self) -> None: ...` to `LLMPort`, `AgentPort`, and `ParserPort`. The `...` body means implementations must define it. All adapters already have it (including Deep Agents after 095). The registry's `hasattr` check remains as a safety net.
+
+#### 139: Add `capabilities` to `AgentPort`
+
+**File**: `ports/agent.py`
+
+Add `@property def capabilities(self) -> PortCapabilities: return PortCapabilities()` to `AgentPort`, matching `LLMPort` and `ParserPort`.
+
+### Group 3: Error Handling
+
+#### 068: Centralize SDK Error Translation
+
+**Files**: `adapters/claude_agent_sdk/agent.py`, `adapters/claude_agent_sdk/errors.py`
+
+- In `errors.py`: add a case for turn/recursion limit detection (check SDK exception types first, fall back to structural signals like exit codes)
+- In `agent.py`: replace the `except Exception` block that does string matching with a call to `wrap_sdk_error(e)`, then check the returned error type for limit-related errors
+
+#### 093: Fix Operator Precedence
+
+**File**: `adapters/langchain_deep_agents/errors.py`
+
+Change line 40 from:
+```python
+if "parse" in error_str or "output" in error_str and "format" in error_str:
+```
+to:
+```python
+if ("parse" in error_str and "output" in error_str) or ("output" in error_str and "format" in error_str):
+```
+
+Ensures "parse" alone is not sufficient to trigger `AgentResponseError` classification.
+
+### Group 4: Heuristic & Import Cleanup
+
+#### 067: Remove `_detect_tool_error` Heuristic
+
+**File**: `adapters/langchain/trace.py`
+
+Remove or neutralize `_detect_tool_error()`. The function's callers should default to `is_error=False` for tool messages. No structural error signal exists in LangChain's `ToolMessage`, so we accept the trade-off of undetected tool errors over false positives.
+
+#### 086: Replace `PydanticOutputParser` with Native Pydantic v2
+
+**Files**: `benchmark/verification/evaluators/template/deep_judgment.py`, `benchmark/verification/evaluators/template/evaluator.py`
+
+- First: write auxiliary script comparing both outputs; verify equivalence
+- In `deep_judgment.py`: replace `PydanticOutputParser(pydantic_object=RawAnswer).get_format_instructions()` with `json.dumps(RawAnswer.model_json_schema(), indent=2)` (or equivalent)
+- In `evaluator.py`: remove the `PydanticOutputParser` import and `format_instructions` generation entirely (unused by `deep_judgment_parse()`)
+- Both files drop the `langchain_core` import
+
+#### 090: Remove Module-Level `load_dotenv()`
+
+**Files**: `adapters/claude_tool/llm.py`, `adapters/claude_tool/agent.py`
+
+Delete `load_dotenv()` calls and `from dotenv import load_dotenv` imports. The caller is responsible for environment setup.
+
+### Group 5: Missing Registrations & Warnings
+
+#### 094: Add Missing Task Registration
+
+**File**: `adapters/langchain_deep_agents/prompts/rubric.py`
+
+Add `"rubric_dynamic_presence_check"` to the `_RUBRIC_TASKS` list, matching Claude Tool and Claude SDK which both register 6 tasks.
+
+#### 069: Fix MCP Config Format Detection
+
+**File**: `adapters/claude_agent_sdk/agent.py`
+
+Replace key-sniffing (`type` or `command` presence) in `_convert_mcp_servers()` with `isinstance` checks against `MCPServerConfig` TypedDicts (`MCPStdioServerConfig`, `MCPHttpServerConfig`) from the port layer.
+
+#### 142: Warn When `max_retries` Is Ignored
+
+**Files**: `adapters/claude_agent_sdk/llm.py`, `adapters/langchain_deep_agents/llm.py`, `ports/llm.py`
+
+- In both adapters' `with_structured_output()`: when `max_retries` is not None, emit `logger.warning("max_retries=%d ignored by %s adapter; retry behavior is managed internally", max_retries, adapter_name)`
+- Update `LLMPort.with_structured_output()` docstring to note adapter support varies
+
+## Verification
+
+- Run full test suite: `cd karenina && uv run pytest tests/ -x -q`
+- Run adapter-specific tests: `uv run pytest tests/ -x -q -k "adapter"`
+- Run mypy on ports: `uv run mypy src/karenina/ports/`
+- Run pre-commit hooks (ruff, vulture)
+- Issue-specific checks listed in TASK.md verification section
+
+## Files Modified
+
+| File | Issues |
+|------|--------|
+| `adapters/langchain/trace.py` | 067 |
+| `adapters/claude_agent_sdk/agent.py` | 068, 069 |
+| `adapters/claude_agent_sdk/errors.py` | 068 |
+| `adapters/claude_agent_sdk/llm.py` | 142 |
+| `adapters/claude_tool/llm.py` | 090 |
+| `adapters/claude_tool/agent.py` | 090 |
+| `adapters/langchain_deep_agents/registration.py` | 091 |
+| `adapters/langchain_deep_agents/agent.py` | 091 |
+| `adapters/langchain_deep_agents/mcp.py` | 092 |
+| `adapters/langchain_deep_agents/errors.py` | 093 |
+| `adapters/langchain_deep_agents/prompts/rubric.py` | 094 |
+| `adapters/langchain_deep_agents/llm.py` | 095, 142 |
+| `benchmark/verification/evaluators/template/deep_judgment.py` | 086 |
+| `benchmark/verification/evaluators/template/evaluator.py` | 086 |
+| `ports/llm.py` | 138, 142 |
+| `ports/agent.py` | 138, 139 |
+| `ports/parser.py` | 138 |

--- a/src/karenina/adapters/claude_agent_sdk/agent.py
+++ b/src/karenina/adapters/claude_agent_sdk/agent.py
@@ -35,6 +35,7 @@ from karenina.ports import (
     Tool,
     UsageMetadata,
 )
+from karenina.ports.capabilities import PortCapabilities
 
 from .mcp import convert_mcp_config
 from .messages import ClaudeSDKMessageConverter
@@ -92,6 +93,15 @@ class ClaudeSDKAgentAdapter:
         """
         self._config = model_config
         self._converter = ClaudeSDKMessageConverter()
+
+    @property
+    def capabilities(self) -> PortCapabilities:
+        """Declare adapter capabilities.
+
+        Returns:
+            PortCapabilities with system_prompt=True.
+        """
+        return PortCapabilities(supports_system_prompt=True)
 
     def _build_options(
         self,

--- a/src/karenina/adapters/claude_agent_sdk/agent.py
+++ b/src/karenina/adapters/claude_agent_sdk/agent.py
@@ -25,7 +25,6 @@ from typing import TYPE_CHECKING, Any
 
 from karenina.ports import (
     AgentConfig,
-    AgentExecutionError,
     AgentPort,
     AgentResponseError,
     AgentResult,
@@ -373,14 +372,14 @@ class ClaudeSDKAgentAdapter:
         except TimeoutError as e:
             raise AgentTimeoutError(f"Agent execution timed out after {config.timeout}s") from e
         except Exception as e:
-            error_str = str(e).lower()
+            from .errors import wrap_sdk_error
 
-            # Check for limit-related errors
-            if "recursion" in error_str or "limit" in error_str or "max_turns" in error_str:
+            translated = wrap_sdk_error(e)
+            if getattr(translated, "limit_reached", False):
                 limit_reached = True
-                logger.warning(f"Agent hit turn limit: {e}")
+                logger.warning("Agent hit turn limit: %s", e)
             else:
-                raise AgentExecutionError(f"Agent execution failed: {e}") from e
+                raise translated from e
 
         if result_message is None and not collected_messages:
             raise AgentResponseError("No messages received from SDK agent")

--- a/src/karenina/adapters/claude_agent_sdk/agent.py
+++ b/src/karenina/adapters/claude_agent_sdk/agent.py
@@ -278,11 +278,19 @@ class ClaudeSDKAgentAdapter:
         if not mcp_servers:
             return None
 
-        # Check if already in SDK format (has 'type' or 'command' keys)
         first_config: Any = next(iter(mcp_servers.values()), {})
-        if isinstance(first_config, dict) and ("type" in first_config or "command" in first_config):
-            # Already SDK format - return as-is
-            return mcp_servers
+        if isinstance(first_config, dict):
+            # Detect karenina's MCPServerConfig format by checking for
+            # required TypedDict fields rather than generic key sniffing.
+            is_karenina_stdio = "command" in first_config
+            is_karenina_http = "url" in first_config and first_config.get("type") in (
+                "http",
+                "sse",
+            )
+
+            if is_karenina_stdio or is_karenina_http:
+                # Karenina simplified format: convert to SDK format
+                return mcp_servers
 
         # Assume simplified format {"name": "url"} - convert
         # This handles the case where mcp_servers is still in karenina's

--- a/src/karenina/adapters/claude_agent_sdk/errors.py
+++ b/src/karenina/adapters/claude_agent_sdk/errors.py
@@ -126,6 +126,21 @@ def wrap_sdk_error(e: Exception) -> PortError:
             message=f"Invalid JSON response from Claude Code CLI{line_info}",
         )
 
+    # Turn/recursion limit errors (by exception type name)
+    if exc_type_name in ("MaxTurnsExceededException", "MaxTurnsExceeded"):
+        return AgentExecutionError(
+            message=f"Agent hit turn limit: {e}",
+            limit_reached=True,
+        )
+
+    # Turn/recursion limit errors (by message content, last resort)
+    error_lower = str(e).lower()
+    if "recursion" in error_lower or "limit" in error_lower or "max_turns" in error_lower:
+        return AgentExecutionError(
+            message=f"Agent hit turn limit: {e}",
+            limit_reached=True,
+        )
+
     # Generic fallback for unknown SDK errors or non-SDK exceptions
     # Preserve the original exception type name for debugging
     return AgentExecutionError(

--- a/src/karenina/adapters/claude_agent_sdk/llm.py
+++ b/src/karenina/adapters/claude_agent_sdk/llm.py
@@ -213,8 +213,8 @@ class ClaudeSDKLLMAdapter:
         # Assert schema exists (this method only called when _structured_schema is set)
         assert self._structured_schema is not None
 
-        content = str(result.structured_output)
         parsed_model = self._structured_schema.model_validate(result.structured_output)
+        content = parsed_model.model_dump_json()
         usage = extract_sdk_usage(result, model=self._config.model_name)
 
         return LLMResponse(content=content, usage=usage, raw=parsed_model)

--- a/src/karenina/adapters/claude_agent_sdk/llm.py
+++ b/src/karenina/adapters/claude_agent_sdk/llm.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import logging
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
@@ -26,6 +27,8 @@ from karenina.ports.capabilities import PortCapabilities
 
 from .messages import ClaudeSDKMessageConverter
 from .usage import extract_sdk_usage
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from claude_agent_sdk import ClaudeAgentOptions, ResultMessage
@@ -262,22 +265,23 @@ class ClaudeSDKLLMAdapter:
         schema: type[BaseModel],
         *,
         max_turns: int | None = None,
-        max_retries: int | None = None,  # noqa: ARG002 - Ignored for API compat
+        max_retries: int | None = None,
     ) -> ClaudeSDKLLMAdapter:
         """Return a new adapter configured for structured output.
 
         The returned adapter uses SDK's output_format option to constrain
         the LLM's output to match the provided JSON schema.
 
-        The SDK handles retries autonomously via max_turns - no manual retry
+        The SDK handles retries autonomously via max_turns, so no manual retry
         logic is needed.
 
         Args:
             schema: A Pydantic model class defining the output structure.
             max_turns: Maximum turns for SDK (handles retries autonomously).
                 Default is 2 (minimum needed for structured output).
-            max_retries: Ignored for API compatibility with LangChain adapter.
-                The SDK handles retries autonomously via max_turns.
+            max_retries: Not supported by this adapter. A warning is emitted
+                if a non-None value is provided. The SDK handles retries
+                autonomously via max_turns.
 
         Returns:
             A new ClaudeSDKLLMAdapter instance configured for structured output.
@@ -292,6 +296,12 @@ class ClaudeSDKLLMAdapter:
             >>> response = await structured.ainvoke(messages)
             >>> assert isinstance(response.raw, Answer)
         """
+        if max_retries is not None:
+            logger.warning(
+                "max_retries=%d ignored by claude_agent_sdk adapter; "
+                "retry behavior is managed internally by the SDK via max_turns",
+                max_retries,
+            )
         return ClaudeSDKLLMAdapter(
             model_config=self._config,
             _structured_schema=schema,

--- a/src/karenina/adapters/claude_tool/agent.py
+++ b/src/karenina/adapters/claude_tool/agent.py
@@ -20,7 +20,6 @@ from contextlib import AsyncExitStack
 from typing import Any
 
 from anthropic import Omit
-from dotenv import load_dotenv
 
 from karenina.ports import (
     AgentConfig,
@@ -48,9 +47,6 @@ from .messages import (
 from .tools import ToolResultCollector, apply_cache_control_to_tool, wrap_mcp_tool, wrap_static_tool
 from .trace import claude_tool_messages_to_raw_trace
 from .usage import aggregate_usage, extract_usage_from_response
-
-# Load environment variables from .env file (for ANTHROPIC_API_KEY)
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/src/karenina/adapters/claude_tool/agent.py
+++ b/src/karenina/adapters/claude_tool/agent.py
@@ -186,15 +186,15 @@ class ClaudeToolAgentAdapter:
                 tool_filter_names: set[str] | None = None
                 if self._config.mcp_tool_filter:
                     tool_filter_names = set(self._config.mcp_tool_filter)
-                    logger.info(f"Restricting Claude Tool agent to MCP tools: {self._config.mcp_tool_filter}")
+                    logger.info("Restricting Claude Tool agent to MCP tools: %s", self._config.mcp_tool_filter)
 
                 for server_name, session, mcp_tool in mcp_tool_list:
                     if tool_filter_names and mcp_tool.name not in tool_filter_names:
-                        logger.debug(f"Skipping MCP tool '{mcp_tool.name}' (not in tool filter)")
+                        logger.debug("Skipping MCP tool '%s' (not in tool filter)", mcp_tool.name)
                         continue
                     wrapped = wrap_mcp_tool(session, mcp_tool, server_name, collector=collector)
                     all_tools.append(wrapped)
-                    logger.debug(f"Added MCP tool '{mcp_tool.name}' from server '{server_name}'")
+                    logger.debug("Added MCP tool '%s' from server '%s'", mcp_tool.name, server_name)
 
             # Apply cache_control to the last tool for Anthropic prompt caching
             # This caches all tool definitions. Enabled by default, disable with
@@ -222,6 +222,49 @@ class ClaudeToolAgentAdapter:
             raise AgentExecutionError(f"Agent execution failed: {e}") from e
         finally:
             await exit_stack.aclose()
+
+    async def _single_turn_create(
+        self,
+        client: Any,
+        kwargs: dict[str, Any],
+    ) -> AgentResult:
+        """Complete a single-turn request via messages.create().
+
+        Used when no tools are provided. The tool_runner API requires a
+        "tools" kwarg, so this method avoids it entirely by calling the
+        standard messages.create() endpoint for a single completion.
+
+        Args:
+            client: The async Anthropic client.
+            kwargs: Keyword arguments for messages.create() (model,
+                max_tokens, messages, etc.).
+
+        Returns:
+            AgentResult with the single response.
+        """
+        logger.debug("No tools provided, using single-turn messages.create()")
+        response = await client.messages.create(**kwargs)
+
+        unified_msg = convert_from_anthropic_message(response)
+        result_messages = [unified_msg]
+        raw_trace = claude_tool_messages_to_raw_trace(result_messages)
+        final_response = self._extract_final_response(result_messages)
+        usage = extract_usage_from_response(response, model=self._config.model_name)
+
+        actual_model = self._config.model_name
+        if hasattr(response, "model") and response.model:
+            actual_model = response.model
+
+        return AgentResult(
+            final_response=final_response,
+            raw_trace=raw_trace,
+            trace_messages=result_messages,
+            usage=usage,
+            turns=1,
+            limit_reached=False,
+            session_id=None,
+            actual_model=actual_model,
+        )
 
     async def _execute_agent_loop(
         self,
@@ -282,6 +325,12 @@ class ClaudeToolAgentAdapter:
         if self._config.temperature is not None:
             kwargs["temperature"] = self._config.temperature
 
+        # No tools: single-turn completion without tool_runner.
+        # tool_runner requires the "tools" kwarg, so when no tools are
+        # provided we fall back to a plain messages.create() call.
+        if not tools:
+            return await self._single_turn_create(client, kwargs)
+
         # Collect messages and usage during the loop
         collected_responses: list[Any] = []
         trace_messages: list[Message] = []
@@ -309,7 +358,7 @@ class ClaudeToolAgentAdapter:
                 # executed the tools from the previous response.
                 if prev_tool_uses and collector is not None:
                     collected_results = collector.drain()
-                    # Match by order — tool_runner executes tools in the order
+                    # Match by order: tool_runner executes tools in the order
                     # they appear in the assistant message
                     for i, tool_use in enumerate(prev_tool_uses):
                         if i < len(collected_results):
@@ -343,7 +392,7 @@ class ClaudeToolAgentAdapter:
                 # Check turn limit
                 if turns >= config.max_turns:
                     limit_reached = True
-                    logger.warning(f"Agent hit turn limit ({config.max_turns})")
+                    logger.warning("Agent hit turn limit (%d)", config.max_turns)
                     break
 
         # Execute with optional timeout

--- a/src/karenina/adapters/claude_tool/agent.py
+++ b/src/karenina/adapters/claude_tool/agent.py
@@ -35,6 +35,7 @@ from karenina.ports import (
     Tool,
     UsageMetadata,
 )
+from karenina.ports.capabilities import PortCapabilities
 from karenina.schemas.config import ModelConfig
 
 from .mcp import connect_all_mcp_servers, get_all_mcp_tools
@@ -99,6 +100,15 @@ class ClaudeToolAgentAdapter:
 
         # Initialize client lazily
         self._async_client: Any = None
+
+    @property
+    def capabilities(self) -> PortCapabilities:
+        """Declare adapter capabilities.
+
+        Returns:
+            PortCapabilities with system_prompt=True.
+        """
+        return PortCapabilities(supports_system_prompt=True)
 
     def _get_async_client(self) -> Any:
         """Get or create the async Anthropic client."""

--- a/src/karenina/adapters/claude_tool/agent.py
+++ b/src/karenina/adapters/claude_tool/agent.py
@@ -329,6 +329,11 @@ class ClaudeToolAgentAdapter:
         # tool_runner requires the "tools" kwarg, so when no tools are
         # provided we fall back to a plain messages.create() call.
         if not tools:
+            if config.timeout:
+                return await asyncio.wait_for(
+                    self._single_turn_create(client, kwargs),
+                    timeout=config.timeout,
+                )
             return await self._single_turn_create(client, kwargs)
 
         # Collect messages and usage during the loop

--- a/src/karenina/adapters/claude_tool/llm.py
+++ b/src/karenina/adapters/claude_tool/llm.py
@@ -265,8 +265,10 @@ class ClaudeToolLLMAdapter:
             raise ParseError(f"Parsed output is {type(parsed_output).__name__}, expected {schema.__name__}")
 
         usage = extract_usage_from_response(response, model=self._config.model_name)
+        # Serialize to JSON so callers can json.loads(response.content)
+        content = parsed_output.model_dump_json()
         return LLMResponse(
-            content=str(parsed_output),
+            content=content,
             usage=usage,
             raw=parsed_output,
         )

--- a/src/karenina/adapters/claude_tool/llm.py
+++ b/src/karenina/adapters/claude_tool/llm.py
@@ -17,7 +17,6 @@ import concurrent.futures
 import logging
 from typing import Any
 
-from dotenv import load_dotenv
 from pydantic import BaseModel
 
 from karenina.ports import AdapterUnavailableError, LLMPort, LLMResponse, Message, ParseError
@@ -27,9 +26,6 @@ from karenina.utils.messages import append_error_feedback
 
 from .messages import build_system_with_cache, convert_to_anthropic, extract_system_prompt
 from .usage import extract_usage_from_response
-
-# Load environment variables from .env file (for ANTHROPIC_API_KEY)
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/src/karenina/adapters/langchain/agent.py
+++ b/src/karenina/adapters/langchain/agent.py
@@ -344,7 +344,11 @@ class LangChainAgentAdapter:
 
         # Use session-based thread_id for checkpointing
         thread_id = str(uuid.uuid4())
-        agent_config = {"configurable": {"thread_id": thread_id}}
+        agent_config: dict[str, Any] = {
+            "configurable": {"thread_id": thread_id},
+            # Each tool call + response = 2 LangGraph steps, so double max_turns
+            "recursion_limit": config.max_turns * 2,
+        }
 
         # LangGraph agent expects dict with "messages" key
         # Use usage metadata callback to reliably capture cumulative token usage

--- a/src/karenina/adapters/langchain/agent.py
+++ b/src/karenina/adapters/langchain/agent.py
@@ -26,6 +26,7 @@ from karenina.ports import (
     Tool,
     UsageMetadata,
 )
+from karenina.ports.capabilities import PortCapabilities
 
 from .messages import LangChainMessageConverter
 from .usage import count_agent_turns, extract_langchain_usage, extract_usage_cumulative
@@ -132,6 +133,15 @@ class LangChainAgentAdapter:
         """
         self._config = model_config
         self._converter = LangChainMessageConverter()
+
+    @property
+    def capabilities(self) -> PortCapabilities:
+        """Declare adapter capabilities.
+
+        Returns:
+            PortCapabilities with system_prompt=True.
+        """
+        return PortCapabilities(supports_system_prompt=True)
 
     def _convert_mcp_servers_to_urls(
         self,

--- a/src/karenina/adapters/langchain/llm.py
+++ b/src/karenina/adapters/langchain/llm.py
@@ -356,8 +356,21 @@ class LangChainLLMAdapter:
                     usage = extract_langchain_usage(cb.usage_metadata, model_name=self._config.model_name)
                     if usage.total_tokens == 0:
                         usage = extract_usage_from_response(response, model_name=self._config.model_name)
+                    # Serialize to JSON so callers can json.loads(response.content)
+                    content = response.model_dump_json()
                     return LLMResponse(
-                        content=str(response),
+                        content=content,
+                        usage=usage,
+                        raw=response,
+                    )
+                if isinstance(response, dict):
+                    # Some LangChain models return a dict instead of a Pydantic model
+                    usage = extract_langchain_usage(cb.usage_metadata, model_name=self._config.model_name)
+                    if usage.total_tokens == 0:
+                        usage = extract_usage_from_response(response, model_name=self._config.model_name)
+                    content = json.dumps(response)
+                    return LLMResponse(
+                        content=content,
                         usage=usage,
                         raw=response,
                     )

--- a/src/karenina/adapters/langchain/trace.py
+++ b/src/karenina/adapters/langchain/trace.py
@@ -221,32 +221,21 @@ def langchain_messages_to_trace_messages(
     return result
 
 
-def _detect_tool_error(content: str) -> bool:
-    """Heuristic for detecting tool errors.
+def _detect_tool_error(_content: str) -> bool:
+    """Check whether tool output represents an error.
 
-    LangChain ToolMessage lacks an is_error field, so we use pattern matching
-    to detect error responses. This is imperfect but matches the design spec.
+    LangChain ToolMessage has no structural error indicator, so this
+    always returns False. The previous heuristic (substring matching on
+    keywords like 'error', 'failed') produced too many false positives
+    on legitimate tool output.
 
     Args:
-        content: The tool result content string
+        content: The tool result content string.
 
     Returns:
-        True if the content appears to contain an error
+        Always False. Retained for backward compatibility with callers.
     """
-    if not content:
-        return False
-
-    error_patterns = [
-        "error",
-        "failed",
-        "exception",
-        "traceback",
-        "permission denied",
-        "not found",
-        "timeout",
-    ]
-    content_lower = content.lower()
-    return any(pattern in content_lower for pattern in error_patterns)
+    return False
 
 
 def _format_langchain_message(msg: Any) -> str:

--- a/src/karenina/adapters/langchain_deep_agents/agent.py
+++ b/src/karenina/adapters/langchain_deep_agents/agent.py
@@ -30,6 +30,7 @@ from karenina.ports import (
     Tool,
     UsageMetadata,
 )
+from karenina.ports.capabilities import PortCapabilities
 
 from .errors import wrap_deep_agents_error
 from .initialization import create_chat_model
@@ -86,6 +87,15 @@ class DeepAgentsAgentAdapter:
         """
         self._config = model_config
         self._converter = DeepAgentsMessageConverter()
+
+    @property
+    def capabilities(self) -> PortCapabilities:
+        """Declare adapter capabilities.
+
+        Returns:
+            PortCapabilities with system_prompt=True.
+        """
+        return PortCapabilities(supports_system_prompt=True)
 
     def _extract_final_response(self, lc_messages: list[Any]) -> str:
         """Extract final text response from the last AIMessage.

--- a/src/karenina/adapters/langchain_deep_agents/agent.py
+++ b/src/karenina/adapters/langchain_deep_agents/agent.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import logging
+from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any
 
 from karenina.ports import (
     AgentConfig,
+    AgentExecutionError,
     AgentResponseError,
     AgentResult,
     AgentTimeoutError,
@@ -128,8 +130,8 @@ class DeepAgentsAgentAdapter:
     async def arun(
         self,
         messages: list[Message],
-        tools: list[Tool] | None = None,  # noqa: ARG002 - required by AgentPort protocol
-        mcp_servers: dict[str, MCPServerConfig] | None = None,  # noqa: ARG002 - required by AgentPort protocol
+        tools: list[Tool] | None = None,
+        mcp_servers: dict[str, MCPServerConfig] | None = None,
         config: AgentConfig | None = None,
     ) -> AgentResult:
         """Execute an agent loop with optional tools and MCP servers.
@@ -196,48 +198,86 @@ class DeepAgentsAgentAdapter:
                 if key not in ("model", "system_prompt", "backend"):
                     agent_kwargs[key] = value
 
-        # Create the agent
-        agent = _create_deep_agent(**agent_kwargs)
+        # Convert MCP servers to LangChain tools and combine with explicit tools
+        all_tools: list[Any] = []
+        if tools:
+            all_tools.extend(tools)
 
-        # Build invocation input
-        invoke_input: dict[str, Any] = {
-            "messages": [{"role": "user", "content": prompt_string}],
-        }
-
-        # LangGraph config for recursion limit
-        # Each tool call + response = 2 steps, so double max_turns
-        langgraph_config: dict[str, Any] = {
-            "recursion_limit": config.max_turns * 2,
-        }
-
-        # Execute agent
+        # Use AsyncExitStack for persistent MCP sessions. Sessions stay alive
+        # for all tool calls during agent execution. Exceptions are captured
+        # inside the block and re-raised after clean exit, because MCP session
+        # cleanup can wrap errors in ExceptionGroup if an exception propagates
+        # through the exit stack.
         result: dict[str, Any] = {}
         limit_reached = False
+        deferred_error: Exception | None = None
 
-        async def execute_agent() -> None:
-            nonlocal result, limit_reached
+        async with AsyncExitStack() as exit_stack:
+            # Convert MCP servers to LangChain tools
+            if mcp_servers:
+                from .mcp import convert_mcp_to_tools
 
-            result = await agent.ainvoke(invoke_input, config=langgraph_config)
+                try:
+                    mcp_tools = await convert_mcp_to_tools(mcp_servers, exit_stack)
+                    all_tools.extend(mcp_tools)
+                    logger.info(
+                        "Loaded %d MCP tools from %d servers",
+                        len(mcp_tools),
+                        len(mcp_servers),
+                    )
+                except Exception as e:
+                    logger.warning("Failed to load MCP tools: %s", e)
+                    deferred_error = AgentExecutionError(f"Failed to initialize MCP tools: {e}")
+                    deferred_error.__cause__ = e
 
-            # Check if limit was reached via state
-            if result.get("is_last_step", False):
-                limit_reached = True
+            if deferred_error is None:
+                # Pass tools to agent if any were collected
+                if all_tools:
+                    agent_kwargs["tools"] = all_tools
 
-        try:
-            if config.timeout:
-                await asyncio.wait_for(execute_agent(), timeout=config.timeout)
-            else:
-                await execute_agent()
+                # Create the agent
+                agent = _create_deep_agent(**agent_kwargs)
 
-        except TimeoutError as e:
-            raise AgentTimeoutError(f"Agent execution timed out after {config.timeout}s") from e
-        except Exception as e:
-            mapped_error, was_limit = wrap_deep_agents_error(e)
-            if was_limit:
-                limit_reached = True
-                logger.warning("Agent hit turn limit: %s", e)
-            else:
-                raise mapped_error from e
+                # Build invocation input
+                invoke_input: dict[str, Any] = {
+                    "messages": [{"role": "user", "content": prompt_string}],
+                }
+
+                # LangGraph config for recursion limit
+                # Each tool call + response = 2 steps, so double max_turns
+                langgraph_config: dict[str, Any] = {
+                    "recursion_limit": config.max_turns * 2,
+                }
+
+                # Execute agent
+                async def execute_agent() -> None:
+                    nonlocal result, limit_reached
+                    result = await agent.ainvoke(invoke_input, config=langgraph_config)
+                    if result.get("is_last_step", False):
+                        limit_reached = True
+
+                try:
+                    if config.timeout:
+                        await asyncio.wait_for(execute_agent(), timeout=config.timeout)
+                    else:
+                        await execute_agent()
+
+                except TimeoutError as e:
+                    deferred_error = AgentTimeoutError(f"Agent execution timed out after {config.timeout}s")
+                    deferred_error.__cause__ = e
+                except Exception as e:
+                    mapped_error, was_limit = wrap_deep_agents_error(e)
+                    if was_limit:
+                        limit_reached = True
+                        logger.warning("Agent hit turn limit: %s", e)
+                    else:
+                        deferred_error = mapped_error
+                        deferred_error.__cause__ = e
+
+        # exit_stack closed: MCP sessions cleaned up
+
+        if deferred_error is not None:
+            raise deferred_error
 
         # Extract messages from result
         lc_messages: list[Any] = result.get("messages", [])

--- a/src/karenina/adapters/langchain_deep_agents/errors.py
+++ b/src/karenina/adapters/langchain_deep_agents/errors.py
@@ -37,7 +37,7 @@ def wrap_deep_agents_error(error: Exception) -> tuple[Exception, bool]:
         return AgentTimeoutError(f"Agent execution timed out: {error}"), False
 
     # Output parsing errors
-    if "parse" in error_str or "output" in error_str and "format" in error_str:
+    if ("parse" in error_str and "output" in error_str) or ("output" in error_str and "format" in error_str):
         return AgentResponseError(f"Failed to parse agent response: {error}"), False
 
     # GraphRecursionError from LangGraph

--- a/src/karenina/adapters/langchain_deep_agents/llm.py
+++ b/src/karenina/adapters/langchain_deep_agents/llm.py
@@ -172,17 +172,24 @@ class DeepAgentsLLMAdapter:
         self,
         schema: type[BaseModel],
         *,
-        max_retries: int | None = None,  # noqa: ARG002
+        max_retries: int | None = None,
     ) -> DeepAgentsLLMAdapter:
         """Return a new adapter configured for structured output.
 
         Args:
             schema: A Pydantic model class defining the output structure.
-            max_retries: Ignored (LangChain handles retries internally).
+            max_retries: Not supported by this adapter. A warning is emitted
+                if a non-None value is provided.
 
         Returns:
             A new DeepAgentsLLMAdapter configured with the schema.
         """
+        if max_retries is not None:
+            logger.warning(
+                "max_retries=%d ignored by langchain_deep_agents adapter; "
+                "retry behavior is managed internally by LangChain",
+                max_retries,
+            )
         return DeepAgentsLLMAdapter(
             self._config,
             _structured_schema=schema,

--- a/src/karenina/adapters/langchain_deep_agents/llm.py
+++ b/src/karenina/adapters/langchain_deep_agents/llm.py
@@ -187,3 +187,11 @@ class DeepAgentsLLMAdapter:
             self._config,
             _structured_schema=schema,
         )
+
+    async def aclose(self) -> None:
+        """Close underlying resources.
+
+        No resources to clean up: the LangChain model is created fresh
+        per ainvoke() call. Provided for interface consistency with other
+        adapters.
+        """

--- a/src/karenina/adapters/langchain_deep_agents/mcp.py
+++ b/src/karenina/adapters/langchain_deep_agents/mcp.py
@@ -7,6 +7,7 @@ compatible with langchain-mcp-adapters' MultiServerMCPClient.
 from __future__ import annotations
 
 import logging
+from contextlib import AsyncExitStack
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -72,14 +73,18 @@ def build_mcp_server_params(
 
 async def convert_mcp_to_tools(
     mcp_servers: dict[str, Any] | None,
+    exit_stack: AsyncExitStack,
 ) -> list[Any]:
     """Convert MCP server configs to LangChain tools via langchain-mcp-adapters.
 
-    Creates a MultiServerMCPClient, connects to all servers, and returns
-    their tools as LangChain BaseTool instances.
+    Creates a MultiServerMCPClient registered with the provided exit_stack
+    so that MCP sessions remain open for the lifetime of the caller's
+    exit_stack context.
 
     Args:
         mcp_servers: Dict mapping server names to MCPServerConfig.
+        exit_stack: AsyncExitStack managing session lifecycles. Sessions
+            remain open until the exit stack closes.
 
     Returns:
         List of LangChain BaseTool instances from all MCP servers.
@@ -90,5 +95,6 @@ async def convert_mcp_to_tools(
 
     from langchain_mcp_adapters.client import MultiServerMCPClient
 
-    async with MultiServerMCPClient(server_params) as client:  # type: ignore[arg-type,misc]
-        return await client.get_tools()
+    client = MultiServerMCPClient(server_params)  # type: ignore[arg-type]
+    await exit_stack.enter_async_context(client)  # type: ignore[arg-type]
+    return await client.get_tools()

--- a/src/karenina/adapters/langchain_deep_agents/parser.py
+++ b/src/karenina/adapters/langchain_deep_agents/parser.py
@@ -232,3 +232,6 @@ class DeepAgentsParserAdapter:
 
         except RuntimeError:
             return asyncio.run(self.aparse_to_pydantic(messages, schema))
+
+    async def aclose(self) -> None:
+        """Close underlying resources (no-op for this adapter)."""

--- a/src/karenina/adapters/langchain_deep_agents/prompts/rubric.py
+++ b/src/karenina/adapters/langchain_deep_agents/prompts/rubric.py
@@ -38,6 +38,7 @@ _RUBRIC_TASKS = [
     "rubric_literal_trait_batch",
     "rubric_literal_trait_single",
     "rubric_metric_trait",
+    "rubric_dynamic_presence_check",
 ]
 for _task in _RUBRIC_TASKS:
     AdapterInstructionRegistry.register("langchain_deep_agents", _task, _deep_agents_rubric_factory)

--- a/src/karenina/adapters/manual/__init__.py
+++ b/src/karenina/adapters/manual/__init__.py
@@ -117,6 +117,11 @@ class ManualAgentAdapter:
         """
         self._model_config = model_config
 
+    @property
+    def capabilities(self) -> PortCapabilities:
+        """Default capabilities for the manual agent adapter (no-op)."""
+        return PortCapabilities()
+
     async def arun(
         self,
         messages: list[Message],

--- a/src/karenina/adapters/manual/__init__.py
+++ b/src/karenina/adapters/manual/__init__.py
@@ -198,6 +198,9 @@ class ManualAgentAdapter:
             actual_model="manual",
         )
 
+    async def aclose(self) -> None:
+        """Close underlying resources (no-op for manual adapter)."""
+
 
 class ManualLLMAdapter:
     """No-op LLMPort implementation for manual interface.
@@ -239,6 +242,9 @@ class ManualLLMAdapter:
         """Raises ManualInterfaceError - manual interface cannot invoke LLM."""
         raise ManualInterfaceError("llm.with_structured_output()")
 
+    async def aclose(self) -> None:
+        """Close underlying resources (no-op for manual adapter)."""
+
 
 class ManualParserAdapter:
     """No-op ParserPort implementation for manual interface.
@@ -270,6 +276,9 @@ class ManualParserAdapter:
     def parse_to_pydantic(self, messages: list[Message], schema: type[T]) -> ParsePortResult[T]:  # noqa: ARG002
         """Raises ManualInterfaceError - manual interface cannot parse via LLM."""
         raise ManualInterfaceError("parser.parse_to_pydantic()")
+
+    async def aclose(self) -> None:
+        """Close underlying resources (no-op for manual adapter)."""
 
 
 # =============================================================================

--- a/src/karenina/benchmark/verification/evaluators/template/deep_judgment.py
+++ b/src/karenina/benchmark/verification/evaluators/template/deep_judgment.py
@@ -13,7 +13,7 @@ with a multi-stage approach:
    - Determines what value the attribute should have based on the evidence
 
 3. Stage 3: Parse final attribute values (standard parsing logic)
-   - Uses PydanticOutputParser with the same schema to extract structured values
+   - Uses ParserPort with the same schema to extract structured values
 
 The feature gracefully handles missing excerpts (refusals, no corroborating evidence)
 and provides detailed metadata about the parsing process.
@@ -130,10 +130,7 @@ def deep_judgment_parse(
     # PREPARE PROMPTS
     # ==========================================
     # Generate JSON schema with field descriptions from the template class
-    from langchain_core.output_parsers import PydanticOutputParser
-
-    temp_parser = PydanticOutputParser(pydantic_object=RawAnswer)
-    json_schema = temp_parser.get_format_instructions()
+    json_schema = json.dumps(RawAnswer.model_json_schema(), indent=2)
 
     # The combined_system_prompt is now format-agnostic (no format_instructions section).
     # Use it directly as the generic system prompt for stages 1&2.

--- a/src/karenina/benchmark/verification/evaluators/template/evaluator.py
+++ b/src/karenina/benchmark/verification/evaluators/template/evaluator.py
@@ -389,8 +389,6 @@ class TemplateEvaluator:
         Returns:
             ParseResult with deep judgment metadata
         """
-        from langchain_core.output_parsers import PydanticOutputParser
-
         from karenina.schemas.verification import VerificationConfig
 
         from .deep_judgment import deep_judgment_parse
@@ -410,10 +408,6 @@ class TemplateEvaluator:
             deep_judgment_search_enabled=deep_judgment_config.get("search_enabled", False),
             deep_judgment_search_tool=deep_judgment_config.get("search_tool", "wikipedia"),
         )
-
-        # Build prompts for deep judgment
-        parser = PydanticOutputParser(pydantic_object=self.answer_class)
-        format_instructions = parser.get_format_instructions()
 
         # Extract ground truth if enabled
         ground_truth = None
@@ -446,7 +440,7 @@ class TemplateEvaluator:
             user_instructions=user_instructions,
             instruction_context={
                 "json_schema": build_parsing_schema(self.answer_class),
-                "format_instructions": format_instructions,
+                "format_instructions": "",
             },
         )
 
@@ -459,7 +453,7 @@ class TemplateEvaluator:
                 parser=self._parser,
                 question_text=question_text,
                 config=dj_config,
-                format_instructions=format_instructions,
+                format_instructions="",  # Unused (ARG001), kept for interface stability
                 combined_system_prompt=combined_system_prompt,
                 usage_tracker=usage_tracker,
                 parsing_model_str=self.model_str,

--- a/src/karenina/benchmark/verification/utils/template_parsing_helpers.py
+++ b/src/karenina/benchmark/verification/utils/template_parsing_helpers.py
@@ -104,7 +104,7 @@ def _extract_attribute_descriptions(json_schema: str, attribute_names: list[str]
     without requiring it to follow the full schema format.
 
     Args:
-        json_schema: JSON schema string from PydanticOutputParser.get_format_instructions()
+        json_schema: JSON schema string from model_json_schema()
         attribute_names: List of attribute names to extract descriptions for
 
     Returns:

--- a/src/karenina/ports/agent.py
+++ b/src/karenina/ports/agent.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict, runtime_checkable
 
+from karenina.ports.capabilities import PortCapabilities
+
 if TYPE_CHECKING:
     from karenina.ports.messages import Message
     from karenina.ports.usage import UsageMetadata
@@ -245,6 +247,17 @@ class AgentPort(Protocol):
         - Both `raw_trace` and `trace_messages` in AgentResult provide the same
           conversation data in different formats for backward compatibility
     """
+
+    @property
+    def capabilities(self) -> PortCapabilities:
+        """Declare what prompt features this agent adapter supports.
+
+        Returns:
+            PortCapabilities with adapter-specific feature flags.
+            Defaults to PortCapabilities() (system prompts supported,
+            structured output not supported).
+        """
+        return PortCapabilities()
 
     async def arun(
         self,

--- a/src/karenina/ports/agent.py
+++ b/src/karenina/ports/agent.py
@@ -311,3 +311,12 @@ class AgentPort(Protocol):
             an existing async context - use `arun()` directly instead.
         """
         ...
+
+    async def aclose(self) -> None:
+        """Close underlying resources.
+
+        Implementations should release any held resources (HTTP connections,
+        file handles, MCP sessions). Safe to call multiple times. The default
+        is a no-op for adapters with no resources to clean up.
+        """
+        ...

--- a/src/karenina/ports/errors.py
+++ b/src/karenina/ports/errors.py
@@ -105,6 +105,7 @@ class AgentExecutionError(PortError):
     Args:
         message: Human-readable description of the error.
         stderr: Standard error output from the failed process, if available.
+        limit_reached: True if the error was caused by hitting a turn/recursion limit.
 
     Example:
         raise AgentExecutionError(
@@ -113,9 +114,10 @@ class AgentExecutionError(PortError):
         )
     """
 
-    def __init__(self, message: str, stderr: str | None = None) -> None:
+    def __init__(self, message: str, stderr: str | None = None, limit_reached: bool = False) -> None:
         super().__init__(message)
         self.stderr = stderr
+        self.limit_reached = limit_reached
 
 
 class AgentTimeoutError(AgentExecutionError):

--- a/src/karenina/ports/llm.py
+++ b/src/karenina/ports/llm.py
@@ -115,7 +115,10 @@ class LLMPort(Protocol):
         Args:
             schema: A Pydantic model class defining the output structure.
             max_retries: Maximum retry attempts on validation failure.
-                Implementation depends on adapter (some may ignore this).
+                Not all adapters support this parameter. LangChain and Claude
+                Tool adapters respect it; Claude SDK and Deep Agents adapters
+                ignore it (with a warning). Check adapter documentation for
+                details.
 
         Returns:
             A new LLMPort instance configured for structured output.

--- a/src/karenina/ports/llm.py
+++ b/src/karenina/ports/llm.py
@@ -127,3 +127,12 @@ class LLMPort(Protocol):
             >>> structured_llm = llm.with_structured_output(Answer)
         """
         ...
+
+    async def aclose(self) -> None:
+        """Close underlying resources.
+
+        Implementations should release any held resources (HTTP connections,
+        file handles, MCP sessions). Safe to call multiple times. The default
+        is a no-op for adapters with no resources to clean up.
+        """
+        ...

--- a/src/karenina/ports/parser.py
+++ b/src/karenina/ports/parser.py
@@ -131,3 +131,12 @@ class ParserPort(Protocol):
             PortError: If the underlying LLM invocation fails.
         """
         ...
+
+    async def aclose(self) -> None:
+        """Close underlying resources.
+
+        Implementations should release any held resources (HTTP connections,
+        file handles, MCP sessions). Safe to call multiple times. The default
+        is a no-op for adapters with no resources to clean up.
+        """
+        ...

--- a/tests/unit/adapters/claude_sdk/test_errors.py
+++ b/tests/unit/adapters/claude_sdk/test_errors.py
@@ -128,3 +128,32 @@ class TestWrapSdkError:
 
         assert isinstance(result, AgentExecutionError)
         assert "ValueError" in result.message
+
+    def test_turn_limit_error_by_type_name(self) -> None:
+        """MaxTurnsExceeded exception should map to AgentExecutionError with limit flag."""
+        mock_error = MagicMock()
+        mock_error.__class__.__name__ = "MaxTurnsExceededException"
+        result = wrap_sdk_error(mock_error)
+        assert isinstance(result, AgentExecutionError)
+        assert result.limit_reached is True
+
+    def test_turn_limit_error_by_message(self) -> None:
+        """Exception with 'max_turns' in message should map to limit error."""
+        error = RuntimeError("Agent exceeded max_turns limit")
+        result = wrap_sdk_error(error)
+        assert isinstance(result, AgentExecutionError)
+        assert result.limit_reached is True
+
+    def test_recursion_in_message(self) -> None:
+        """Exception with 'recursion' in message should map to limit error."""
+        error = RuntimeError("Hit recursion limit after 50 turns")
+        result = wrap_sdk_error(error)
+        assert isinstance(result, AgentExecutionError)
+        assert result.limit_reached is True
+
+    def test_non_limit_error_has_limit_reached_false(self) -> None:
+        """Non-limit errors should have limit_reached=False."""
+        error = ValueError("Something went wrong")
+        result = wrap_sdk_error(error)
+        assert isinstance(result, AgentExecutionError)
+        assert result.limit_reached is False

--- a/tests/unit/adapters/claude_sdk/test_mcp_config.py
+++ b/tests/unit/adapters/claude_sdk/test_mcp_config.py
@@ -1,11 +1,14 @@
 """Tests for MCP configuration conversion and validation.
 
-Tests convert_mcp_config, validate_mcp_config, and convert_and_validate_mcp_config.
+Tests convert_mcp_config, validate_mcp_config, convert_and_validate_mcp_config,
+and _convert_mcp_servers format detection on ClaudeSDKAgentAdapter.
 """
 
 from __future__ import annotations
 
 from typing import Any
+
+import pytest
 
 from karenina.adapters.claude_agent_sdk import convert_mcp_config
 from karenina.adapters.claude_agent_sdk.mcp import (
@@ -190,3 +193,79 @@ class TestConvertAndValidateMcpConfig:
 
         # All should be present
         assert len(config) == 4
+
+
+@pytest.mark.unit
+class TestConvertMcpServersFormatDetection:
+    """Tests for ClaudeSDKAgentAdapter._convert_mcp_servers format detection."""
+
+    @pytest.fixture
+    def adapter(self) -> Any:
+        """Create an adapter instance for testing."""
+        from karenina.adapters.claude_agent_sdk.agent import ClaudeSDKAgentAdapter
+        from karenina.schemas.config import ModelConfig
+
+        config = ModelConfig(
+            id="test",
+            model_name="claude-sonnet-4-20250514",
+            model_provider="anthropic",
+            interface="claude_agent_sdk",
+        )
+        return ClaudeSDKAgentAdapter(config)
+
+    def test_stdio_config_detected_as_sdk_format(self, adapter: Any) -> None:
+        """Config with 'command' key should be recognized as SDK format."""
+        servers = {"local": {"command": "/usr/bin/mcp-server", "args": ["-v"]}}
+        result = adapter._convert_mcp_servers(servers)
+
+        assert result is servers
+
+    def test_http_config_detected_as_sdk_format(self, adapter: Any) -> None:
+        """Config with 'url' and type='http' should be recognized as SDK format."""
+        servers = {"api": {"type": "http", "url": "https://mcp.example.com/"}}
+        result = adapter._convert_mcp_servers(servers)
+
+        assert result is servers
+
+    def test_sse_config_detected_as_sdk_format(self, adapter: Any) -> None:
+        """Config with 'url' and type='sse' should be recognized as SDK format."""
+        servers = {"api": {"type": "sse", "url": "https://mcp.example.com/sse"}}
+        result = adapter._convert_mcp_servers(servers)
+
+        assert result is servers
+
+    def test_generic_type_key_not_false_positive(self, adapter: Any) -> None:
+        """A dict with 'type' but no 'command' or 'url' should not match SDK format.
+
+        This was the original bug: any dict with a 'type' key was treated as
+        already-converted SDK format, causing configs to skip conversion.
+        With the fix, only configs that have 'command' (stdio) or 'url' plus
+        a known transport type are recognized as SDK format.
+        """
+        servers = {
+            "custom": {"type": "custom_plugin", "endpoint": "https://example.com"},
+            "remote": "https://mcp.example.com/mcp/",
+        }
+        result = adapter._convert_mcp_servers(servers)
+
+        # The string URL should have been converted (not passed through as-is)
+        assert result is not servers
+        assert "remote" in result
+        assert result["remote"].get("type") == "http"
+
+    def test_url_without_known_type_falls_through(self, adapter: Any) -> None:
+        """A dict with 'url' but unrecognized type should not match SDK format."""
+        servers = {"api": {"type": "grpc", "url": "https://grpc.example.com"}}
+        result = adapter._convert_mcp_servers(servers)
+
+        # Should fall through to URL extraction, not early-return as SDK format
+        assert "api" in result
+        assert result["api"].get("type") == "http"
+
+    def test_none_returns_none(self, adapter: Any) -> None:
+        """None input should return None."""
+        assert adapter._convert_mcp_servers(None) is None
+
+    def test_empty_dict_returns_none(self, adapter: Any) -> None:
+        """Empty dict should return None."""
+        assert adapter._convert_mcp_servers({}) is None

--- a/tests/unit/adapters/claude_tool/test_agent_adapter.py
+++ b/tests/unit/adapters/claude_tool/test_agent_adapter.py
@@ -497,6 +497,34 @@ class TestAgentAdapterExecuteLoop:
             assert result.limit_reached is False
             assert result.final_response == "Single turn"
 
+    @pytest.mark.asyncio
+    async def test_execute_loop_without_tools_applies_timeout(self, model_config: Any) -> None:
+        """Test _execute_agent_loop applies timeout to single-turn path.
+
+        When no tools are provided, the adapter falls back to
+        messages.create(). The timeout must still apply to this path.
+        """
+        import asyncio
+
+        adapter = ClaudeToolAgentAdapter(model_config)
+
+        async def slow_create(**kwargs: Any) -> MockResponse:
+            await asyncio.sleep(10)
+            return MockResponse()
+
+        mock_client = MagicMock()
+        mock_client.messages.create = slow_create
+
+        with (
+            patch.object(adapter, "_get_async_client", return_value=mock_client),
+            pytest.raises(TimeoutError),
+        ):
+            await adapter._execute_agent_loop(
+                messages=[Message.user("Hello")],
+                tools=[],
+                config=AgentConfig(timeout=0.01),
+            )
+
 
 class TestAgentAdapterSync:
     """Tests for synchronous agent execution."""

--- a/tests/unit/adapters/claude_tool/test_agent_adapter.py
+++ b/tests/unit/adapters/claude_tool/test_agent_adapter.py
@@ -6,7 +6,7 @@ Tests agent adapter functionality for multi-turn tool execution.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -210,10 +210,9 @@ class TestAgentAdapterRun:
         adapter = ClaudeToolAgentAdapter(model_config)
 
         mock_response = MockResponse(content=[MockTextBlock("Hello!")])
-        mock_iterator = MockAsyncIterator([mock_response])
 
         mock_client = MagicMock()
-        mock_client.beta.messages.tool_runner = MagicMock(return_value=mock_iterator)
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
 
         with patch.object(adapter, "_get_async_client", return_value=mock_client):
             result = await adapter.arun(
@@ -226,9 +225,30 @@ class TestAgentAdapterRun:
             assert result.trace_messages is not None
 
     @pytest.mark.asyncio
-    async def test_run_uses_tool_runner(self, model_config: Any) -> None:
-        """Test run uses tool_runner for execution."""
+    async def test_run_without_tools_uses_messages_create(self, model_config: Any) -> None:
+        """Test run uses messages.create when no tools are provided."""
         adapter = ClaudeToolAgentAdapter(model_config)
+
+        mock_response = MockResponse()
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+        with patch.object(adapter, "_get_async_client", return_value=mock_client):
+            await adapter.arun(messages=[Message.user("Hello")])
+
+            mock_client.messages.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_with_tools_uses_tool_runner(self, model_config: Any) -> None:
+        """Test run uses tool_runner when tools are provided."""
+        adapter = ClaudeToolAgentAdapter(model_config)
+
+        tool = Tool(
+            name="my_tool",
+            description="A tool",
+            input_schema={"type": "object", "properties": {}},
+        )
 
         mock_response = MockResponse()
         mock_iterator = MockAsyncIterator([mock_response])
@@ -236,8 +256,17 @@ class TestAgentAdapterRun:
         mock_client = MagicMock()
         mock_client.beta.messages.tool_runner = MagicMock(return_value=mock_iterator)
 
-        with patch.object(adapter, "_get_async_client", return_value=mock_client):
-            await adapter.arun(messages=[Message.user("Hello")])
+        with (
+            patch.object(adapter, "_get_async_client", return_value=mock_client),
+            patch("karenina.adapters.claude_tool.agent.wrap_static_tool") as mock_wrap,
+        ):
+            mock_wrapped = MagicMock()
+            mock_wrap.return_value = mock_wrapped
+
+            await adapter.arun(
+                messages=[Message.user("Hello")],
+                tools=[tool],
+            )
 
             mock_client.beta.messages.tool_runner.assert_called_once()
 
@@ -247,15 +276,14 @@ class TestAgentAdapterRun:
         adapter = ClaudeToolAgentAdapter(model_config)
 
         mock_response = MockResponse()
-        mock_iterator = MockAsyncIterator([mock_response])
 
         mock_client = MagicMock()
-        mock_client.beta.messages.tool_runner = MagicMock(return_value=mock_iterator)
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
 
         with patch.object(adapter, "_get_async_client", return_value=mock_client):
             await adapter.arun(messages=[Message.user("Hello")])
 
-            call_kwargs = mock_client.beta.messages.tool_runner.call_args.kwargs
+            call_kwargs = mock_client.messages.create.call_args.kwargs
             assert call_kwargs["model"] == "claude-haiku-4-5"
             assert call_kwargs["max_tokens"] == 1024
 
@@ -356,10 +384,10 @@ class TestAgentAdapterWithMCPServers:
         }
 
         mock_response = MockResponse()
-        mock_iterator = MockAsyncIterator([mock_response])
 
         mock_client = MagicMock()
-        mock_client.beta.messages.tool_runner = MagicMock(return_value=mock_iterator)
+        # No MCP tools returned, so the no-tools path uses messages.create
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
 
         with (
             patch.object(adapter, "_get_async_client", return_value=mock_client),
@@ -378,7 +406,7 @@ class TestAgentAdapterWithMCPServers:
 
 
 class TestAgentAdapterExecuteLoop:
-    """Tests for agent loop execution."""
+    """Tests for agent loop execution with tools (tool_runner path)."""
 
     @pytest.mark.asyncio
     async def test_execute_loop_collects_messages(self, model_config: Any) -> None:
@@ -392,10 +420,11 @@ class TestAgentAdapterExecuteLoop:
         mock_client = MagicMock()
         mock_client.beta.messages.tool_runner = MagicMock(return_value=mock_iterator)
 
+        sentinel_tool = MagicMock()
         with patch.object(adapter, "_get_async_client", return_value=mock_client):
             result = await adapter._execute_agent_loop(
                 messages=[Message.user("Hello")],
-                tools=[],
+                tools=[sentinel_tool],
                 config=AgentConfig(),
             )
 
@@ -412,13 +441,14 @@ class TestAgentAdapterExecuteLoop:
         mock_client = MagicMock()
         mock_client.beta.messages.tool_runner = MagicMock(return_value=mock_iterator)
 
+        sentinel_tool = MagicMock()
         with (
             patch.object(adapter, "_get_async_client", return_value=mock_client),
             pytest.raises(AgentResponseError, match="No messages received"),
         ):
             await adapter._execute_agent_loop(
                 messages=[Message.user("Hello")],
-                tools=[],
+                tools=[sentinel_tool],
                 config=AgentConfig(),
             )
 
@@ -433,15 +463,39 @@ class TestAgentAdapterExecuteLoop:
         mock_client = MagicMock()
         mock_client.beta.messages.tool_runner = MagicMock(return_value=mock_iterator)
 
+        sentinel_tool = MagicMock()
         with patch.object(adapter, "_get_async_client", return_value=mock_client):
             result = await adapter._execute_agent_loop(
                 messages=[Message.user("Hello")],
-                tools=[],
+                tools=[sentinel_tool],
                 config=AgentConfig(max_turns=3),
             )
 
             assert result.turns == 3
             assert result.limit_reached is True
+
+    @pytest.mark.asyncio
+    async def test_execute_loop_without_tools_uses_messages_create(self, model_config: Any) -> None:
+        """Test _execute_agent_loop uses messages.create when tools list is empty."""
+        adapter = ClaudeToolAgentAdapter(model_config)
+
+        mock_response = MockResponse(content=[MockTextBlock("Single turn")])
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+        with patch.object(adapter, "_get_async_client", return_value=mock_client):
+            result = await adapter._execute_agent_loop(
+                messages=[Message.user("Hello")],
+                tools=[],
+                config=AgentConfig(),
+            )
+
+            mock_client.messages.create.assert_called_once()
+            assert len(result.trace_messages) == 1
+            assert result.turns == 1
+            assert result.limit_reached is False
+            assert result.final_response == "Single turn"
 
 
 class TestAgentAdapterSync:

--- a/tests/unit/adapters/claude_tool/test_llm_adapter.py
+++ b/tests/unit/adapters/claude_tool/test_llm_adapter.py
@@ -257,6 +257,38 @@ class TestLLMAdapterStructuredOutput:
             assert result.raw == mock_parsed
 
     @pytest.mark.asyncio
+    async def test_structured_ainvoke_content_is_json(self, model_config: Any) -> None:
+        """Test structured output content is valid JSON, not str(model).
+
+        The content field must be JSON-serialized so that callers can
+        json.loads(response.content) to reconstruct the parsed object.
+        """
+        import json
+
+        class TestSchema(BaseModel):
+            value: str
+            count: int
+
+        adapter = ClaudeToolLLMAdapter(model_config)
+        structured = adapter.with_structured_output(TestSchema)
+
+        mock_parsed = TestSchema(value="hello", count=42)
+        mock_response = MagicMock()
+        mock_response.parsed_output = mock_parsed
+        mock_response.usage = MockUsage()
+
+        mock_client = AsyncMock()
+        mock_client.beta.messages.parse.return_value = mock_response
+
+        with patch.object(structured, "_get_async_client", return_value=mock_client):
+            result = await structured.ainvoke([Message.user("Parse this")])
+
+            # Content must be valid JSON
+            parsed = json.loads(result.content)
+            assert parsed["value"] == "hello"
+            assert parsed["count"] == 42
+
+    @pytest.mark.asyncio
     async def test_structured_ainvoke_passes_output_format(self, model_config: Any) -> None:
         """Test structured output passes schema as output_format."""
 

--- a/tests/unit/adapters/conformance/test_agent_port.py
+++ b/tests/unit/adapters/conformance/test_agent_port.py
@@ -65,6 +65,13 @@ class TestAgentPortConformance:
         assert result.turns >= 0
         assert isinstance(result.limit_reached, bool)
 
+    def test_agent_port_has_capabilities(self, deep_agents_agent_adapter):
+        """AgentPort should expose a capabilities property."""
+        from karenina.ports.capabilities import PortCapabilities
+
+        caps = deep_agents_agent_adapter.capabilities
+        assert isinstance(caps, PortCapabilities)
+
     @pytest.mark.asyncio
     async def test_agent_result_usage_valid(
         self,

--- a/tests/unit/adapters/langchain/test_trace_tool_error.py
+++ b/tests/unit/adapters/langchain/test_trace_tool_error.py
@@ -1,0 +1,24 @@
+"""Test that tool error detection no longer produces false positives."""
+
+import pytest
+
+from karenina.adapters.langchain.trace import _detect_tool_error
+
+
+@pytest.mark.unit
+class TestToolErrorDetectionRemoved:
+    def test_legitimate_tool_output_not_flagged(self):
+        """Tool output containing error keywords should not be flagged."""
+        assert _detect_tool_error("No errors found in the analysis") is False
+        assert _detect_tool_error("timeout set to 30 seconds") is False
+        assert _detect_tool_error("The exception handling looks correct") is False
+        assert _detect_tool_error("Search failed to find any results") is False
+
+    def test_actual_error_also_not_flagged(self):
+        """Even actual errors return False (no structural signal available)."""
+        assert _detect_tool_error("Error: connection refused") is False
+        assert _detect_tool_error("Traceback (most recent call last):") is False
+
+    def test_empty_content(self):
+        """Empty content returns False."""
+        assert _detect_tool_error("") is False

--- a/tests/unit/adapters/langchain_deep_agents/test_agent.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_agent.py
@@ -256,3 +256,159 @@ class TestDeepAgentsAgentAdapter:
         """aclose() should not raise."""
         adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
         await adapter.aclose()
+
+
+@pytest.mark.unit
+class TestDeepAgentsMCPToolsWiring:
+    """Test that arun() passes tools and MCP-derived tools to the agent."""
+
+    @pytest.mark.asyncio
+    async def test_explicit_tools_passed_to_agent(self, deep_agents_model_config, monkeypatch):
+        """Explicit tools should be forwarded to create_deep_agent."""
+        from karenina.ports import AgentConfig, Message, Tool
+        from karenina.ports.usage import UsageMetadata
+
+        captured_kwargs = {}
+
+        def mock_create_deep_agent(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_agent = AsyncMock()
+            mock_agent.ainvoke = AsyncMock(
+                return_value={
+                    "messages": [MagicMock(content="Done", type="ai")],
+                    "is_last_step": False,
+                }
+            )
+            return mock_agent
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+            mock_create_deep_agent,
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.deep_agents_messages_to_raw_trace",
+            lambda _msgs: "trace",
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.extract_deep_agents_usage",
+            lambda _msgs, model: UsageMetadata(model=model),
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.extract_actual_model",
+            lambda _msgs: None,
+        )
+
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        test_tool = Tool(name="test_tool", description="A test tool", input_schema={})
+
+        await adapter.arun(
+            messages=[Message.user("Hello")],
+            tools=[test_tool],
+            config=AgentConfig(max_turns=5),
+        )
+
+        assert "tools" in captured_kwargs
+        assert len(captured_kwargs["tools"]) >= 1
+
+    @pytest.mark.asyncio
+    async def test_mcp_tools_loaded_and_combined(self, deep_agents_model_config, monkeypatch):
+        """MCP servers should be converted to tools and combined with explicit tools."""
+        from karenina.ports import AgentConfig, Message, Tool
+        from karenina.ports.usage import UsageMetadata
+
+        captured_kwargs = {}
+        fake_mcp_tool = MagicMock()
+        fake_mcp_tool.name = "mcp_tool"
+
+        def mock_create_deep_agent(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_agent = AsyncMock()
+            mock_agent.ainvoke = AsyncMock(
+                return_value={
+                    "messages": [MagicMock(content="Done", type="ai")],
+                    "is_last_step": False,
+                }
+            )
+            return mock_agent
+
+        async def mock_convert_mcp(servers, exit_stack):
+            return [fake_mcp_tool]
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+            mock_create_deep_agent,
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.mcp.convert_mcp_to_tools",
+            mock_convert_mcp,
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.deep_agents_messages_to_raw_trace",
+            lambda _msgs: "trace",
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.extract_deep_agents_usage",
+            lambda _msgs, model: UsageMetadata(model=model),
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.extract_actual_model",
+            lambda _msgs: None,
+        )
+
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        test_tool = Tool(name="explicit_tool", description="Explicit", input_schema={})
+
+        await adapter.arun(
+            messages=[Message.user("Hello")],
+            tools=[test_tool],
+            mcp_servers={"server1": {"type": "stdio", "command": "echo"}},
+            config=AgentConfig(max_turns=5),
+        )
+
+        assert "tools" in captured_kwargs
+        tool_names = [t.name if hasattr(t, "name") else str(t) for t in captured_kwargs["tools"]]
+        assert "mcp_tool" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_no_tools_kwarg_when_none_provided(self, deep_agents_model_config, monkeypatch):
+        """When neither tools nor mcp_servers are given, tools kwarg should be absent."""
+        from karenina.ports import AgentConfig, Message
+        from karenina.ports.usage import UsageMetadata
+
+        captured_kwargs = {}
+
+        def mock_create_deep_agent(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_agent = AsyncMock()
+            mock_agent.ainvoke = AsyncMock(
+                return_value={
+                    "messages": [MagicMock(content="Done", type="ai")],
+                    "is_last_step": False,
+                }
+            )
+            return mock_agent
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+            mock_create_deep_agent,
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.deep_agents_messages_to_raw_trace",
+            lambda _msgs: "trace",
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.extract_deep_agents_usage",
+            lambda _msgs, model: UsageMetadata(model=model),
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.extract_actual_model",
+            lambda _msgs: None,
+        )
+
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        await adapter.arun(
+            messages=[Message.user("Hello")],
+            config=AgentConfig(max_turns=5),
+        )
+
+        assert "tools" not in captured_kwargs

--- a/tests/unit/adapters/langchain_deep_agents/test_agent.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_agent.py
@@ -259,6 +259,18 @@ class TestDeepAgentsAgentAdapter:
 
 
 @pytest.mark.unit
+class TestDeepAgentsAgentCapabilities:
+    def test_capabilities_returns_port_capabilities(self, deep_agents_model_config):
+        """DeepAgentsAgentAdapter should expose a capabilities property."""
+        from karenina.ports.capabilities import PortCapabilities
+
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        caps = adapter.capabilities
+        assert isinstance(caps, PortCapabilities)
+        assert caps.supports_system_prompt is True
+
+
+@pytest.mark.unit
 class TestDeepAgentsMCPToolsWiring:
     """Test that arun() passes tools and MCP-derived tools to the agent."""
 

--- a/tests/unit/adapters/langchain_deep_agents/test_errors.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_errors.py
@@ -1,0 +1,39 @@
+"""Tests for Deep Agents error wrapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.adapters.langchain_deep_agents.errors import wrap_deep_agents_error
+from karenina.ports.errors import AgentExecutionError, AgentResponseError
+
+
+@pytest.mark.unit
+class TestWrapDeepAgentsError:
+    def test_parse_alone_does_not_trigger_response_error(self):
+        """'parse' alone should NOT map to AgentResponseError (093 regression)."""
+        error = RuntimeError("failed to parse MCP configuration")
+        mapped, was_limit = wrap_deep_agents_error(error)
+        assert not isinstance(mapped, AgentResponseError)
+        assert isinstance(mapped, AgentExecutionError)
+
+    def test_parse_output_triggers_response_error(self):
+        """'parse' + 'output' should map to AgentResponseError."""
+        error = RuntimeError("failed to parse output from agent")
+        mapped, was_limit = wrap_deep_agents_error(error)
+        assert isinstance(mapped, AgentResponseError)
+        assert was_limit is False
+
+    def test_output_format_triggers_response_error(self):
+        """'output' + 'format' should map to AgentResponseError."""
+        error = RuntimeError("output format error in response")
+        mapped, was_limit = wrap_deep_agents_error(error)
+        assert isinstance(mapped, AgentResponseError)
+        assert was_limit is False
+
+    def test_recursion_limit_detected(self):
+        """Recursion limit errors should set limit_reached=True."""
+        error = RuntimeError("Hit recursion limit")
+        mapped, was_limit = wrap_deep_agents_error(error)
+        assert isinstance(mapped, AgentExecutionError)
+        assert was_limit is True

--- a/tests/unit/adapters/langchain_deep_agents/test_llm.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_llm.py
@@ -53,6 +53,23 @@ class TestDeepAgentsLLMAdapter:
         assert structured._structured_schema == Answer
         assert adapter._structured_schema is None  # Original unchanged
 
+    def test_with_structured_output_warns_on_max_retries(self, deep_agents_model_config, caplog):
+        """with_structured_output should warn when max_retries is provided."""
+        import logging
+
+        from pydantic import BaseModel, Field
+
+        class Answer(BaseModel):
+            value: str = Field(description="The answer")
+
+        adapter = DeepAgentsLLMAdapter(deep_agents_model_config)
+
+        with caplog.at_level(logging.WARNING):
+            adapter.with_structured_output(Answer, max_retries=5)
+
+        assert "max_retries" in caplog.text
+        assert "ignored" in caplog.text.lower()
+
     @pytest.mark.asyncio
     async def test_aclose_exists_and_is_noop(self, deep_agents_model_config):
         """aclose() should exist and complete without error."""

--- a/tests/unit/adapters/langchain_deep_agents/test_llm.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_llm.py
@@ -52,3 +52,9 @@ class TestDeepAgentsLLMAdapter:
         assert isinstance(structured, DeepAgentsLLMAdapter)
         assert structured._structured_schema == Answer
         assert adapter._structured_schema is None  # Original unchanged
+
+    @pytest.mark.asyncio
+    async def test_aclose_exists_and_is_noop(self, deep_agents_model_config):
+        """aclose() should exist and complete without error."""
+        adapter = DeepAgentsLLMAdapter(deep_agents_model_config)
+        await adapter.aclose()  # Should not raise

--- a/tests/unit/adapters/langchain_deep_agents/test_mcp.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_mcp.py
@@ -2,7 +2,42 @@
 
 from __future__ import annotations
 
+from contextlib import AsyncExitStack
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
+
+
+@pytest.mark.unit
+class TestConvertMcpToToolsSessionLifetime:
+    """Test that convert_mcp_to_tools keeps sessions alive via exit_stack."""
+
+    @pytest.mark.asyncio
+    async def test_sessions_remain_open_after_return(self):
+        """Tools returned by convert_mcp_to_tools should have live sessions."""
+        from karenina.adapters.langchain_deep_agents.mcp import convert_mcp_to_tools
+
+        mock_tool = MagicMock(name="mock_tool")
+        mock_client = AsyncMock()
+        mock_client.get_tools = AsyncMock(return_value=[mock_tool])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "langchain_mcp_adapters.client.MultiServerMCPClient",
+            return_value=mock_client,
+        ):
+            async with AsyncExitStack() as exit_stack:
+                tools = await convert_mcp_to_tools(
+                    {"test": {"type": "http", "url": "http://localhost:8080"}},
+                    exit_stack,
+                )
+                assert len(tools) == 1
+                # Client should NOT have been closed yet (exit_stack still open)
+                mock_client.__aexit__.assert_not_called()
+
+            # After exit_stack closes, client should be cleaned up
+            mock_client.__aexit__.assert_called_once()
 
 
 @pytest.mark.unit

--- a/tests/unit/adapters/langchain_deep_agents/test_rubric_registration.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_rubric_registration.py
@@ -1,0 +1,20 @@
+"""Tests for Deep Agents rubric task registration."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+class TestRubricTaskRegistration:
+    def test_rubric_dynamic_presence_check_registered(self):
+        """Deep Agents should register rubric_dynamic_presence_check like other adapters."""
+        from karenina.adapters.langchain_deep_agents.prompts.rubric import _RUBRIC_TASKS
+
+        assert "rubric_dynamic_presence_check" in _RUBRIC_TASKS
+
+    def test_rubric_task_count_matches_other_adapters(self):
+        """Deep Agents should register the same number of rubric tasks as Claude Tool."""
+        from karenina.adapters.langchain_deep_agents.prompts.rubric import _RUBRIC_TASKS
+
+        assert len(_RUBRIC_TASKS) == 6

--- a/tests/unit/ports/test_protocols.py
+++ b/tests/unit/ports/test_protocols.py
@@ -64,12 +64,19 @@ class MockLLMPort:
         """Mock structured output configuration."""
         return self
 
+    async def aclose(self) -> None:
+        """Mock cleanup."""
+
 
 class MockAgentPort:
     """Mock implementation of AgentPort for testing isinstance checks.
 
-    Implements all required methods: arun, run.
+    Implements all required members: capabilities, arun, run, aclose.
     """
+
+    @property
+    def capabilities(self) -> PortCapabilities:
+        return PortCapabilities()
 
     async def arun(
         self,
@@ -105,6 +112,9 @@ class MockAgentPort:
             limit_reached=False,
         )
 
+    async def aclose(self) -> None:
+        """Mock cleanup."""
+
 
 class MockParserPort:
     """Mock implementation of ParserPort for testing isinstance checks.
@@ -123,6 +133,9 @@ class MockParserPort:
     def parse_to_pydantic(self, response: str, schema: type[BaseModel]) -> ParsePortResult:
         """Mock sync parsing."""
         return ParsePortResult(parsed=schema())
+
+    async def aclose(self) -> None:
+        """Mock cleanup."""
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Fix 15 cataloged issues across all 4 non-manual adapters and the port protocol layer
- Fix 6 additional bugs discovered during hot testing: structured output JSON serialization (3 adapters), LangChain turn limit not wired, Claude Tool crash without tools, Claude Tool timeout bypass
- Update adapter authoring skills and documentation with lessons learned

## Changes

**Port Protocols:**
- Add `aclose()` to LLMPort, AgentPort, ParserPort protocols
- Add `capabilities` property to AgentPort (was missing, unlike LLM/Parser)
- Add `limit_reached` attribute to `AgentExecutionError`

**Deep Agents Adapter:**
- Wire up MCP/tools support for real (was declared but silently ignored)
- Fix MCP session lifetime with `AsyncExitStack` pattern
- Fix operator precedence bug in error classification
- Add missing `rubric_dynamic_presence_check` registration
- Add `aclose()` to LLM adapter

**Claude SDK Adapter:**
- Centralize turn-limit detection via `wrap_sdk_error()`
- Replace MCP config key-sniffing with proper TypedDict field checks
- Fix structured output JSON serialization

**LangChain Adapter:**
- Remove false-positive-prone tool error heuristic
- Fix structured output JSON serialization
- Wire `max_turns` to LangGraph `recursion_limit` (was never passed)

**Claude Tool Adapter:**
- Remove module-level `load_dotenv()` calls
- Handle agent calls without tools (fallback to `messages.create()`)
- Fix structured output JSON serialization
- Apply timeout to no-tools fallback path

**Evaluators:**
- Replace `PydanticOutputParser` with native Pydantic v2 `model_json_schema()`

**Cross-Adapter:**
- Warn when `max_retries` is ignored by adapter

**Documentation:**
- Update 5 adapter creation skills with hot-testing-proven guidelines
- Update 4 docs in `docs/advanced-adapters/` for protocol changes

## Test plan

- [x] 3963 cold tests pass (0 fail)
- [x] 36/36 hot tests pass (H1-H9 across all 4 adapters with `claude-haiku-4-5`)
- [x] mypy clean on ports
- [x] All pre-commit hooks pass (ruff, vulture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)