### PR TITLE
fix(cli): CLI consistency fixes

### DIFF
--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -75,6 +75,8 @@ Most users start with a preset file that defines model providers, evaluation mod
 karenina verify checkpoint.jsonld --preset claude-haiku.json --answering-model claude-sonnet-4-5
 ```
 
+Feature flags (`--abstention`, `--sufficiency`, `--embedding-check`, `--deep-judgment`) are tri-state: `--flag` enables, `--no-flag` disables, and omitting both preserves the preset default. Embedding settings (`--embedding-threshold`, `--embedding-model`) defer to environment variables when not passed explicitly.
+
 See [Configuration Hierarchy](../../workflows/configuration/index.md) for how presets, CLI arguments, and environment variables interact.
 
 ### Progressive save and resume

--- a/docs/reference/cli/verify.md
+++ b/docs/reference/cli/verify.md
@@ -63,10 +63,12 @@ Configuration priority: interactive selection > CLI arguments + preset > preset 
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--abstention` | flag | `False` | Enable abstention detection (stage 5) |
-| `--sufficiency` | flag | `False` | Enable trace sufficiency detection (stage 6) |
-| `--embedding-check` | flag | `False` | Enable embedding similarity check (stage 9) |
-| `--deep-judgment` | flag | `False` | Enable deep judgment for templates (stage 10) |
+| `--abstention / --no-abstention` | flag pair | None (use preset/default) | Enable or disable abstention detection (stage 5) |
+| `--sufficiency / --no-sufficiency` | flag pair | None (use preset/default) | Enable or disable trace sufficiency detection (stage 6) |
+| `--embedding-check / --no-embedding-check` | flag pair | None (use preset/default) | Enable or disable embedding similarity check (stage 9) |
+| `--deep-judgment / --no-deep-judgment` | flag pair | None (use preset/default) | Enable or disable deep judgment for templates (stage 10) |
+
+Feature flags are tri-state: passing `--flag` enables the feature, `--no-flag` disables it, and passing neither preserves the preset default (or the built-in default of `False` when no preset is used).
 
 ### Deep Judgment — Rubric Settings
 
@@ -85,8 +87,8 @@ Configuration priority: interactive selection > CLI arguments + preset > preset 
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--embedding-threshold` | `FLOAT` | `0.85` | Embedding similarity threshold (`0.0`–`1.0`) |
-| `--embedding-model` | `TEXT` | `all-MiniLM-L6-v2` | Embedding model name |
+| `--embedding-threshold` | `FLOAT` | None (defers to env var or `0.85`) | Embedding similarity threshold (`0.0`--`1.0`). When omitted, respects `EMBEDDING_CHECK_THRESHOLD` env var; falls back to `0.85`. |
+| `--embedding-model` | `TEXT` | None (defers to env var or `all-MiniLM-L6-v2`) | Embedding model name. When omitted, respects `EMBEDDING_CHECK_MODEL` env var; falls back to `all-MiniLM-L6-v2`. |
 
 ### Trace Filtering (MCP)
 
@@ -207,6 +209,13 @@ karenina verify checkpoint.jsonld --preset default.json --questions 5-10
 ```bash
 karenina verify checkpoint.jsonld --preset default.json \
   --abstention --sufficiency --deep-judgment
+```
+
+### Disable a preset feature
+
+```bash
+# Preset has abstention_enabled=true; override it off
+karenina verify checkpoint.jsonld --preset default.json --no-abstention
 ```
 
 ### Template and rubric evaluation

--- a/docs/reference/configuration/env-vars.md
+++ b/docs/reference/configuration/env-vars.md
@@ -23,9 +23,9 @@ This is the exhaustive reference for every environment variable recognized by ka
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `EMBEDDING_CHECK` | `bool` | `false` | Enable embedding similarity checking. When enabled, compares the LLM's parsed answer to ground truth using vector similarity. Also read by `VerificationConfig.__init__()` to set `embedding_check_enabled` if not explicitly provided. |
-| `EMBEDDING_CHECK_MODEL` | `str` | `all-MiniLM-L6-v2` | SentenceTransformer model name for embedding computation. Also read by `VerificationConfig.__init__()` to set `embedding_check_model` if not explicitly provided. |
-| `EMBEDDING_CHECK_THRESHOLD` | `float` | `0.85` | Similarity threshold (0.0–1.0). Values outside this range are clamped. Also read by `VerificationConfig.__init__()` to set `embedding_check_threshold` if not explicitly provided. Invalid values fall back to the default. |
+| `EMBEDDING_CHECK` | `bool` | `false` | Enable embedding similarity checking. When enabled, compares the LLM's parsed answer to ground truth using vector similarity. Read by `VerificationConfig.__init__()` to set `embedding_check_enabled` if not explicitly provided. The CLI defers to this env var when `--embedding-check` / `--no-embedding-check` is not passed. |
+| `EMBEDDING_CHECK_MODEL` | `str` | `all-MiniLM-L6-v2` | SentenceTransformer model name for embedding computation. Read by `VerificationConfig.__init__()` to set `embedding_check_model` if not explicitly provided. The CLI defers to this env var when `--embedding-model` is not passed. |
+| `EMBEDDING_CHECK_THRESHOLD` | `float` | `0.85` | Similarity threshold (0.0 to 1.0). Read by `VerificationConfig.__init__()` to set `embedding_check_threshold` if not explicitly provided. The CLI defers to this env var when `--embedding-threshold` is not passed. Invalid values fall back to the default. |
 
 ### Async Execution
 

--- a/src/karenina/cli/verify.py
+++ b/src/karenina/cli/verify.py
@@ -19,14 +19,12 @@ from karenina.schemas import FinishedTemplate, VerificationConfig, VerificationR
 from karenina.schemas.verification.config import (
     DEFAULT_DEEP_JUDGMENT_FUZZY_THRESHOLD,
     DEFAULT_DEEP_JUDGMENT_RETRY_ATTEMPTS,
-    DEFAULT_EMBEDDING_MODEL,
-    DEFAULT_EMBEDDING_THRESHOLD,
     DEFAULT_RUBRIC_MAX_EXCERPTS,
 )
 from karenina.utils.progressive_save import ProgressiveSaveManager, TaskIdentifier, generate_task_manifest
 
 from .utils import cli_error, filter_templates_by_indices, parse_question_indices, validate_output_path
-from .verify_config import build_config_non_interactive
+from .verify_config import build_config_non_interactive, validate_cli_config_requirements
 from .verify_output import (
     display_summary,
     export_results,
@@ -228,11 +226,20 @@ def verify(
     ] = None,
     # General settings
     replicate_count: Annotated[int | None, typer.Option(help="Number of replicates per verification")] = None,
-    # Feature flags
-    abstention: Annotated[bool, typer.Option("--abstention", help="Enable abstention detection")] = False,
-    sufficiency: Annotated[bool, typer.Option("--sufficiency", help="Enable trace sufficiency detection")] = False,
-    embedding_check: Annotated[bool, typer.Option("--embedding-check", help="Enable embedding check")] = False,
-    deep_judgment: Annotated[bool, typer.Option("--deep-judgment", help="Enable deep judgment for templates")] = False,
+    # Feature flags (tri-state: None = use preset/default, True = enable, False = disable)
+    abstention: Annotated[
+        bool | None, typer.Option("--abstention/--no-abstention", help="Enable/disable abstention detection")
+    ] = None,
+    sufficiency: Annotated[
+        bool | None, typer.Option("--sufficiency/--no-sufficiency", help="Enable/disable trace sufficiency detection")
+    ] = None,
+    embedding_check: Annotated[
+        bool | None, typer.Option("--embedding-check/--no-embedding-check", help="Enable/disable embedding check")
+    ] = None,
+    deep_judgment: Annotated[
+        bool | None,
+        typer.Option("--deep-judgment/--no-deep-judgment", help="Enable/disable deep judgment for templates"),
+    ] = None,
     # Deep judgment rubric settings
     deep_judgment_rubric_mode: Annotated[
         str, typer.Option(help="Deep judgment mode for rubrics (disabled/enable_all/use_checkpoint/custom)")
@@ -278,10 +285,8 @@ def verify(
     evaluation_mode: Annotated[
         str, typer.Option(help="Evaluation mode (template_only/template_and_rubric/rubric_only)")
     ] = "template_only",
-    embedding_threshold: Annotated[
-        float, typer.Option(help="Embedding similarity threshold (0.0-1.0)")
-    ] = DEFAULT_EMBEDDING_THRESHOLD,
-    embedding_model: Annotated[str, typer.Option(help="Embedding model name")] = DEFAULT_EMBEDDING_MODEL,
+    embedding_threshold: Annotated[float | None, typer.Option(help="Embedding similarity threshold (0.0-1.0)")] = None,
+    embedding_model: Annotated[str | None, typer.Option(help="Embedding model name")] = None,
     no_async: Annotated[bool, typer.Option("--no-async", help="Disable async execution")] = False,
     async_workers: Annotated[
         int | None, typer.Option(help="Number of async workers (default: 2 or KARENINA_ASYNC_MAX_WORKERS)")
@@ -356,7 +361,19 @@ def verify(
         selected_question_indices: list[int] | None = None
         show_progress_bar_interactive: bool | None = None
 
-        # Step 2: Handle resume mode or build fresh config
+        # Step 2: Early config validation (before benchmark load, so config errors are not masked)
+        if not resume and not interactive and not preset:
+            validation_errors = validate_cli_config_requirements(
+                interface, answering_model, parsing_model, answering_provider, parsing_provider, manual_traces
+            )
+            if validation_errors:
+                console.print("[red]Configuration errors:[/red]")
+                for error in validation_errors:
+                    console.print(f"  [red]• {error}[/red]")
+                console.print("\n[dim]Run with --interactive for guided configuration[/dim]")
+                raise typer.Exit(code=1)
+
+        # Step 3: Handle resume mode or build fresh config
         if resume:
             progressive_manager, config, benchmark_path, output, output_format, pending_task_ids = _handle_resume_mode(
                 resume

--- a/src/karenina/cli/verify_config.py
+++ b/src/karenina/cli/verify_config.py
@@ -29,10 +29,10 @@ def build_config_from_cli_args(
     temperature: float | None,
     interface: str | None,
     replicate_count: int | None,
-    abstention: bool,
-    sufficiency: bool,
-    embedding_check: bool,
-    deep_judgment: bool,
+    abstention: bool | None,
+    sufficiency: bool | None,
+    embedding_check: bool | None,
+    deep_judgment: bool | None,
     deep_judgment_rubric_mode: str,
     deep_judgment_rubric_excerpts: bool,
     deep_judgment_rubric_max_excerpts: int,
@@ -44,8 +44,8 @@ def build_config_from_cli_args(
     use_full_trace_for_template: bool,
     use_full_trace_for_rubric: bool,
     evaluation_mode: str,
-    embedding_threshold: float,
-    embedding_model: str,
+    embedding_threshold: float | None,
+    embedding_model: str | None,
     async_execution: bool,
     async_workers: int | None,
     preset_config: VerificationConfig | None = None,
@@ -170,7 +170,8 @@ def validate_cli_config_requirements(
             "--interface is required when not using a preset (langchain/openrouter/openai_endpoint)"
         )
 
-    if not answering_model:
+    # Manual interface doesn't need an answering model (traces replace generation)
+    if not answering_model and interface != "manual":
         validation_errors.append("--answering-model is required when not using a preset")
 
     if not parsing_model:
@@ -280,10 +281,10 @@ def build_config_non_interactive(
     parsing_id: str,
     temperature: float | None,
     replicate_count: int | None,
-    abstention: bool,
-    sufficiency: bool,
-    embedding_check: bool,
-    deep_judgment: bool,
+    abstention: bool | None,
+    sufficiency: bool | None,
+    embedding_check: bool | None,
+    deep_judgment: bool | None,
     deep_judgment_rubric_mode: str,
     deep_judgment_rubric_excerpts: bool,
     deep_judgment_rubric_max_excerpts: int,
@@ -295,8 +296,8 @@ def build_config_non_interactive(
     use_full_trace_for_template: bool,
     use_full_trace_for_rubric: bool,
     evaluation_mode: str,
-    embedding_threshold: float,
-    embedding_model: str,
+    embedding_threshold: float | None,
+    embedding_model: str | None,
     async_execution: bool,
     async_workers: int | None,
     manual_traces: Path | None,

--- a/tests/integration/cli/test_cli_live.py
+++ b/tests/integration/cli/test_cli_live.py
@@ -1,0 +1,290 @@
+"""Live CLI integration tests with real LLM calls.
+
+These tests verify the CLI works end-to-end with actual API calls.
+They use claude-haiku-4-5 (cheapest model), 2 questions, and 2 replicates
+to cover features like replicates and progressive save/resume.
+
+Requires: ANTHROPIC_API_KEY set in the environment.
+
+Run with: uv run pytest tests/integration/cli/test_cli_live.py -v -s
+"""
+
+import json
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from karenina.cli import app
+
+runner = CliRunner()
+
+ARTIFACTS = Path("/Users/carli/Projects/karenina-salvage/automated_experiments/artifacts/shared")
+BENCHMARK_PATH = ARTIFACTS / "benchmark_qa.jsonld"
+
+requires_api_key = pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not set",
+)
+
+
+@pytest.fixture()
+def work_dir(tmp_path: Path) -> Path:
+    """Set up a working directory with a copy of the benchmark."""
+    checkpoint = tmp_path / "benchmark.jsonld"
+    shutil.copy(BENCHMARK_PATH, checkpoint)
+    return tmp_path
+
+
+@pytest.fixture()
+def preset_path(work_dir: Path) -> Path:
+    """Create a preset with 2 replicates for testing."""
+    preset = work_dir / "preset.json"
+    preset.write_text(
+        json.dumps(
+            {
+                "config": {
+                    "answering_models": [
+                        {
+                            "id": "answerer",
+                            "model_provider": "anthropic",
+                            "model_name": "claude-haiku-4-5",
+                            "temperature": 0.0,
+                        }
+                    ],
+                    "parsing_models": [
+                        {
+                            "id": "judge",
+                            "model_provider": "anthropic",
+                            "model_name": "claude-haiku-4-5",
+                            "temperature": 0.0,
+                        }
+                    ],
+                    "replicate_count": 2,
+                    "abstention_enabled": True,
+                }
+            },
+            indent=2,
+        )
+    )
+    return preset
+
+
+@pytest.fixture()
+def manual_traces_path(work_dir: Path) -> Path:
+    """Create manual traces for the first 2 questions."""
+    traces = work_dir / "traces.json"
+    traces.write_text(
+        json.dumps(
+            {
+                # France capital question
+                "25bd04c8b293421d91bbbecd5b24929f": (
+                    "The capital of France is Paris. "
+                    "Its approximate population is about 2,161,000 people in the city proper. "
+                    "Paris is also the capital of the Ile-de-France region. "
+                    "Yes, it is the most populous city in France."
+                ),
+                # Japan capital question
+                "1134ebdb3686b8cb4b0a4a79b68c4e4c": (
+                    "The capital of Japan is Tokyo. "
+                    "Its approximate population is about 13,960,000 people. "
+                    "Tokyo is the most populous city in Japan."
+                ),
+            }
+        )
+    )
+    return traces
+
+
+@requires_api_key
+@pytest.mark.e2e
+@pytest.mark.cli
+class TestCLIVerifyLive:
+    """Live CLI verify tests with real LLM calls (2 questions, 2 replicates)."""
+
+    def test_verify_with_preset_and_replicates(self, work_dir: Path, preset_path: Path) -> None:
+        """Full verify: preset with 2 replicates, 2 questions, JSON output."""
+        checkpoint = work_dir / "benchmark.jsonld"
+        output = work_dir / "results.json"
+
+        result = runner.invoke(
+            app,
+            [
+                "verify",
+                str(checkpoint),
+                "--preset",
+                str(preset_path),
+                "--questions",
+                "0,1",
+                "--output",
+                str(output),
+            ],
+        )
+
+        assert result.exit_code == 0, f"CLI failed:\n{result.stdout}"
+        assert output.exists(), "Output file not created"
+
+        results_data = json.loads(output.read_text())
+        # 2 questions x 2 replicates = 4 results
+        assert len(results_data) >= 4, f"Expected >= 4 results, got {len(results_data)}"
+
+    def test_verify_with_manual_traces_and_replicates(self, work_dir: Path, manual_traces_path: Path) -> None:
+        """Manual interface: 2 pre-recorded traces, 2 replicates, only parsing LLM called."""
+        checkpoint = work_dir / "benchmark.jsonld"
+        output = work_dir / "results.json"
+
+        result = runner.invoke(
+            app,
+            [
+                "verify",
+                str(checkpoint),
+                "--interface",
+                "manual",
+                "--manual-traces",
+                str(manual_traces_path),
+                "--parsing-model",
+                "claude-haiku-4-5",
+                "--parsing-provider",
+                "anthropic",
+                "--replicate-count",
+                "2",
+                "--questions",
+                "0,1",
+                "--output",
+                str(output),
+            ],
+        )
+
+        assert result.exit_code == 0, f"CLI failed:\n{result.stdout}"
+        assert output.exists(), "Output file not created"
+
+        results_data = json.loads(output.read_text())
+        # 2 questions x 2 replicates = 4 results
+        assert len(results_data) >= 4, f"Expected >= 4 results, got {len(results_data)}"
+
+    def test_verify_flag_override_disables_preset_default(self, work_dir: Path, preset_path: Path) -> None:
+        """Issue 036: --no-abstention overrides preset's abstention_enabled=True."""
+        checkpoint = work_dir / "benchmark.jsonld"
+        output = work_dir / "results.json"
+
+        result = runner.invoke(
+            app,
+            [
+                "verify",
+                str(checkpoint),
+                "--preset",
+                str(preset_path),
+                "--questions",
+                "0",
+                "--no-abstention",
+                "--replicate-count",
+                "1",
+                "--output",
+                str(output),
+            ],
+        )
+
+        assert result.exit_code == 0, f"CLI failed:\n{result.stdout}"
+        assert output.exists(), "Output file not created"
+
+    def test_verify_csv_output(self, work_dir: Path, manual_traces_path: Path) -> None:
+        """Verify CSV export works via CLI with 2 questions."""
+        checkpoint = work_dir / "benchmark.jsonld"
+        output = work_dir / "results.csv"
+
+        result = runner.invoke(
+            app,
+            [
+                "verify",
+                str(checkpoint),
+                "--interface",
+                "manual",
+                "--manual-traces",
+                str(manual_traces_path),
+                "--parsing-model",
+                "claude-haiku-4-5",
+                "--parsing-provider",
+                "anthropic",
+                "--questions",
+                "0,1",
+                "--output",
+                str(output),
+            ],
+        )
+
+        assert result.exit_code == 0, f"CLI failed:\n{result.stdout}"
+        assert output.exists(), "CSV file not created"
+        lines = output.read_text().strip().split("\n")
+        # Header + at least 2 data rows (1 per question)
+        assert len(lines) >= 3, f"CSV too short: {len(lines)} lines"
+
+    def test_progressive_save_and_resume(self, work_dir: Path, manual_traces_path: Path) -> None:
+        """Progressive save creates state file; resume completes remaining work."""
+        checkpoint = work_dir / "benchmark.jsonld"
+        output = work_dir / "results.json"
+
+        # Run with progressive save (2 questions, should complete normally)
+        result = runner.invoke(
+            app,
+            [
+                "verify",
+                str(checkpoint),
+                "--interface",
+                "manual",
+                "--manual-traces",
+                str(manual_traces_path),
+                "--parsing-model",
+                "claude-haiku-4-5",
+                "--parsing-provider",
+                "anthropic",
+                "--questions",
+                "0,1",
+                "--output",
+                str(output),
+                "--progressive-save",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Progressive save failed:\n{result.stdout}"
+        assert output.exists(), "Output file not created"
+
+        # Verify results were produced
+        results_data = json.loads(output.read_text())
+        assert len(results_data) >= 2, f"Expected >= 2 results, got {len(results_data)}"
+
+        # State file should exist (or be cleaned up on success)
+        # The .state file is cleaned up when all tasks complete successfully,
+        # so we verify the final output instead
+        assert "progressive save" in result.stdout.lower() or "results" in result.stdout.lower()
+
+
+@pytest.mark.integration
+@pytest.mark.cli
+class TestCLIConfigValidationLive:
+    """Tests that don't need LLM calls (validation-only)."""
+
+    def test_config_error_before_benchmark(self, work_dir: Path) -> None:
+        """Issue 035: Config errors shown before benchmark load attempt."""
+        nonexistent = work_dir / "does_not_exist.jsonld"
+        output = work_dir / "results.json"
+
+        result = runner.invoke(
+            app,
+            ["verify", str(nonexistent), "--output", str(output)],
+        )
+
+        assert result.exit_code != 0
+        stdout_lower = result.stdout.lower()
+        assert "interface" in stdout_lower or "required" in stdout_lower, (
+            f"Expected config error, got:\n{result.stdout}"
+        )
+
+    def test_no_flag_help_shows_flag_pairs(self) -> None:
+        """Issue 036: Help shows --flag/--no-flag pairs."""
+        result = runner.invoke(app, ["verify", "--help"])
+        assert result.exit_code == 0
+        assert "--no-abstention" in result.stdout
+        assert "--no-sufficiency" in result.stdout
+        assert "--no-deep-judgment" in result.stdout

--- a/tests/unit/cli/test_cli_consistency.py
+++ b/tests/unit/cli/test_cli_consistency.py
@@ -1,0 +1,429 @@
+"""Tests for CLI consistency fixes (issues 035, 036, 037).
+
+Issue 035: CLI verify validates benchmark before config, masking config errors.
+Issue 036: CLI boolean feature flags are enable-only, cannot override preset defaults.
+Issue 037: CLI embedding defaults conflict with env var defaults in VerificationConfig.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from karenina.cli import app
+from karenina.cli.verify_config import build_config_from_cli_args
+from karenina.schemas import VerificationConfig
+from karenina.schemas.verification.config import DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_THRESHOLD
+
+runner = CliRunner()
+
+
+def _create_checkpoint(path: Path) -> Path:
+    """Create a minimal valid checkpoint file."""
+    checkpoint_path = path / "test.jsonld"
+    checkpoint_data = {
+        "@context": "https://schema.org",
+        "@type": "DataFeed",
+        "name": "Test",
+        "description": "Test",
+        "version": "1.0.0",
+        "dateCreated": "2024-01-01T00:00:00",
+        "dateModified": "2024-01-01T00:00:00",
+        "dataFeedElement": [
+            {
+                "@type": "DataFeedItem",
+                "@id": "q1",
+                "dateCreated": "2024-01-01T00:00:00",
+                "dateModified": "2024-01-01T00:00:00",
+                "item": {
+                    "@type": "Question",
+                    "text": "What is 2+2?",
+                    "acceptedAnswer": {"@type": "Answer", "text": "4"},
+                },
+            }
+        ],
+    }
+    checkpoint_path.write_text(json.dumps(checkpoint_data, indent=2))
+    return checkpoint_path
+
+
+def _create_preset(path: Path, **overrides: Any) -> Path:
+    """Create a preset with optional config overrides."""
+    preset_path = path / "preset.json"
+    config = {
+        "answering_models": [{"id": "answering-1", "model_provider": "anthropic", "model_name": "claude-haiku-4-5"}],
+        "parsing_models": [{"id": "parsing-1", "model_provider": "anthropic", "model_name": "claude-haiku-4-5"}],
+        "replicate_count": 1,
+    }
+    config.update(overrides)
+    preset_path.write_text(json.dumps({"config": config}, indent=2))
+    return preset_path
+
+
+# =============================================================================
+# Issue 035: Config validation should run before benchmark loading
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestConfigValidationOrder:
+    """Issue 035: Config errors should be reported even when benchmark path is invalid."""
+
+    def test_config_error_shown_before_benchmark_error(self, tmp_path: Path) -> None:
+        """When both config and benchmark are invalid, config error should appear.
+
+        Currently, the benchmark load error masks config errors because
+        Benchmark.load() runs first. After the fix, config validation
+        should run first, so missing --interface is reported even when
+        the benchmark file doesn't exist.
+        """
+        nonexistent_benchmark = tmp_path / "does_not_exist.jsonld"
+        output_path = tmp_path / "results.json"
+
+        result = runner.invoke(
+            app,
+            [
+                "verify",
+                str(nonexistent_benchmark),
+                "--output",
+                str(output_path),
+                # No --interface, no --answering-model, no --parsing-model, no --preset
+            ],
+        )
+
+        assert result.exit_code != 0
+        # The config error should appear, not a benchmark loading error
+        assert "interface" in result.stdout.lower() or "required" in result.stdout.lower()
+
+
+# =============================================================================
+# Issue 036: Boolean flags should support --flag/--no-flag pairs
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestBooleanFlagPairs:
+    """Issue 036: Boolean flags should be tri-state (None/True/False) to allow overriding preset defaults."""
+
+    def test_no_flag_does_not_override_preset_abstention(self, tmp_path: Path) -> None:
+        """When user doesn't pass --abstention or --no-abstention, preset's value should be preserved.
+
+        Currently, the CLI passes abstention=False (the default) to from_overrides(),
+        which overrides a preset that has abstention_enabled=True.
+        """
+        preset_path = _create_preset(tmp_path, abstention_enabled=True)
+        preset_config = VerificationConfig.from_preset(preset_path)
+
+        # Simulate CLI with no flag (should be None, not False)
+        config = build_config_from_cli_args(
+            answering_model=None,
+            answering_provider=None,
+            answering_id="answering-1",
+            parsing_model=None,
+            parsing_provider=None,
+            parsing_id="parsing-1",
+            temperature=None,
+            interface=None,
+            replicate_count=None,
+            abstention=None,  # Should be None when user doesn't pass flag
+            sufficiency=None,
+            embedding_check=None,
+            deep_judgment=None,
+            deep_judgment_rubric_mode="disabled",
+            deep_judgment_rubric_excerpts=True,
+            deep_judgment_rubric_max_excerpts=3,
+            deep_judgment_rubric_fuzzy_threshold=0.8,
+            deep_judgment_rubric_retry_attempts=1,
+            deep_judgment_rubric_search=False,
+            deep_judgment_rubric_search_tool="tavily",
+            deep_judgment_rubric_config=None,
+            use_full_trace_for_template=False,
+            use_full_trace_for_rubric=True,
+            evaluation_mode="template_only",
+            embedding_threshold=None,
+            embedding_model=None,
+            async_execution=True,
+            async_workers=None,
+            preset_config=preset_config,
+        )
+
+        # Preset had abstention_enabled=True; it should be preserved
+        assert config.abstention_enabled is True
+
+    def test_explicit_no_flag_overrides_preset_abstention(self, tmp_path: Path) -> None:
+        """When user passes --no-abstention, preset's True should be overridden to False."""
+        preset_path = _create_preset(tmp_path, abstention_enabled=True)
+        preset_config = VerificationConfig.from_preset(preset_path)
+
+        config = build_config_from_cli_args(
+            answering_model=None,
+            answering_provider=None,
+            answering_id="answering-1",
+            parsing_model=None,
+            parsing_provider=None,
+            parsing_id="parsing-1",
+            temperature=None,
+            interface=None,
+            replicate_count=None,
+            abstention=False,  # Explicit --no-abstention
+            sufficiency=None,
+            embedding_check=None,
+            deep_judgment=None,
+            deep_judgment_rubric_mode="disabled",
+            deep_judgment_rubric_excerpts=True,
+            deep_judgment_rubric_max_excerpts=3,
+            deep_judgment_rubric_fuzzy_threshold=0.8,
+            deep_judgment_rubric_retry_attempts=1,
+            deep_judgment_rubric_search=False,
+            deep_judgment_rubric_search_tool="tavily",
+            deep_judgment_rubric_config=None,
+            use_full_trace_for_template=False,
+            use_full_trace_for_rubric=True,
+            evaluation_mode="template_only",
+            embedding_threshold=None,
+            embedding_model=None,
+            async_execution=True,
+            async_workers=None,
+            preset_config=preset_config,
+        )
+
+        assert config.abstention_enabled is False
+
+    def test_no_flag_preserves_preset_for_all_boolean_flags(self, tmp_path: Path) -> None:
+        """All four boolean flags should preserve preset values when not explicitly set."""
+        preset_path = _create_preset(
+            tmp_path,
+            abstention_enabled=True,
+            sufficiency_enabled=True,
+            embedding_check_enabled=True,
+            deep_judgment_enabled=True,
+        )
+        preset_config = VerificationConfig.from_preset(preset_path)
+
+        config = build_config_from_cli_args(
+            answering_model=None,
+            answering_provider=None,
+            answering_id="answering-1",
+            parsing_model=None,
+            parsing_provider=None,
+            parsing_id="parsing-1",
+            temperature=None,
+            interface=None,
+            replicate_count=None,
+            abstention=None,  # Not set by user
+            sufficiency=None,
+            embedding_check=None,
+            deep_judgment=None,
+            deep_judgment_rubric_mode="disabled",
+            deep_judgment_rubric_excerpts=True,
+            deep_judgment_rubric_max_excerpts=3,
+            deep_judgment_rubric_fuzzy_threshold=0.8,
+            deep_judgment_rubric_retry_attempts=1,
+            deep_judgment_rubric_search=False,
+            deep_judgment_rubric_search_tool="tavily",
+            deep_judgment_rubric_config=None,
+            use_full_trace_for_template=False,
+            use_full_trace_for_rubric=True,
+            evaluation_mode="template_only",
+            embedding_threshold=None,
+            embedding_model=None,
+            async_execution=True,
+            async_workers=None,
+            preset_config=preset_config,
+        )
+
+        assert config.abstention_enabled is True
+        assert config.sufficiency_enabled is True
+        assert config.embedding_check_enabled is True
+        assert config.deep_judgment_enabled is True
+
+    def test_cli_accepts_no_abstention_flag(self) -> None:
+        """The CLI should accept --no-abstention as a valid flag."""
+        result = runner.invoke(app, ["verify", "--help"])
+        assert result.exit_code == 0
+        assert "--no-abstention" in result.stdout
+
+    def test_cli_accepts_no_sufficiency_flag(self) -> None:
+        """The CLI should accept --no-sufficiency as a valid flag."""
+        result = runner.invoke(app, ["verify", "--help"])
+        assert result.exit_code == 0
+        assert "--no-sufficiency" in result.stdout
+
+    def test_cli_accepts_no_embedding_check_flag(self) -> None:
+        """The CLI should accept --no-embedding-check as a valid flag."""
+        result = runner.invoke(app, ["verify", "--help"])
+        assert result.exit_code == 0
+        # Rich console may truncate long flag names; check for the prefix
+        assert "--no-embedding-che" in result.stdout
+
+    def test_cli_accepts_no_deep_judgment_flag(self) -> None:
+        """The CLI should accept --no-deep-judgment as a valid flag."""
+        result = runner.invoke(app, ["verify", "--help"])
+        assert result.exit_code == 0
+        assert "--no-deep-judgment" in result.stdout
+
+
+# =============================================================================
+# Issue 037: Embedding defaults should defer to VerificationConfig
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestEmbeddingDefaults:
+    """Issue 037: CLI embedding defaults should not override env vars."""
+
+    def test_env_var_embedding_threshold_not_masked_by_cli(self, monkeypatch: Any) -> None:
+        """Env var EMBEDDING_CHECK_THRESHOLD should apply when CLI doesn't specify threshold.
+
+        Currently, CLI always passes DEFAULT_EMBEDDING_THRESHOLD (0.85) to from_overrides(),
+        which prevents the env var from taking effect.
+        """
+        monkeypatch.setenv("EMBEDDING_CHECK_THRESHOLD", "0.72")
+
+        config = build_config_from_cli_args(
+            answering_model="test-model",
+            answering_provider="anthropic",
+            answering_id="answering-1",
+            parsing_model="test-model",
+            parsing_provider="anthropic",
+            parsing_id="parsing-1",
+            temperature=None,
+            interface="langchain",
+            replicate_count=None,
+            abstention=None,
+            sufficiency=None,
+            embedding_check=None,
+            deep_judgment=None,
+            deep_judgment_rubric_mode="disabled",
+            deep_judgment_rubric_excerpts=True,
+            deep_judgment_rubric_max_excerpts=3,
+            deep_judgment_rubric_fuzzy_threshold=0.8,
+            deep_judgment_rubric_retry_attempts=1,
+            deep_judgment_rubric_search=False,
+            deep_judgment_rubric_search_tool="tavily",
+            deep_judgment_rubric_config=None,
+            use_full_trace_for_template=False,
+            use_full_trace_for_rubric=True,
+            evaluation_mode="template_only",
+            embedding_threshold=None,  # CLI didn't specify; env var should apply
+            embedding_model=None,
+            async_execution=True,
+            async_workers=None,
+        )
+
+        assert config.embedding_check_threshold == pytest.approx(0.72)
+
+    def test_env_var_embedding_model_not_masked_by_cli(self, monkeypatch: Any) -> None:
+        """Env var EMBEDDING_CHECK_MODEL should apply when CLI doesn't specify model."""
+        monkeypatch.setenv("EMBEDDING_CHECK_MODEL", "custom-embed-model")
+
+        config = build_config_from_cli_args(
+            answering_model="test-model",
+            answering_provider="anthropic",
+            answering_id="answering-1",
+            parsing_model="test-model",
+            parsing_provider="anthropic",
+            parsing_id="parsing-1",
+            temperature=None,
+            interface="langchain",
+            replicate_count=None,
+            abstention=None,
+            sufficiency=None,
+            embedding_check=None,
+            deep_judgment=None,
+            deep_judgment_rubric_mode="disabled",
+            deep_judgment_rubric_excerpts=True,
+            deep_judgment_rubric_max_excerpts=3,
+            deep_judgment_rubric_fuzzy_threshold=0.8,
+            deep_judgment_rubric_retry_attempts=1,
+            deep_judgment_rubric_search=False,
+            deep_judgment_rubric_search_tool="tavily",
+            deep_judgment_rubric_config=None,
+            use_full_trace_for_template=False,
+            use_full_trace_for_rubric=True,
+            evaluation_mode="template_only",
+            embedding_threshold=None,
+            embedding_model=None,  # CLI didn't specify; env var should apply
+            async_execution=True,
+            async_workers=None,
+        )
+
+        assert config.embedding_check_model == "custom-embed-model"
+
+    def test_explicit_cli_threshold_overrides_env_var(self, monkeypatch: Any) -> None:
+        """When user explicitly passes --embedding-threshold, it should override the env var."""
+        monkeypatch.setenv("EMBEDDING_CHECK_THRESHOLD", "0.72")
+
+        config = build_config_from_cli_args(
+            answering_model="test-model",
+            answering_provider="anthropic",
+            answering_id="answering-1",
+            parsing_model="test-model",
+            parsing_provider="anthropic",
+            parsing_id="parsing-1",
+            temperature=None,
+            interface="langchain",
+            replicate_count=None,
+            abstention=None,
+            sufficiency=None,
+            embedding_check=None,
+            deep_judgment=None,
+            deep_judgment_rubric_mode="disabled",
+            deep_judgment_rubric_excerpts=True,
+            deep_judgment_rubric_max_excerpts=3,
+            deep_judgment_rubric_fuzzy_threshold=0.8,
+            deep_judgment_rubric_retry_attempts=1,
+            deep_judgment_rubric_search=False,
+            deep_judgment_rubric_search_tool="tavily",
+            deep_judgment_rubric_config=None,
+            use_full_trace_for_template=False,
+            use_full_trace_for_rubric=True,
+            evaluation_mode="template_only",
+            embedding_threshold=0.90,  # Explicit CLI override
+            embedding_model=None,
+            async_execution=True,
+            async_workers=None,
+        )
+
+        assert config.embedding_check_threshold == pytest.approx(0.90)
+
+    def test_no_env_var_uses_field_default(self) -> None:
+        """When neither CLI nor env var sets threshold, field default should apply."""
+        config = build_config_from_cli_args(
+            answering_model="test-model",
+            answering_provider="anthropic",
+            answering_id="answering-1",
+            parsing_model="test-model",
+            parsing_provider="anthropic",
+            parsing_id="parsing-1",
+            temperature=None,
+            interface="langchain",
+            replicate_count=None,
+            abstention=None,
+            sufficiency=None,
+            embedding_check=None,
+            deep_judgment=None,
+            deep_judgment_rubric_mode="disabled",
+            deep_judgment_rubric_excerpts=True,
+            deep_judgment_rubric_max_excerpts=3,
+            deep_judgment_rubric_fuzzy_threshold=0.8,
+            deep_judgment_rubric_retry_attempts=1,
+            deep_judgment_rubric_search=False,
+            deep_judgment_rubric_search_tool="tavily",
+            deep_judgment_rubric_config=None,
+            use_full_trace_for_template=False,
+            use_full_trace_for_rubric=True,
+            evaluation_mode="template_only",
+            embedding_threshold=None,
+            embedding_model=None,
+            async_execution=True,
+            async_workers=None,
+        )
+
+        assert config.embedding_check_threshold == pytest.approx(DEFAULT_EMBEDDING_THRESHOLD)
+        assert config.embedding_check_model == DEFAULT_EMBEDDING_MODEL


### PR DESCRIPTION
## Summary

Three CLI consistency fixes plus a bug found during live testing.

- **Config validation order**: validation now runs before benchmark loading, so config errors (missing `--interface`, `--model`) appear even when the benchmark file doesn't exist
- **Tri-state feature flags**: `--abstention`, `--sufficiency`, `--embedding-check`, `--deep-judgment` now support `--flag/--no-flag` pairs with `None` default, preserving preset values when neither flag is passed
- **Embedding default deferral**: `--embedding-threshold` and `--embedding-model` defaults changed to `None`, deferring to `EMBEDDING_CHECK_THRESHOLD` and `EMBEDDING_CHECK_MODEL` environment variables
- **Manual interface validation**: early validation now skips `--answering-model` requirement for `--interface manual`, since manual traces replace LLM generation

## Test plan

- [x] 12 unit tests for the three fixes (config order, flag pairs, embedding defaults)
- [x] 7 live CLI integration tests with real LLM calls (claude-haiku-4-5):
  - Preset with 2 questions and 2 replicates
  - Manual traces with replicates
  - `--no-abstention` flag override of preset default
  - CSV export
  - Progressive save
  - Config validation order
  - Help flag pairs
- [x] Existing 19 CLI tests pass (zero regressions)
- [x] Full suite: 3943 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)