### PR TITLE
feat: API design improvements

### DIFF
--- a/docs/superpowers/plans/2026-03-24-api-design-improvements.md
+++ b/docs/superpowers/plans/2026-03-24-api-design-improvements.md
@@ -1,0 +1,1383 @@
+# API Design Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix API gaps, naming inconsistencies, type improvements, and extract result storage from the Benchmark facade into a standalone ResultsStore.
+
+**Architecture:** Changes span the rubric schema layer (higher_is_better unification), the manager layer (RubricManager method improvements), the facade layer (deprecations and new delegations), a new ResultsStore class, and miscellaneous type/naming fixes. Each task is independently testable and committable.
+
+**Tech Stack:** Python 3.13, Pydantic v2, pytest, uv
+
+**Spec:** `docs/superpowers/specs/2026-03-24-api-design-improvements.md`
+
+**Test runner:** `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/api-design && uv run pytest tests/ -x -q`
+
+**Important:** Do not reference issue numbers in commit messages. They were an internal naming scheme.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `src/karenina/schemas/entities/rubric.py` | higher_is_better on all traits, from_traits factory, get_trait_directionalities |
+| Modify | `src/karenina/benchmark/core/rubrics.py` | set_global_rubric, set_question_rubric, rename get_questions_with_rubric, validate_rubrics |
+| Modify | `src/karenina/benchmark/benchmark.py` | Facade delegations, deprecations |
+| Create | `src/karenina/benchmark/core/results_store.py` | Standalone ResultsStore class |
+| Modify | `src/karenina/benchmark/core/__init__.py` | Export ResultsStore |
+| Modify | `src/karenina/benchmark/task_eval/models.py` | Docstring updates for summary methods |
+| Modify | `src/karenina/schemas/verification/config.py` | DeepJudgmentRubricCustomConfig, typed config field |
+| Modify | `src/karenina/benchmark/verification/stages/helpers/deep_judgment_helpers.py` | Update dict access to model access for rubric config |
+| Modify | `src/karenina/benchmark/verification/stages/core/base.py:302` | Update type annotation for rubric config |
+| Modify | `src/karenina/benchmark/verification/runner.py:53` | Update type annotation for rubric config |
+| Modify | `src/karenina/benchmark/verification/utils/task_helpers.py:186` | Update rubric config access |
+| Modify | `src/karenina/cli/verify_config.py:101-104` | Accept raw dict and convert to model |
+| Modify | `src/karenina/cli/interactive.py:204` | Convert dict to model when assigning |
+| Modify | `tests/unit/benchmark/core/test_rubrics.py:561-590` | Update after get_questions_with_rubric rename |
+| Modify | `src/karenina/schemas/results/verification_result_set.py` | __repr__, group_by_replicate |
+| Modify | `src/karenina/schemas/results/template.py` | group_by_model by param |
+| Modify | `src/karenina/schemas/results/rubric.py` | group_by_model by param |
+| Modify | `src/karenina/schemas/results/judgment.py` | group_by_model by param |
+| Create | `tests/unit/schemas/entities/test_higher_is_better.py` | Tests for higher_is_better changes |
+| Create | `tests/unit/benchmark/core/test_results_store.py` | Tests for ResultsStore |
+| Create | `tests/unit/schemas/test_api_design_fixes.py` | Tests for type improvements (repr, replicate, group_by_model, config) |
+| Create | `tests/unit/benchmark/core/test_rubric_manager_api.py` | Tests for RubricManager API changes |
+| Create | `tests/unit/benchmark/test_facade_api.py` | Tests for facade changes |
+
+---
+
+### Task 1: Unify `higher_is_better` across all trait types
+
+**Files:**
+- Modify: `src/karenina/schemas/entities/rubric.py:91-97` (LLMRubricTrait), `:198-201` (Regex), `:303-307` (Callable), `:527` (Metric), `:673-680` (Agentic), `:124-130` (LLM legacy validator), `:205-211` (Regex legacy), `:323-342` (Callable legacy), `:727-743` (Agentic legacy), `:939-968` (get_trait_directionalities)
+- Create: `tests/unit/schemas/entities/test_higher_is_better.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""Tests for higher_is_better unification across all trait types."""
+
+import pytest
+
+from karenina.schemas.entities.rubric import (
+    AgenticRubricTrait,
+    CallableRubricTrait,
+    LLMRubricTrait,
+    MetricRubricTrait,
+    RegexRubricTrait,
+    Rubric,
+)
+
+
+@pytest.mark.unit
+class TestHigherIsBetterUnification:
+    """Test that all trait types support higher_is_better: bool | None."""
+
+    def test_llm_trait_accepts_none(self):
+        """LLMRubricTrait should accept None for higher_is_better."""
+        trait = LLMRubricTrait(
+            name="test",
+            description="test trait",
+            higher_is_better=None,
+        )
+        assert trait.higher_is_better is None
+
+    def test_llm_trait_defaults_to_true(self):
+        """LLMRubricTrait should default to True when not specified."""
+        trait = LLMRubricTrait(name="test", description="test trait")
+        assert trait.higher_is_better is True
+
+    def test_regex_trait_accepts_none(self):
+        """RegexRubricTrait should accept None for higher_is_better."""
+        trait = RegexRubricTrait(
+            name="test",
+            description="test trait",
+            pattern=r"\d+",
+            higher_is_better=None,
+        )
+        assert trait.higher_is_better is None
+
+    def test_regex_trait_defaults_to_true(self):
+        """RegexRubricTrait should default to True when not specified."""
+        trait = RegexRubricTrait(
+            name="test", description="test trait", pattern=r"\d+"
+        )
+        assert trait.higher_is_better is True
+
+    def test_callable_trait_accepts_none(self):
+        """CallableRubricTrait should accept None for higher_is_better."""
+        trait = CallableRubricTrait(
+            name="test",
+            description="test trait",
+            callable_name="my_func",
+            kind="boolean",
+            higher_is_better=None,
+        )
+        assert trait.higher_is_better is None
+
+    def test_callable_trait_defaults_to_true(self):
+        """CallableRubricTrait should default to True when not specified."""
+        trait = CallableRubricTrait(
+            name="test",
+            description="test trait",
+            callable_name="my_func",
+            kind="boolean",
+        )
+        assert trait.higher_is_better is True
+
+    def test_agentic_trait_preserves_none(self):
+        """AgenticRubricTrait should preserve explicit None (not coerce to True)."""
+        trait = AgenticRubricTrait(
+            name="test",
+            description="test trait",
+            kind="boolean",
+            higher_is_better=None,
+        )
+        assert trait.higher_is_better is None
+
+    def test_metric_trait_has_higher_is_better(self):
+        """MetricRubricTrait should have higher_is_better field defaulting to None."""
+        trait = MetricRubricTrait(
+            name="test",
+            description="test trait",
+            metrics=["precision"],
+        )
+        assert trait.higher_is_better is None
+
+    def test_metric_trait_accepts_true(self):
+        """MetricRubricTrait should accept True for higher_is_better."""
+        trait = MetricRubricTrait(
+            name="test",
+            description="test trait",
+            metrics=["precision"],
+            higher_is_better=True,
+        )
+        assert trait.higher_is_better is True
+
+    def test_legacy_data_without_field_defaults_to_true(self):
+        """Legacy data missing higher_is_better should still get True."""
+        trait = LLMRubricTrait.model_validate(
+            {"name": "test", "description": "test"}
+        )
+        assert trait.higher_is_better is True
+
+    def test_get_trait_directionalities_includes_metric(self):
+        """Rubric.get_trait_directionalities() should include metric traits."""
+        rubric = Rubric(
+            llm_traits=[
+                LLMRubricTrait(name="clarity", description="clear", higher_is_better=True)
+            ],
+            metric_traits=[
+                MetricRubricTrait(name="precision", description="prec", metrics=["precision"])
+            ],
+        )
+        dirs = rubric.get_trait_directionalities()
+        assert "clarity" in dirs
+        assert dirs["clarity"] is True
+        assert "precision" in dirs
+        assert dirs["precision"] is None
+
+    def test_get_trait_directionalities_none_values(self):
+        """Traits with higher_is_better=None should appear as None in directionalities."""
+        rubric = Rubric(
+            llm_traits=[
+                LLMRubricTrait(name="word_count", description="wc", higher_is_better=None)
+            ],
+        )
+        dirs = rubric.get_trait_directionalities()
+        assert dirs["word_count"] is None
+
+    def test_agentic_template_kind_still_none(self):
+        """AgenticRubricTrait with template kind should still have higher_is_better=None."""
+        from pydantic import BaseModel
+
+        class MyOutput(BaseModel):
+            result: str
+
+        trait = AgenticRubricTrait(
+            name="test",
+            description="test",
+            kind=MyOutput,
+            higher_is_better=None,
+        )
+        assert trait.higher_is_better is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/schemas/entities/test_higher_is_better.py -v`
+Expected: Multiple FAILs (None coerced to True, MetricRubricTrait has no higher_is_better, metric excluded from directionalities)
+
+- [ ] **Step 3: Implement higher_is_better changes**
+
+In `src/karenina/schemas/entities/rubric.py`:
+
+**LLMRubricTrait (line 91):** Change field type and add default:
+```python
+higher_is_better: bool | None = Field(
+    default=True,
+    description="Whether higher values indicate better performance. "
+    "For boolean: True means True is good. "
+    "For score: True means higher score is better. "
+    "None means directionality does not apply.",
+)
+```
+
+**LLMRubricTrait legacy validator (line 128):** Only fill when key is absent:
+```python
+if isinstance(values, dict) and "higher_is_better" not in values:
+    values["higher_is_better"] = True
+```
+
+**RegexRubricTrait (line 198):** Same field change to `bool | None = Field(default=True, ...)`.
+
+**RegexRubricTrait legacy validator (line 209):** Same fix, only when key absent.
+
+**CallableRubricTrait (line 303):** Same field change to `bool | None = Field(default=True, ...)`.
+
+**CallableRubricTrait legacy validator (line 328):** Same fix, only when key absent.
+
+**AgenticRubricTrait legacy validator (line 741):** Same fix, only when key absent:
+```python
+if "higher_is_better" not in values or values.get("higher_is_better") is None:
+```
+Change to:
+```python
+if "higher_is_better" not in values:
+```
+(But preserve the template-kind skip logic that already exists earlier in the validator.)
+
+**MetricRubricTrait (after line 527 fields):** Add field:
+```python
+higher_is_better: bool | None = Field(
+    default=None,
+    description="Whether higher metric values indicate better performance. "
+    "None means directionality does not apply (default for metrics).",
+)
+```
+
+**get_trait_directionalities (line 939-968):** Add metric traits and update docstring:
+```python
+def get_trait_directionalities(self) -> dict[str, bool | None]:
+    """Get higher_is_better for all trait types.
+
+    Returns:
+        Dict mapping trait name to higher_is_better value. None indicates
+        directionality does not apply (e.g. informational metrics,
+        agentic template kinds).
+    """
+    directionalities = {}
+
+    llm_trait: LLMRubricTrait
+    for llm_trait in self.llm_traits:
+        directionalities[llm_trait.name] = llm_trait.higher_is_better
+
+    regex_trait: RegexRubricTrait
+    for regex_trait in self.regex_traits:
+        directionalities[regex_trait.name] = regex_trait.higher_is_better
+
+    callable_trait: CallableRubricTrait
+    for callable_trait in self.callable_traits:
+        directionalities[callable_trait.name] = callable_trait.higher_is_better
+
+    for agentic_trait in self.agentic_traits:
+        directionalities[agentic_trait.name] = agentic_trait.higher_is_better
+
+    for metric_trait in self.metric_traits:
+        directionalities[metric_trait.name] = metric_trait.higher_is_better
+
+    return directionalities
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/schemas/entities/test_higher_is_better.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `uv run pytest tests/ -x -q`
+Expected: All pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/karenina/schemas/entities/rubric.py tests/unit/schemas/entities/test_higher_is_better.py
+git commit -m "feat: unify higher_is_better as bool | None across all trait types
+
+Add higher_is_better field to MetricRubricTrait (default None).
+Widen type to bool | None on LLM, Regex, Callable traits with
+default True. Fix legacy validators to not coerce explicit None.
+Include metric traits in get_trait_directionalities()."
+```
+
+---
+
+### Task 2: Add `Rubric.from_traits()` factory method
+
+**Files:**
+- Modify: `src/karenina/schemas/entities/rubric.py` (Rubric class, near line 811)
+- Modify: `tests/unit/schemas/entities/test_higher_is_better.py` (add tests)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/unit/schemas/entities/test_higher_is_better.py`:
+
+```python
+@pytest.mark.unit
+class TestRubricFromTraits:
+    """Test Rubric.from_traits() factory method."""
+
+    def test_from_mixed_traits(self):
+        """from_traits should categorize a flat list into typed trait lists."""
+        llm = LLMRubricTrait(name="clarity", description="clear")
+        regex = RegexRubricTrait(name="has_number", description="num", pattern=r"\d+")
+        metric = MetricRubricTrait(name="precision", description="prec", metrics=["precision"])
+
+        rubric = Rubric.from_traits([llm, regex, metric])
+
+        assert len(rubric.llm_traits) == 1
+        assert rubric.llm_traits[0].name == "clarity"
+        assert len(rubric.regex_traits) == 1
+        assert rubric.regex_traits[0].name == "has_number"
+        assert len(rubric.metric_traits) == 1
+        assert rubric.metric_traits[0].name == "precision"
+        assert len(rubric.callable_traits) == 0
+        assert len(rubric.agentic_traits) == 0
+
+    def test_from_empty_traits(self):
+        """from_traits with empty list should produce empty Rubric."""
+        rubric = Rubric.from_traits([])
+        assert len(rubric.llm_traits) == 0
+        assert len(rubric.regex_traits) == 0
+
+    def test_from_none_returns_none(self):
+        """from_traits with None should return None."""
+        assert Rubric.from_traits(None) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/schemas/entities/test_higher_is_better.py::TestRubricFromTraits -v`
+Expected: FAIL with AttributeError (no from_traits method)
+
+- [ ] **Step 3: Implement from_traits**
+
+Add classmethod to `Rubric` class in `src/karenina/schemas/entities/rubric.py`:
+
+```python
+@classmethod
+def from_traits(
+    cls,
+    traits: list[LLMRubricTrait | RegexRubricTrait | CallableRubricTrait | MetricRubricTrait | AgenticRubricTrait] | None,
+) -> "Rubric | None":
+    """Create a Rubric from a flat list of traits, categorizing by type.
+
+    Args:
+        traits: Flat list of trait objects. If None, returns None.
+
+    Returns:
+        Rubric with traits sorted into typed lists, or None if input is None.
+    """
+    if traits is None:
+        return None
+
+    llm_traits = []
+    regex_traits = []
+    callable_traits = []
+    metric_traits = []
+    agentic_traits = []
+
+    for trait in traits:
+        if isinstance(trait, LLMRubricTrait):
+            llm_traits.append(trait)
+        elif isinstance(trait, RegexRubricTrait):
+            regex_traits.append(trait)
+        elif isinstance(trait, CallableRubricTrait):
+            callable_traits.append(trait)
+        elif isinstance(trait, MetricRubricTrait):
+            metric_traits.append(trait)
+        elif isinstance(trait, AgenticRubricTrait):
+            agentic_traits.append(trait)
+
+    return cls(
+        llm_traits=llm_traits,
+        regex_traits=regex_traits,
+        callable_traits=callable_traits,
+        metric_traits=metric_traits,
+        agentic_traits=agentic_traits,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/schemas/entities/test_higher_is_better.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/karenina/schemas/entities/rubric.py tests/unit/schemas/entities/test_higher_is_better.py
+git commit -m "feat: add Rubric.from_traits() factory for flat trait lists
+
+Categorizes a flat list of mixed trait types into the typed trait
+lists (llm_traits, regex_traits, etc.). Returns None for None input."
+```
+
+---
+
+### Task 3: RubricManager API improvements
+
+**Files:**
+- Modify: `src/karenina/benchmark/core/rubrics.py:323-325` (rename), `:327-337` (set_global_rubric), add set_question_rubric, `:223-288` (validate_rubrics)
+- Modify: `src/karenina/benchmark/benchmark.py:654-680` (facade delegations), `:393-395` (get_question_rubric)
+- Create: `tests/unit/benchmark/core/test_rubric_manager_api.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""Tests for RubricManager API improvements."""
+
+import pytest
+
+from karenina.benchmark import Benchmark
+from karenina.schemas.entities.rubric import (
+    LLMRubricTrait,
+    MetricRubricTrait,
+    RegexRubricTrait,
+    Rubric,
+)
+
+
+def _create_benchmark():
+    """Create a fresh Benchmark for testing."""
+    return Benchmark.create(name="test_rubric_api")
+
+
+def _create_benchmark_with_question():
+    """Create a Benchmark with one question."""
+    b = Benchmark.create(name="test_rubric_api")
+    b.add_question(question_id="q1", question="What is 2+2?", expected_answer="4")
+    return b, "q1"
+
+
+@pytest.mark.unit
+class TestRubricManagerSetGlobalRubric:
+    """Test set_global_rubric accepts both Rubric and list."""
+
+    def test_accepts_rubric_object(self):
+        """set_global_rubric should accept a Rubric object."""
+        b = _create_benchmark()
+        rubric = Rubric(
+            llm_traits=[LLMRubricTrait(name="t1", description="d1")],
+            regex_traits=[RegexRubricTrait(name="t2", description="d2", pattern=r"\d+")],
+        )
+        b._rubric_manager.set_global_rubric(rubric)
+        result = b._rubric_manager.get_global_rubric()
+        assert result is not None
+        assert len(result.llm_traits) == 1
+        assert len(result.regex_traits) == 1
+
+    def test_accepts_trait_list(self):
+        """set_global_rubric should accept a flat list of traits."""
+        b = _create_benchmark()
+        traits = [
+            LLMRubricTrait(name="t1", description="d1"),
+            RegexRubricTrait(name="t2", description="d2", pattern=r"\d+"),
+        ]
+        b._rubric_manager.set_global_rubric(traits)
+        result = b._rubric_manager.get_global_rubric()
+        assert result is not None
+        assert len(result.llm_traits) == 1
+        assert len(result.regex_traits) == 1
+
+
+@pytest.mark.unit
+class TestRubricManagerSetQuestionRubric:
+    """Test set_question_rubric on RubricManager."""
+
+    def test_set_question_rubric_with_rubric(self):
+        """set_question_rubric should accept a Rubric object."""
+        b, q_id = _create_benchmark_with_question()
+        rubric = Rubric(
+            llm_traits=[LLMRubricTrait(name="t1", description="d1")],
+        )
+        b._rubric_manager.set_question_rubric(q_id, rubric)
+        traits = b._rubric_manager.get_question_rubric(q_id)
+        assert traits is not None
+        assert len(traits) == 1
+
+    def test_set_question_rubric_replaces_existing(self):
+        """set_question_rubric should clear existing then set new."""
+        b, q_id = _create_benchmark_with_question()
+        rubric1 = Rubric(
+            llm_traits=[LLMRubricTrait(name="t1", description="d1")],
+        )
+        rubric2 = Rubric(
+            regex_traits=[RegexRubricTrait(name="t2", description="d2", pattern=r"\d+")],
+        )
+        b._rubric_manager.set_question_rubric(q_id, rubric1)
+        b._rubric_manager.set_question_rubric(q_id, rubric2)
+        traits = b._rubric_manager.get_question_rubric(q_id)
+        assert len(traits) == 1
+        assert traits[0].name == "t2"
+
+
+@pytest.mark.unit
+class TestRubricManagerRename:
+    """Test get_questions_with_rubric rename."""
+
+    def test_get_question_ids_with_rubric_exists(self):
+        """Renamed method should exist and return list[str]."""
+        b = _create_benchmark()
+        result = b._rubric_manager.get_question_ids_with_rubric()
+        assert isinstance(result, list)
+
+    def test_old_name_does_not_exist(self):
+        """Old method name should not exist."""
+        b = _create_benchmark()
+        assert not hasattr(b._rubric_manager, "get_questions_with_rubric")
+
+
+@pytest.mark.unit
+class TestValidateRubricsErrorShape:
+    """Test validate_rubrics returns dict-based errors."""
+
+    def test_returns_dict_errors(self):
+        """validate_rubrics errors should be list[dict[str, str]]."""
+        b = _create_benchmark()
+        b._rubric_manager.add_global_rubric_trait(
+            LLMRubricTrait(name="", description="test")
+        )
+        valid, errors = b._rubric_manager.validate_rubrics()
+        assert valid is False
+        assert len(errors) > 0
+        assert isinstance(errors[0], dict)
+        assert "source" in errors[0]
+        assert "error" in errors[0]
+```
+
+Note: Tests use `Benchmark.create()` inline (matching the pattern in `tests/unit/benchmark/core/test_rubrics.py`). No fixtures needed.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/benchmark/core/test_rubric_manager_api.py -v`
+Expected: Multiple FAILs
+
+- [ ] **Step 3: Implement RubricManager changes**
+
+In `src/karenina/benchmark/core/rubrics.py`:
+
+**Rename** `get_questions_with_rubric` (line 323) to `get_question_ids_with_rubric`.
+
+**Modify** `set_global_rubric` (line 327) to accept `Rubric | list`:
+```python
+def set_global_rubric(
+    self,
+    rubric: Rubric | list[LLMRubricTrait | RegexRubricTrait | CallableRubricTrait | MetricRubricTrait | AgenticRubricTrait],
+) -> None:
+    """Set the global rubric, replacing any existing global traits.
+
+    Args:
+        rubric: A Rubric object or a flat list of trait objects.
+    """
+    self.clear_global_rubric()
+    if isinstance(rubric, Rubric):
+        traits = (
+            list(rubric.llm_traits)
+            + list(rubric.regex_traits)
+            + list(rubric.callable_traits)
+            + list(rubric.metric_traits)
+            + list(rubric.agentic_traits)
+        )
+    else:
+        traits = rubric
+    for trait in traits:
+        self.add_global_rubric_trait(trait)
+```
+
+**Add** `set_question_rubric` method:
+```python
+def set_question_rubric(
+    self,
+    question_id: str,
+    rubric: Rubric | list[LLMRubricTrait | RegexRubricTrait | CallableRubricTrait | MetricRubricTrait | AgenticRubricTrait],
+) -> None:
+    """Set question-specific rubric, replacing any existing question rubric.
+
+    Args:
+        question_id: The question ID.
+        rubric: A Rubric object or a flat list of trait objects.
+    """
+    self.remove_question_rubric(question_id)
+    if isinstance(rubric, Rubric):
+        traits = (
+            list(rubric.llm_traits)
+            + list(rubric.regex_traits)
+            + list(rubric.callable_traits)
+            + list(rubric.metric_traits)
+            + list(rubric.agentic_traits)
+        )
+    else:
+        traits = rubric
+    for trait in traits:
+        self.add_question_rubric_trait(question_id, trait)
+```
+
+**Modify** `validate_rubrics` (line 223) return type and error format. Change return type to `tuple[bool, list[dict[str, str]]]`. Replace each `errors.append("message")` with `errors.append({"source": scope_identifier, "error": message})`. The `source` should be the trait name for trait-level errors, or `"global"` / `f"question:{q_id}"` for scope-level errors.
+
+- [ ] **Step 4: Update callers of renamed method and changed return types**
+
+The rename from `get_questions_with_rubric` to `get_question_ids_with_rubric` on `RubricManager` affects:
+- `tests/unit/benchmark/core/test_rubrics.py:561-590`: Update test calls to use the new name.
+
+The `validate_rubrics()` return type change affects:
+- `src/karenina/benchmark/benchmark.py:698`: Update facade return type annotation from `tuple[bool, list[str]]` to `tuple[bool, list[dict[str, str]]]`.
+- Any existing tests in `tests/unit/benchmark/core/test_rubrics.py` or `tests/unit/benchmark/test_rubrics_issues.py` that assert on error item types.
+
+Grep for both `get_questions_with_rubric` and `validate_rubrics` across the test suite to find all callers.
+
+- [ ] **Step 5: Simplify facade delegations**
+
+In `src/karenina/benchmark/benchmark.py`:
+
+**Replace** `set_global_rubric` (lines 654-666):
+```python
+def set_global_rubric(self, rubric: Rubric) -> None:
+    """Set the complete global rubric (replaces existing)."""
+    self._rubric_manager.set_global_rubric(rubric)
+```
+
+**Replace** `set_question_rubric` (lines 668-680):
+```python
+def set_question_rubric(self, question_id: str, rubric: Rubric) -> None:
+    """Set the complete question-specific rubric (replaces existing)."""
+    self._rubric_manager.set_question_rubric(question_id, rubric)
+```
+
+**Add** `get_question_rubric` facade method (near the other rubric methods):
+```python
+def get_question_rubric(self, question_id: str) -> Rubric | None:
+    """Get the question-specific rubric for a question."""
+    traits = self._rubric_manager.get_question_rubric(question_id)
+    return Rubric.from_traits(traits)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/benchmark/core/test_rubric_manager_api.py -v`
+Expected: All PASS
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `uv run pytest tests/ -x -q`
+Expected: All pass. Watch for any existing tests that called `RubricManager.get_questions_with_rubric()` by the old name, or that check `validate_rubrics()` error format as plain strings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/karenina/benchmark/core/rubrics.py src/karenina/benchmark/benchmark.py tests/unit/benchmark/core/test_rubric_manager_api.py
+git commit -m "feat: improve RubricManager API and facade delegations
+
+RubricManager.set_global_rubric accepts Rubric or list.
+Add RubricManager.set_question_rubric with same flexibility.
+Rename get_questions_with_rubric to get_question_ids_with_rubric.
+Unify validate_rubrics error shape to list[dict[str, str]].
+Add get_question_rubric to facade, simplify set_* delegations."
+```
+
+---
+
+### Task 4: Create ResultsStore
+
+**Files:**
+- Create: `src/karenina/benchmark/core/results_store.py`
+- Modify: `src/karenina/benchmark/core/__init__.py`
+- Create: `tests/unit/benchmark/core/test_results_store.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""Tests for standalone ResultsStore."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from karenina.benchmark.core.results_store import ResultsStore
+from karenina.schemas.results.verification_result_set import VerificationResultSet
+
+
+def _make_result(question_id: str, passed: bool = True) -> MagicMock:
+    """Create a mock VerificationResult."""
+    result = MagicMock()
+    result.metadata = MagicMock()
+    result.metadata.question_id = question_id
+    result.metadata.passed = passed
+    result.model_dump = MagicMock(return_value={
+        "metadata": {"question_id": question_id, "passed": passed},
+    })
+    return result
+
+
+def _make_result_set(results: list) -> VerificationResultSet:
+    """Create a VerificationResultSet from mock results."""
+    return VerificationResultSet(results=results)
+
+
+@pytest.mark.unit
+class TestResultsStoreAdd:
+    """Test adding results to the store."""
+
+    def test_add_with_run_name(self):
+        """add() should store results under the given run name."""
+        store = ResultsStore()
+        rs = _make_result_set([_make_result("q1")])
+        store.add(rs, run_name="run_1")
+        assert store.has_results(run_name="run_1")
+
+    def test_add_auto_generates_run_name(self):
+        """add() without run_name should auto-generate one."""
+        store = ResultsStore()
+        rs = _make_result_set([_make_result("q1")])
+        store.add(rs)
+        runs = store.get_all_runs()
+        assert len(runs) == 1
+
+
+@pytest.mark.unit
+class TestResultsStoreQuery:
+    """Test querying results."""
+
+    def test_get_by_run(self):
+        """get_by_run should return the stored VerificationResultSet."""
+        store = ResultsStore()
+        rs = _make_result_set([_make_result("q1"), _make_result("q2")])
+        store.add(rs, run_name="run_1")
+        result = store.get_by_run("run_1")
+        assert isinstance(result, VerificationResultSet)
+        assert len(result.results) == 2
+
+    def test_get_by_question(self):
+        """get_by_question should return results keyed by run name."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="run_1")
+        store.add(_make_result_set([_make_result("q1")]), run_name="run_2")
+        result = store.get_by_question("q1")
+        assert "run_1" in result
+        assert "run_2" in result
+
+    def test_get_latest(self):
+        """get_latest should return most recent result per question."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="run_1")
+        store.add(_make_result_set([_make_result("q1")]), run_name="run_2")
+        latest = store.get_latest("q1")
+        assert "q1" in latest
+
+    def test_has_results_empty(self):
+        """has_results should return False when empty."""
+        store = ResultsStore()
+        assert store.has_results() is False
+
+    def test_get_all_runs_ordered(self):
+        """get_all_runs should return run names in insertion order."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="b")
+        store.add(_make_result_set([_make_result("q1")]), run_name="a")
+        assert store.get_all_runs() == ["b", "a"]
+
+
+@pytest.mark.unit
+class TestResultsStoreClear:
+    """Test clearing results."""
+
+    def test_clear_all(self):
+        """clear() with no args should remove everything."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="run_1")
+        store.clear()
+        assert store.has_results() is False
+
+    def test_clear_by_run(self):
+        """clear(run_name=...) should remove only that run."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="run_1")
+        store.add(_make_result_set([_make_result("q1")]), run_name="run_2")
+        store.clear(run_name="run_1")
+        assert not store.has_results(run_name="run_1")
+        assert store.has_results(run_name="run_2")
+
+
+@pytest.mark.unit
+class TestResultsStoreSummary:
+    """Test summary and export methods."""
+
+    def test_get_summary(self):
+        """get_summary should return dict with result counts."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1"), _make_result("q2")]), run_name="r1")
+        summary = store.get_summary()
+        assert isinstance(summary, dict)
+        assert summary["total_results"] >= 2
+
+    def test_get_statistics_by_run(self):
+        """get_statistics_by_run should return per-run stats."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="r1")
+        store.add(_make_result_set([_make_result("q1"), _make_result("q2")]), run_name="r2")
+        stats = store.get_statistics_by_run()
+        assert "r1" in stats
+        assert "r2" in stats
+
+    def test_export_returns_serializable(self):
+        """export should return a JSON-serializable dict."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="r1")
+        exported = store.export()
+        assert isinstance(exported, dict)
+        json.dumps(exported)  # should not raise
+
+    def test_export_to_file_and_load(self, tmp_path):
+        """export_to_file and from_file should round-trip."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="r1")
+        path = tmp_path / "results.json"
+        store.export_to_file(path)
+        loaded = ResultsStore.from_file(path)
+        assert loaded.has_results(run_name="r1")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/benchmark/core/test_results_store.py -v`
+Expected: FAIL (module not found)
+
+- [ ] **Step 3: Implement ResultsStore**
+
+Create `src/karenina/benchmark/core/results_store.py`. The implementation should be self-contained (no dependency on `BenchmarkBase`). Use `ResultsManager` (in `results.py`) as reference for method behavior, but the store holds its own `dict[str, VerificationResultSet]` keyed by run name.
+
+Key implementation notes:
+- Internal storage: `_runs: dict[str, VerificationResultSet]` (ordered dict by insertion)
+- `add()`: generate timestamped run name if not provided
+- `get_latest()`: iterate runs in reverse insertion order, collect first result per question
+- `get_by_question()`: iterate all runs, collect results matching the question_id
+- `get_by_run()`: direct dict lookup, raise `KeyError` if not found
+- `has_results()`: check filters against stored data
+- `clear()`: support filtering by run_name and question_ids
+- `get_summary()`, `get_statistics_by_run()`, `export()`, `export_to_file()`, `from_file()`: implement based on ResultsManager patterns
+
+- [ ] **Step 4: Update __init__.py**
+
+Add `ResultsStore` to exports in `src/karenina/benchmark/core/__init__.py`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/benchmark/core/test_results_store.py -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/karenina/benchmark/core/results_store.py src/karenina/benchmark/core/__init__.py tests/unit/benchmark/core/test_results_store.py
+git commit -m "feat: add standalone ResultsStore for cross-run result management
+
+ResultsStore accumulates VerificationResultSets keyed by run name,
+with query methods for filtering by question, run, or recency.
+Independent of Benchmark facade."
+```
+
+---
+
+### Task 5: Deprecate facade result methods
+
+**Files:**
+- Modify: `src/karenina/benchmark/benchmark.py:911-980`
+- Create: `tests/unit/benchmark/test_facade_api.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""Tests for facade API changes (deprecations and new methods)."""
+
+import warnings
+
+import pytest
+
+from karenina.benchmark import Benchmark
+from karenina.schemas.entities.rubric import LLMRubricTrait, Rubric
+
+
+def _create_benchmark():
+    return Benchmark.create(name="test_facade_api")
+
+
+def _create_benchmark_with_question():
+    b = Benchmark.create(name="test_facade_api")
+    b.add_question(question_id="q1", question="What is 2+2?", expected_answer="4")
+    return b
+
+
+@pytest.mark.unit
+class TestFacadeResultDeprecations:
+    """Test that facade result methods emit deprecation warnings."""
+
+    def test_store_verification_results_warns(self):
+        """store_verification_results should emit DeprecationWarning."""
+        b = _create_benchmark()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            b.store_verification_results({})
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "ResultsStore" in str(w[0].message)
+
+    def test_get_verification_results_warns(self):
+        """get_verification_results should emit DeprecationWarning."""
+        b = _create_benchmark()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            b.get_verification_results()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+
+@pytest.mark.unit
+class TestFacadeGetQuestionRubric:
+    """Test get_question_rubric facade method."""
+
+    def test_returns_none_when_no_rubric(self):
+        """get_question_rubric returns None when no rubric set."""
+        b = _create_benchmark_with_question()
+        assert b.get_question_rubric("q1") is None
+
+    def test_returns_rubric_when_set(self):
+        """get_question_rubric returns Rubric after setting one."""
+        b = _create_benchmark_with_question()
+        rubric = Rubric(llm_traits=[LLMRubricTrait(name="t", description="d")])
+        b.set_question_rubric("q1", rubric)
+        result = b.get_question_rubric("q1")
+        assert isinstance(result, Rubric)
+        assert len(result.llm_traits) == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/benchmark/test_facade_api.py -v`
+Expected: FAIL (no DeprecationWarning emitted, no get_question_rubric method)
+
+- [ ] **Step 3: Add deprecation warnings to facade result methods**
+
+In `src/karenina/benchmark/benchmark.py`, add `warnings.warn()` to each of the 10 result methods (lines 911-980). Example pattern:
+
+```python
+def store_verification_results(self, results, run_name=None):
+    """Store verification results. Deprecated: use ResultsStore.add() instead."""
+    warnings.warn(
+        "store_verification_results is deprecated. Use ResultsStore.add() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return self._results_manager.store_verification_results(results, run_name)
+```
+
+Add `import warnings` at the top of the file if not already present.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/benchmark/test_facade_api.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest tests/ -x -q`
+Expected: All pass. Some existing tests may trigger deprecation warnings; this is expected. If any tests use `warnings.filterwarnings("error")`, they may need updating.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/karenina/benchmark/benchmark.py tests/unit/benchmark/test_facade_api.py
+git commit -m "feat: deprecate facade result methods in favor of ResultsStore
+
+All 10 result storage/query methods on Benchmark now emit
+DeprecationWarning pointing to ResultsStore equivalents.
+Add get_question_rubric facade method."
+```
+
+---
+
+### Task 6: Docstring and naming consistency fixes
+
+**Files:**
+- Modify: `src/karenina/benchmark/task_eval/models.py:530-531,571-572`
+- Modify: `src/karenina/benchmark/core/rubrics.py` (validate_rubrics, already done in Task 3 if combined; if not, do here)
+
+- [ ] **Step 1: Update TaskEvalResult docstrings**
+
+In `src/karenina/benchmark/task_eval/models.py`:
+
+**`summary()` (line 531):** Replace docstring:
+```python
+def summary(self) -> str:
+    """Return a concise summary of the evaluation results.
+
+    Aggregates across global evaluation and all per-step evaluations.
+    """
+```
+
+**`summary_compact()` (line 572):** Replace docstring:
+```python
+def summary_compact(self) -> str:
+    """Return a very compact one-line summary.
+
+    Reports global evaluation statistics only (excludes per-step evaluations).
+    """
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `uv run pytest tests/ -x -q`
+Expected: All pass (docstring-only changes)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/karenina/benchmark/task_eval/models.py
+git commit -m "docs: clarify scope of summary() vs summary_compact() in TaskEvalResult
+
+summary() aggregates global + per-step evaluations.
+summary_compact() reports global evaluation statistics only."
+```
+
+---
+
+### Task 7: Type improvements (repr, config, group_by_model, group_by_replicate)
+
+**Files:**
+- Modify: `src/karenina/schemas/results/verification_result_set.py:404-425` (group_by_replicate), `:1199+` (__repr__)
+- Modify: `src/karenina/schemas/results/template.py:648` (group_by_model)
+- Modify: `src/karenina/schemas/results/rubric.py:633` (group_by_model)
+- Modify: `src/karenina/schemas/results/judgment.py:585` (group_by_model)
+- Modify: `src/karenina/schemas/verification/config.py:51,158` (DeepJudgmentRubricCustomConfig)
+- Create: `tests/unit/schemas/test_api_design_fixes.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""Tests for type improvements: repr, config, group_by_model, group_by_replicate."""
+
+from typing import Literal
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from karenina.schemas.results.verification_result_set import VerificationResultSet
+from karenina.schemas.verification.config import (
+    DeepJudgmentRubricCustomConfig,
+    DeepJudgmentTraitConfig,
+    VerificationConfig,
+)
+
+
+def _make_result(question_id="q1", answering_model="gpt-4", parsing_model="gpt-4", replicate=1):
+    """Create a mock VerificationResult with metadata."""
+    result = MagicMock()
+    result.metadata = MagicMock()
+    result.metadata.question_id = question_id
+    result.metadata.answering_model = answering_model
+    result.metadata.parsing_model = parsing_model
+    result.metadata.replicate = replicate
+    result.metadata.mcp_servers = None
+    return result
+
+
+@pytest.mark.unit
+class TestVerificationResultSetRepr:
+    """Test simplified __repr__."""
+
+    def test_repr_empty(self):
+        """Empty result set repr should be concise."""
+        rs = VerificationResultSet(results=[])
+        r = repr(rs)
+        assert "VerificationResultSet" in r
+        assert "0" in r
+
+    def test_repr_with_results(self):
+        """Result set repr should show count without calling get_summary."""
+        rs = VerificationResultSet(results=[_make_result(), _make_result()])
+        r = repr(rs)
+        assert "2" in r
+        assert "VerificationResultSet" in r
+
+
+@pytest.mark.unit
+class TestGroupByReplicate:
+    """Test group_by_replicate preserves None."""
+
+    def test_none_replicate_preserved(self):
+        """Results with replicate=None should be grouped under None key."""
+        rs = VerificationResultSet(results=[
+            _make_result(replicate=None),
+            _make_result(replicate=1),
+        ])
+        groups = rs.group_by_replicate()
+        assert None in groups
+        assert 1 in groups
+        assert len(groups[None].results) == 1
+        assert len(groups[1].results) == 1
+
+
+@pytest.mark.unit
+class TestDeepJudgmentRubricCustomConfig:
+    """Test typed deep judgment rubric config."""
+
+    def test_valid_config(self):
+        """DeepJudgmentRubricCustomConfig should validate correctly."""
+        config = DeepJudgmentRubricCustomConfig(
+            **{
+                "global": {"trait1": DeepJudgmentTraitConfig(enabled=True)},
+                "question_specific": {},
+            }
+        )
+        assert len(config.global_traits) == 1
+
+    def test_custom_mode_requires_config(self):
+        """VerificationConfig with mode=custom should require config field."""
+        with pytest.raises(ValidationError, match="deep_judgment_rubric_config"):
+            VerificationConfig(
+                deep_judgment_rubric_mode="custom",
+                deep_judgment_rubric_config=None,
+                answering_models=[{"provider": "anthropic", "model": "test"}],
+                parsing_models=[{"provider": "anthropic", "model": "test"}],
+            )
+
+
+@pytest.mark.unit
+class TestViewGroupByModel:
+    """Test view-level group_by_model accepts and uses 'by' parameter."""
+
+    def test_template_results_by_answering(self):
+        """TemplateResults.group_by_model(by='answering') groups by answering model."""
+        from karenina.schemas.results.template import TemplateResults
+        rs = VerificationResultSet(results=[
+            _make_result(answering_model="gpt-4", parsing_model="claude-3"),
+            _make_result(answering_model="claude-3", parsing_model="claude-3"),
+        ])
+        tr = rs.get_template_results()
+        groups = tr.group_by_model(by="answering")
+        assert "gpt-4" in groups
+        assert "claude-3" in groups
+
+    def test_template_results_by_parsing(self):
+        """TemplateResults.group_by_model(by='parsing') groups by parsing model."""
+        from karenina.schemas.results.template import TemplateResults
+        rs = VerificationResultSet(results=[
+            _make_result(answering_model="gpt-4", parsing_model="claude-3"),
+            _make_result(answering_model="gpt-4", parsing_model="gpt-4"),
+        ])
+        tr = rs.get_template_results()
+        groups = tr.group_by_model(by="parsing")
+        assert "claude-3" in groups
+        assert "gpt-4" in groups
+
+    def test_rubric_results_by_param(self):
+        """RubricResults.group_by_model should accept 'by' parameter."""
+        import inspect
+        from karenina.schemas.results.rubric import RubricResults
+        sig = inspect.signature(RubricResults.group_by_model)
+        assert "by" in sig.parameters
+
+    def test_judgment_results_by_param(self):
+        """JudgmentResults.group_by_model should accept 'by' parameter."""
+        import inspect
+        from karenina.schemas.results.judgment import JudgmentResults
+        sig = inspect.signature(JudgmentResults.group_by_model)
+        assert "by" in sig.parameters
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/schemas/test_api_design_fixes.py -v`
+Expected: Multiple FAILs
+
+- [ ] **Step 3: Implement __repr__ simplification**
+
+In `src/karenina/schemas/results/verification_result_set.py`, replace the `__repr__` method (line 1199+) with:
+
+```python
+def __repr__(self) -> str:
+    n = len(self.results)
+    return f"VerificationResultSet({n} result{'s' if n != 1 else ''})"
+```
+
+- [ ] **Step 4: Implement group_by_replicate None preservation**
+
+In `src/karenina/schemas/results/verification_result_set.py` (line 404-425), change:
+- Return type from `dict[int, VerificationResultSet]` to `dict[int | None, VerificationResultSet]`
+- Replace `result.metadata.replicate or 0` with `result.metadata.replicate`
+
+- [ ] **Step 5: Implement DeepJudgmentRubricCustomConfig**
+
+In `src/karenina/schemas/verification/config.py`:
+
+Add new model after `DeepJudgmentTraitConfig` (after line 65):
+
+```python
+class DeepJudgmentRubricCustomConfig(BaseModel):
+    """Per-trait deep judgment configuration for custom mode."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    global_traits: dict[str, DeepJudgmentTraitConfig] = Field(
+        default_factory=dict, alias="global"
+    )
+    question_specific: dict[str, dict[str, DeepJudgmentTraitConfig]] = Field(
+        default_factory=dict
+    )
+```
+
+Change `deep_judgment_rubric_config` field (line 158) to:
+```python
+deep_judgment_rubric_config: DeepJudgmentRubricCustomConfig | None = None
+```
+
+Add cross-field validator:
+```python
+@model_validator(mode="after")
+def validate_custom_mode_has_config(self) -> "VerificationConfig":
+    """Require deep_judgment_rubric_config when mode is custom."""
+    if self.deep_judgment_rubric_mode == "custom" and self.deep_judgment_rubric_config is None:
+        raise ValueError("deep_judgment_rubric_config is required when deep_judgment_rubric_mode is 'custom'")
+    return self
+```
+
+Update the `from_overrides()` parameter type (line 681) to `DeepJudgmentRubricCustomConfig | dict[str, Any] | None`. In the method body, convert dict to model if needed.
+
+**Update all callers that use dict-style access on `deep_judgment_rubric_config`:**
+
+- `src/karenina/schemas/verification/config.py:535-536`: Change `.get("global", {})` and `.get("question_specific", {})` to `.global_traits` and `.question_specific`
+- `src/karenina/benchmark/verification/stages/helpers/deep_judgment_helpers.py:88-97`: Change `config_dict["question_specific"][question_id]` to use model attributes
+- `src/karenina/benchmark/verification/stages/core/base.py:302`: Change type annotation from `dict[str, Any] | None` to `DeepJudgmentRubricCustomConfig | None`
+- `src/karenina/benchmark/verification/runner.py:53`: Same type annotation update
+- `src/karenina/benchmark/verification/utils/task_helpers.py:186`: Update attribute access
+- `src/karenina/cli/verify_config.py:101-104`: When loading from JSON, wrap raw dict in `DeepJudgmentRubricCustomConfig.model_validate()`
+- `src/karenina/cli/interactive.py:204`: Same conversion when assigning
+
+**Update existing tests:**
+- `tests/unit/schemas/test_verification_config.py`: Tests that pass raw dicts as `deep_judgment_rubric_config` need to pass `DeepJudgmentRubricCustomConfig` or use `model_validate`
+
+- [ ] **Step 6: Add `by` parameter to view-level group_by_model**
+
+In each view class, add the `by` parameter and implement key-building logic matching `VerificationResultSet.group_by_model()`:
+
+**`src/karenina/schemas/results/template.py:648`:**
+```python
+def group_by_model(self, by: Literal["answering", "parsing", "both"] = "answering") -> dict[str, "TemplateResults"]:
+```
+
+**`src/karenina/schemas/results/rubric.py:633`:**
+```python
+def group_by_model(self, by: Literal["answering", "parsing", "both"] = "answering") -> dict[str, "RubricResults"]:
+```
+
+**`src/karenina/schemas/results/judgment.py:585`:**
+```python
+def group_by_model(self, by: Literal["answering", "parsing", "both"] = "answering") -> dict[str, "JudgmentResults"]:
+```
+
+For each, implement the key-building logic from `VerificationResultSet.group_by_model()` (lines 370-402 of verification_result_set.py), including MCP server info for answering keys.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/schemas/test_api_design_fixes.py -v`
+Expected: All PASS
+
+- [ ] **Step 8: Run full test suite**
+
+Run: `uv run pytest tests/ -x -q`
+Expected: All pass. Watch for:
+- Tests that depend on `__repr__` output format
+- Tests that check `group_by_replicate` returns `dict[int, ...]`
+- Tests that use `deep_judgment_rubric_config` as a raw dict
+- Tests that check existing `group_by_model` without `by` parameter (should still work due to default)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/karenina/schemas/results/verification_result_set.py src/karenina/schemas/results/template.py src/karenina/schemas/results/rubric.py src/karenina/schemas/results/judgment.py src/karenina/schemas/verification/config.py tests/unit/schemas/test_api_design_fixes.py
+git commit -m "feat: type improvements for result sets and verification config
+
+Simplify VerificationResultSet.__repr__ (no more get_summary call).
+Preserve None in group_by_replicate return type.
+Add DeepJudgmentRubricCustomConfig typed model for custom mode.
+Add 'by' parameter to view-level group_by_model methods."
+```
+
+---
+
+### Task 8: Remove duplicate server config router mount
+
+**Files:**
+- Modify: `karenina-server/src/karenina_server/server.py:541`
+
+**Note:** The server is at `/Users/carli/Projects/karenina-salvage/karenina-server/`, a sibling submodule outside this worktree. This task must be done in the main repo or a server worktree.
+
+- [ ] **Step 1: Verify GUI uses correct paths**
+
+Grep the GUI source for `/api/config/v2/config` to confirm no references to the redundant mount:
+
+```bash
+cd /Users/carli/Projects/karenina-salvage/karenina-gui && grep -r "api/config/v2/config" src/
+```
+
+Expected: No matches. The GUI uses `/api/v2/config/...` (correct paths via the `/api` mount).
+
+- [ ] **Step 2: Remove duplicate mount**
+
+In `/Users/carli/Projects/karenina-salvage/karenina-server/src/karenina_server/server.py`, remove line 541:
+```python
+# Remove this line:
+app.include_router(config_router, prefix="/api/config")
+```
+
+Keep line 542:
+```python
+app.include_router(config_router, prefix="/api")  # V2 endpoints at /api/v2/config/...
+```
+
+- [ ] **Step 3: Run server tests**
+
+```bash
+cd /Users/carli/Projects/karenina-salvage/karenina-server && uv run pytest tests/ -x -q
+```
+
+Expected: All pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/carli/Projects/karenina-salvage/karenina-server
+git add src/karenina_server/server.py
+git commit -m "fix: remove duplicate config router mount creating redundant endpoints
+
+Config router was mounted at both /api/config and /api, producing
+22 endpoints instead of 11. The /api/config mount created redundant
+/api/config/v2/config/... paths."
+```
+
+---
+
+## Task Dependency Summary
+
+```
+Task 1 (higher_is_better) ─► Task 2 (from_traits) ─► Task 3 (RubricManager)
+                                                          │
+Task 6 (docstrings) ◄── no deps                          ▼
+Task 7 (type improvements) ◄── no deps        Task 4 (ResultsStore) ─► Task 5 (deprecations)
+Task 8 (server) ◄── no deps
+```
+
+Tasks 1-5 are sequential. Tasks 6, 7, 8 are independent and can be parallelized with each other (and with tasks 4-5 if desired).

--- a/docs/superpowers/specs/2026-03-24-api-design-improvements.md
+++ b/docs/superpowers/specs/2026-03-24-api-design-improvements.md
@@ -1,8 +1,8 @@
 # API Design Improvements
 
 **Date**: 2026-03-24
-**Scope**: Core library (`karenina/`) and server (`karenina-server/`), ~10 files
-**Effort**: ~3 hours
+**Scope**: Core library (`karenina/`) and server (`karenina-server/`), ~12 files
+**Effort**: ~4 hours
 
 ## Overview
 
@@ -12,78 +12,130 @@ Fourteen items covering API gaps, naming inconsistencies, type improvements, and
 
 ### Decision
 
-The `Benchmark` object defines evaluation items (questions, templates, rubrics), not results. Result storage methods are removed from the facade and replaced with a standalone `ResultsStore` class.
+The `Benchmark` object defines evaluation items (questions, templates, rubrics), not results. Result storage methods are moved from the facade to a standalone `ResultsStore` class.
 
 ### Changes
-
-**Remove from `Benchmark` facade:**
-- `store_verification_results()`
-- `get_verification_results()`
-- `get_verification_history()`
-- Remove `ResultsManager` as a Benchmark dependency (if it is only used for result storage)
 
 **Create `ResultsStore`** in `karenina/benchmark/core/results_store.py`:
 
 ```python
 class ResultsStore:
-    """Container for gathering verification results across runs."""
+    """Container for gathering verification results across runs.
 
-    def add(self, result_set: VerificationResultSet) -> None:
-        """Store a result set, keyed by run name."""
+    Stores VerificationResultSets keyed by run name. Provides query
+    methods for filtering by question, run, or recency.
+    """
+
+    def add(self, result_set: VerificationResultSet, run_name: str | None = None) -> None:
+        """Store a result set.
+
+        Args:
+            result_set: The results to store.
+            run_name: Key for this run. If None, auto-generates a
+                timestamped name (e.g. "run_2026-03-24T10:30:00").
+        """
 
     def get_latest(self, question_id: str | None = None) -> dict[str, VerificationResult]:
-        """Get latest results, optionally filtered by question."""
+        """Get latest results. Keys are question IDs.
+
+        If question_id is given, returns only that question's latest result
+        (dict with one entry). Otherwise returns the latest result per question
+        across all runs.
+        """
 
     def has_results(self, question_id: str | None = None, run_name: str | None = None) -> bool:
-        """Check whether results exist."""
+        """Check whether results exist, optionally filtered."""
 
     def get_by_question(self, question_id: str) -> dict[str, VerificationResult]:
-        """Get all results for a question across runs."""
+        """Get all results for a question. Keys are run names."""
 
-    def get_by_run(self, run_name: str) -> dict[str, VerificationResult]:
-        """Get all results for a specific run."""
+    def get_by_run(self, run_name: str) -> VerificationResultSet:
+        """Get the full result set for a specific run."""
 
     def get_all_runs(self) -> list[str]:
-        """List all stored run names."""
+        """List all stored run names, ordered by insertion."""
+
+    def get_summary(self, run_name: str | None = None) -> dict[str, Any]:
+        """Get summary statistics, optionally filtered by run."""
+
+    def get_statistics_by_run(self) -> dict[str, dict[str, Any]]:
+        """Get per-run statistics."""
+
+    def clear(self, question_ids: list[str] | None = None, run_name: str | None = None) -> None:
+        """Remove results, optionally filtered."""
+
+    def export(self, question_ids: list[str] | None = None, run_name: str | None = None) -> dict:
+        """Export results as serializable dict."""
+
+    def export_to_file(self, file_path: Path, **kwargs) -> None:
+        """Export results to a JSON file."""
+
+    @classmethod
+    def from_file(cls, file_path: Path) -> ResultsStore:
+        """Load a ResultsStore from a previously exported file."""
 ```
+
+**Note**: `VerificationResultSet` has no `run_name` field. The `add()` method accepts an explicit `run_name` parameter; if omitted, a timestamped name is generated.
+
+**Deprecate on `Benchmark` facade** (with deprecation warnings pointing to `ResultsStore`):
+- `store_verification_results()`
+- `get_verification_results()`
+- `get_verification_history()`
+- `clear_verification_results()`
+- `export_verification_results()`
+- `export_verification_results_to_file()`
+- `load_verification_results_from_file()`
+- `get_verification_summary()`
+- `get_all_run_names()`
+- `get_results_statistics_by_run()`
+
+These methods remain functional but emit `DeprecationWarning` pointing to the `ResultsStore` equivalent. They will be removed in a future release. The internal `_results_manager` stays for now to back the deprecated methods.
+
+**Server impact**: Check `karenina-server/` for any usage of the deprecated methods and update to use `ResultsStore` where appropriate.
 
 **Usage pattern:**
 
 ```python
 store = ResultsStore()
 results = benchmark.run_verification(config)
-store.add(results)
+store.add(results, run_name="experiment_1")
 
-store.get_latest("q1")
-store.has_results(run_name="run_2")
-store.get_by_question("q1")
+store.get_latest("q1")          # {"q1": VerificationResult}
+store.has_results(run_name="experiment_1")
+store.get_by_question("q1")     # {"experiment_1": VerificationResult}
+store.get_by_run("experiment_1") # VerificationResultSet
 ```
 
 ## Section 2: Facade API Gaps
 
 ### 019: Add `get_question_rubric()` to facade
 
-Simple delegation:
+`RubricManager.get_question_rubric()` returns `list[TraitUnion] | None` (a flat trait list), not a `Rubric`. The facade should wrap this into a `Rubric` for a clean public API:
 
 ```python
 def get_question_rubric(self, question_id: str) -> Rubric | None:
     """Get the question-specific rubric for a question."""
-    return self._rubric_manager.get_question_rubric(question_id)
+    traits = self._rubric_manager.get_question_rubric(question_id)
+    if traits is None:
+        return None
+    return Rubric.from_traits(traits)
 ```
+
+If `Rubric.from_traits()` does not exist, add a factory method that categorizes a flat trait list into the typed trait lists (`llm_traits`, `regex_traits`, etc.). Reference the existing categorization pattern in `RubricManager.get_global_rubric()` (rubrics.py:82-95) which already separates traits by type using `isinstance` checks.
 
 ### 144: `set_global_rubric()` and `set_question_rubric()` delegation
 
 Both facade methods currently decompose a `Rubric` into traits and add them one-by-one. The manager should accept both a `Rubric` object and a raw traits list.
 
 **RubricManager changes:**
-- `set_global_rubric(rubric: Rubric | list[TraitUnion])`: accepts either form
-- Add `set_question_rubric(question_id: str, rubric: Rubric | list[TraitUnion])`: new method
+- `set_global_rubric(rubric: Rubric | list[TraitUnion])`: accepts either form. When given a `Rubric`, extract all traits via its typed trait lists. The current manager method already replaces atomically (not append), so clear-then-set semantics are preserved.
+- Add `set_question_rubric(question_id: str, rubric: Rubric | list[TraitUnion])`: entirely new method on the manager (does not currently exist). Clears existing question rubric first, then sets the new traits.
 
 **Facade changes:** Both `set_global_rubric()` and `set_question_rubric()` become one-liner delegations.
 
 ### 145: Rename `RubricManager.get_questions_with_rubric()` to `get_question_ids_with_rubric()`
 
-Internal-only rename. The facade's same-named method delegates to `QuestionManager` (returns `list[dict]`), which is unchanged.
+Internal-only rename. The facade's same-named method delegates to `QuestionManager` (returns `list[dict]`), which is unchanged. Update all internal callers of the old name.
 
 ## Section 3: Naming and Consistency
 
@@ -95,11 +147,17 @@ Add docstring clarification to both `TaskEvalResult` methods:
 
 ### 047: Unify `validate_rubrics()` error shape
 
-Change `validate_rubrics()` return from `tuple[bool, list[str]]` to `tuple[bool, list[dict[str, str]]]` with `{"source": trait_name_or_scope, "error": message}`. Matches `validate_templates()`.
+Change `validate_rubrics()` return from `tuple[bool, list[str]]` to `tuple[bool, list[dict[str, str]]]` with `{"source": trait_name_or_scope, "error": message}`.
+
+Note: `validate_templates()` uses `{"question_id": ..., "error": ...}` as its dict keys. The key names differ intentionally because templates are scoped to questions while rubric errors are scoped to traits/rubric scopes. The shapes are structurally aligned (`list[dict[str, str]]`) even if the key names are domain-appropriate.
 
 ### 064: Remove duplicate config router mount
 
-Remove `app.include_router(config_router, prefix="/api/config")` from `server.py`. Keep only the `/api` mount. Verify the GUI does not reference `/api/config/v2/config/...` paths before removing.
+Remove `app.include_router(config_router, prefix="/api/config")` from `server.py` (line 541). Keep only the `/api` mount (line 542). The `/api/config` mount creates redundant paths like `/api/config/v2/config/...` (doubled prefix).
+
+Pre-implementation check: grep `karenina-gui/` for any references to `/api/config/v2/config/` paths. If found, update them to use `/api/v2/config/` instead.
+
+Expected result: exactly 11 config endpoints (down from 22).
 
 ## Section 4: Type Improvements
 
@@ -109,12 +167,44 @@ Replace the current `get_summary()`-calling repr with a lightweight version:
 
 ```python
 def __repr__(self) -> str:
-    return f"VerificationResultSet(results={len(self.results)}, run_name={self.run_name!r})"
+    n = len(self.results)
+    return f"VerificationResultSet({n} result{'s' if n != 1 else ''})"
 ```
 
 ### 136: Type `deep_judgment_rubric_config`
 
-Change from `dict[str, Any] | None` to `dict[str, DeepJudgmentTraitConfig] | None`. `DeepJudgmentTraitConfig` already exists in the same file. Add a cross-field `model_validator` to require the field when `deep_judgment_rubric_mode="custom"`.
+The current `dict[str, Any] | None` has a nested structure:
+
+```python
+{
+    "global": {"TraitName": {"enabled": True, "excerpt_enabled": True, ...}},
+    "question_specific": {"question-id": {"TraitName": {"enabled": True, ...}}}
+}
+```
+
+Create a dedicated Pydantic model:
+
+```python
+class DeepJudgmentRubricCustomConfig(BaseModel):
+    """Per-trait deep judgment configuration for custom mode."""
+    model_config = ConfigDict(extra="forbid")
+
+    global_traits: dict[str, DeepJudgmentTraitConfig] = Field(
+        default_factory=dict, alias="global"
+    )
+    question_specific: dict[str, dict[str, DeepJudgmentTraitConfig]] = Field(
+        default_factory=dict
+    )
+```
+
+Change the field type on `VerificationConfig`:
+```python
+deep_judgment_rubric_config: DeepJudgmentRubricCustomConfig | None = None
+```
+
+Add a cross-field `model_validator` to require this field when `deep_judgment_rubric_mode="custom"`.
+
+Also update the `create()` factory method parameter type to match.
 
 ### 176: Add `by` parameter to view-level `group_by_model()`
 
@@ -123,11 +213,13 @@ Add `by: Literal["answering", "parsing", "both"] = "answering"` to:
 - `RubricResults.group_by_model()`
 - `JudgmentResults.group_by_model()`
 
-Use the same key-building logic as `VerificationResultSet.group_by_model()`.
+Use the same key-building logic as `VerificationResultSet.group_by_model()`, including MCP server info in answering keys when present.
 
 ### 121: Preserve `None` in `group_by_replicate()`
 
 Change return type from `dict[int, VerificationResultSet]` to `dict[int | None, VerificationResultSet]`. Use `result.metadata.replicate` directly instead of `result.metadata.replicate or 0`.
+
+Currently `group_by_replicate()` has no external callers (only used internally within `VerificationResultSet`). The internal `_calculate_replicate_stats` method uses its own grouping logic and already filters `None` replicates, so it is unaffected.
 
 ## Section 5: `higher_is_better` on all trait types
 
@@ -135,13 +227,49 @@ Change return type from `dict[int, VerificationResultSet]` to `dict[int | None, 
 
 Add `higher_is_better: bool | None` to all trait types. `None` means directionality does not apply.
 
-**Changes:**
-- `LLMRubricTrait`: change from `bool` to `bool | None`, default stays `True`
-- `RegexRubricTrait`: change from `bool` to `bool | None`, default stays `True`
-- `CallableRubricTrait`: change from `bool` to `bool | None`, default stays `True`
-- `AgenticRubricTrait`: change from `bool` to `bool | None`, default stays `True` (verify current state)
-- `MetricRubricTrait`: add `higher_is_better: bool | None = None`
-- `Rubric.get_trait_directionalities()`: include metric traits, return `dict[str, bool | None]`
+### Legacy validator changes
+
+`LLMRubricTrait`, `RegexRubricTrait`, `CallableRubricTrait`, and `AgenticRubricTrait` each have a `set_legacy_defaults` validator that coerces `None` to `True`:
+
+```python
+if "higher_is_better" not in values or values.get("higher_is_better") is None:
+    values["higher_is_better"] = True
+```
+
+This must be changed to only fill the default when the key is **absent**, not when it is explicitly `None`:
+
+```python
+if "higher_is_better" not in values:
+    values["higher_is_better"] = True
+```
+
+This preserves backward compatibility for legacy data missing the field, while allowing explicit `None` to mean "directionality does not apply."
+
+### Field declaration changes
+
+`LLMRubricTrait`, `RegexRubricTrait`, and `CallableRubricTrait` declare `higher_is_better` as `Field(...)` (required, no default). Change to `Field(default=True)` so the field is optional with a sensible default. Combined with the type widening to `bool | None`, the full declaration becomes:
+
+```python
+higher_is_better: bool | None = Field(
+    default=True,
+    description="Whether higher values indicate better performance. "
+    "None means directionality does not apply."
+)
+```
+
+### Per-trait changes
+
+- `LLMRubricTrait`: type `bool` -> `bool | None`, add `default=True`, fix legacy validator
+- `RegexRubricTrait`: type `bool` -> `bool | None`, add `default=True`, fix legacy validator
+- `CallableRubricTrait`: type `bool` -> `bool | None`, add `default=True`, fix legacy validator
+- `AgenticRubricTrait`: already `bool | None`, but its `set_legacy_defaults` validator has the same coercion bug (coerces explicit `None` to `True` for non-template kinds). Apply the same fix: only fill default when key is absent.
+- `MetricRubricTrait`: add `higher_is_better: bool | None = Field(default=None, ...)`. No `set_legacy_defaults` validator needed since the default is `None` and Pydantic handles missing fields automatically.
+
+### Rubric.get_trait_directionalities()
+
+Update to include metric traits. Remove the comment "MetricRubricTraits are excluded as metrics (precision/recall/F1) are inherently 'higher is better'." Update the docstring to reflect that `None` values indicate directionality does not apply.
+
+Return type is already `dict[str, bool | None]` (AgenticRubricTrait template kinds already return `None`).
 
 ## Dropped
 
@@ -156,6 +284,8 @@ Dropped after investigation. The function operates on classes (not instances) an
 - `set_global_rubric` and `set_question_rubric` accept both `Rubric` and `list` (144)
 - Config router (064) produces exactly 11 config endpoints, not 22
 - `__repr__` (120) is fast for large result sets
-- `higher_is_better` (071) works as `bool | None` across all trait types
-- `group_by_replicate` (121) preserves `None` keys
-- `ResultsStore` accumulates results across runs
+- `higher_is_better` works as `bool | None` across all trait types; explicit `None` is preserved (not coerced to `True`)
+- `group_by_replicate` (121) preserves `None` keys; callers handle `None` gracefully
+- `ResultsStore` accumulates results across runs and exposes query/export methods
+- Deprecated facade methods emit `DeprecationWarning`
+- `deep_judgment_rubric_config` validates against `DeepJudgmentRubricCustomConfig` model

--- a/docs/superpowers/specs/2026-03-24-api-design-improvements.md
+++ b/docs/superpowers/specs/2026-03-24-api-design-improvements.md
@@ -1,0 +1,161 @@
+# API Design Improvements
+
+**Date**: 2026-03-24
+**Scope**: Core library (`karenina/`) and server (`karenina-server/`), ~10 files
+**Effort**: ~3 hours
+
+## Overview
+
+Fourteen items covering API gaps, naming inconsistencies, type improvements, and design decisions. One item (131: inject_question_id) was dropped after investigation showed the current approach is correct. Grouped into five sections.
+
+## Section 1: ResultsStore (replaces facade result storage)
+
+### Decision
+
+The `Benchmark` object defines evaluation items (questions, templates, rubrics), not results. Result storage methods are removed from the facade and replaced with a standalone `ResultsStore` class.
+
+### Changes
+
+**Remove from `Benchmark` facade:**
+- `store_verification_results()`
+- `get_verification_results()`
+- `get_verification_history()`
+- Remove `ResultsManager` as a Benchmark dependency (if it is only used for result storage)
+
+**Create `ResultsStore`** in `karenina/benchmark/core/results_store.py`:
+
+```python
+class ResultsStore:
+    """Container for gathering verification results across runs."""
+
+    def add(self, result_set: VerificationResultSet) -> None:
+        """Store a result set, keyed by run name."""
+
+    def get_latest(self, question_id: str | None = None) -> dict[str, VerificationResult]:
+        """Get latest results, optionally filtered by question."""
+
+    def has_results(self, question_id: str | None = None, run_name: str | None = None) -> bool:
+        """Check whether results exist."""
+
+    def get_by_question(self, question_id: str) -> dict[str, VerificationResult]:
+        """Get all results for a question across runs."""
+
+    def get_by_run(self, run_name: str) -> dict[str, VerificationResult]:
+        """Get all results for a specific run."""
+
+    def get_all_runs(self) -> list[str]:
+        """List all stored run names."""
+```
+
+**Usage pattern:**
+
+```python
+store = ResultsStore()
+results = benchmark.run_verification(config)
+store.add(results)
+
+store.get_latest("q1")
+store.has_results(run_name="run_2")
+store.get_by_question("q1")
+```
+
+## Section 2: Facade API Gaps
+
+### 019: Add `get_question_rubric()` to facade
+
+Simple delegation:
+
+```python
+def get_question_rubric(self, question_id: str) -> Rubric | None:
+    """Get the question-specific rubric for a question."""
+    return self._rubric_manager.get_question_rubric(question_id)
+```
+
+### 144: `set_global_rubric()` and `set_question_rubric()` delegation
+
+Both facade methods currently decompose a `Rubric` into traits and add them one-by-one. The manager should accept both a `Rubric` object and a raw traits list.
+
+**RubricManager changes:**
+- `set_global_rubric(rubric: Rubric | list[TraitUnion])`: accepts either form
+- Add `set_question_rubric(question_id: str, rubric: Rubric | list[TraitUnion])`: new method
+
+**Facade changes:** Both `set_global_rubric()` and `set_question_rubric()` become one-liner delegations.
+
+### 145: Rename `RubricManager.get_questions_with_rubric()` to `get_question_ids_with_rubric()`
+
+Internal-only rename. The facade's same-named method delegates to `QuestionManager` (returns `list[dict]`), which is unchanged.
+
+## Section 3: Naming and Consistency
+
+### 026: Document `summary()` vs `summary_compact()` scope
+
+Add docstring clarification to both `TaskEvalResult` methods:
+- `summary()`: "Aggregates across global evaluation and all per-step evaluations"
+- `summary_compact()`: "Reports global evaluation statistics only"
+
+### 047: Unify `validate_rubrics()` error shape
+
+Change `validate_rubrics()` return from `tuple[bool, list[str]]` to `tuple[bool, list[dict[str, str]]]` with `{"source": trait_name_or_scope, "error": message}`. Matches `validate_templates()`.
+
+### 064: Remove duplicate config router mount
+
+Remove `app.include_router(config_router, prefix="/api/config")` from `server.py`. Keep only the `/api` mount. Verify the GUI does not reference `/api/config/v2/config/...` paths before removing.
+
+## Section 4: Type Improvements
+
+### 120: Simplify `VerificationResultSet.__repr__`
+
+Replace the current `get_summary()`-calling repr with a lightweight version:
+
+```python
+def __repr__(self) -> str:
+    return f"VerificationResultSet(results={len(self.results)}, run_name={self.run_name!r})"
+```
+
+### 136: Type `deep_judgment_rubric_config`
+
+Change from `dict[str, Any] | None` to `dict[str, DeepJudgmentTraitConfig] | None`. `DeepJudgmentTraitConfig` already exists in the same file. Add a cross-field `model_validator` to require the field when `deep_judgment_rubric_mode="custom"`.
+
+### 176: Add `by` parameter to view-level `group_by_model()`
+
+Add `by: Literal["answering", "parsing", "both"] = "answering"` to:
+- `TemplateResults.group_by_model()`
+- `RubricResults.group_by_model()`
+- `JudgmentResults.group_by_model()`
+
+Use the same key-building logic as `VerificationResultSet.group_by_model()`.
+
+### 121: Preserve `None` in `group_by_replicate()`
+
+Change return type from `dict[int, VerificationResultSet]` to `dict[int | None, VerificationResultSet]`. Use `result.metadata.replicate` directly instead of `result.metadata.replicate or 0`.
+
+## Section 5: `higher_is_better` on all trait types
+
+### Decision
+
+Add `higher_is_better: bool | None` to all trait types. `None` means directionality does not apply.
+
+**Changes:**
+- `LLMRubricTrait`: change from `bool` to `bool | None`, default stays `True`
+- `RegexRubricTrait`: change from `bool` to `bool | None`, default stays `True`
+- `CallableRubricTrait`: change from `bool` to `bool | None`, default stays `True`
+- `AgenticRubricTrait`: change from `bool` to `bool | None`, default stays `True` (verify current state)
+- `MetricRubricTrait`: add `higher_is_better: bool | None = None`
+- `Rubric.get_trait_directionalities()`: include metric traits, return `dict[str, bool | None]`
+
+## Dropped
+
+### 131: `inject_question_id` subclass chain
+
+Dropped after investigation. The function operates on classes (not instances) and the class is instantiated later during LLM response parsing. The subclassing approach is necessary; the proposed "set after construction" fix does not apply.
+
+## Verification
+
+- Full test suite passes in both `karenina/` and `karenina-server/`
+- New facade methods (019) are callable and delegate correctly
+- `set_global_rubric` and `set_question_rubric` accept both `Rubric` and `list` (144)
+- Config router (064) produces exactly 11 config endpoints, not 22
+- `__repr__` (120) is fast for large result sets
+- `higher_is_better` (071) works as `bool | None` across all trait types
+- `group_by_replicate` (121) preserves `None` keys
+- `ResultsStore` accumulates results across runs

--- a/src/karenina/benchmark/benchmark.py
+++ b/src/karenina/benchmark/benchmark.py
@@ -653,35 +653,27 @@ class Benchmark:
 
     def set_global_rubric(self, rubric: Rubric) -> None:
         """Set the complete global rubric (replaces existing)."""
-        self.clear_global_rubric()
-        for trait in rubric.llm_traits:
-            self.add_global_rubric_trait(trait)
-        for regex_trait in rubric.regex_traits:
-            self.add_global_rubric_trait(regex_trait)
-        for callable_trait in rubric.callable_traits:
-            self.add_global_rubric_trait(callable_trait)
-        for metric_trait in rubric.metric_traits:
-            self.add_global_rubric_trait(metric_trait)
-        for agentic_trait in rubric.agentic_traits:
-            self.add_global_rubric_trait(agentic_trait)
+        self._rubric_manager.set_global_rubric(rubric)
 
     def set_question_rubric(self, question_id: str, rubric: Rubric) -> None:
         """Set the complete question-specific rubric (replaces existing)."""
-        self.remove_question_rubric(question_id)
-        for trait in rubric.llm_traits:
-            self.add_question_rubric_trait(question_id, trait)
-        for regex_trait in rubric.regex_traits:
-            self.add_question_rubric_trait(question_id, regex_trait)
-        for callable_trait in rubric.callable_traits:
-            self.add_question_rubric_trait(question_id, callable_trait)
-        for metric_trait in rubric.metric_traits:
-            self.add_question_rubric_trait(question_id, metric_trait)
-        for agentic_trait in rubric.agentic_traits:
-            self.add_question_rubric_trait(question_id, agentic_trait)
+        self._rubric_manager.set_question_rubric(question_id, rubric)
 
     def get_global_rubric(self) -> Rubric | None:
         """Get the global rubric from the benchmark."""
         return self._rubric_manager.get_global_rubric()
+
+    def get_question_rubric(self, question_id: str) -> Rubric | None:
+        """Get the question-specific rubric for a question.
+
+        Args:
+            question_id: The question ID.
+
+        Returns:
+            Rubric containing the question-specific traits, or None.
+        """
+        traits = self._rubric_manager.get_question_rubric(question_id)
+        return Rubric.from_traits(traits)
 
     def clear_global_rubric(self) -> bool:
         """Remove the global rubric."""
@@ -695,7 +687,7 @@ class Benchmark:
         """Remove all rubrics (global and question-specific)."""
         return self._rubric_manager.clear_all_rubrics()
 
-    def validate_rubrics(self) -> tuple[bool, list[str]]:
+    def validate_rubrics(self) -> tuple[bool, list[dict[str, str]]]:
         """Validate all rubrics are properly configured."""
         return self._rubric_manager.validate_rubrics()
 

--- a/src/karenina/benchmark/benchmark.py
+++ b/src/karenina/benchmark/benchmark.py
@@ -10,6 +10,7 @@ conversion is in benchmark_helpers.py.
 """
 
 import logging
+import warnings
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
@@ -918,6 +919,11 @@ class Benchmark:
         run_name: str | None = None,
     ) -> None:
         """Store verification results in the benchmark metadata."""
+        warnings.warn(
+            "store_verification_results is deprecated. Use ResultsStore.add() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         _helpers.store_verification_results(self, results, run_name)
 
     def get_verification_results(
@@ -926,10 +932,20 @@ class Benchmark:
         run_name: str | None = None,
     ) -> dict[str, VerificationResult]:
         """Get verification results for specific questions and/or runs."""
+        warnings.warn(
+            "get_verification_results is deprecated. Use ResultsStore.get_by_run() or ResultsStore.get_latest() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._results_manager.get_verification_results(question_ids, run_name)
 
     def get_verification_history(self, question_id: str | None = None) -> dict[str, dict[str, VerificationResult]]:
         """Get verification history organized by run name."""
+        warnings.warn(
+            "get_verification_history is deprecated. Use ResultsStore.get_by_question() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._results_manager.get_verification_history(question_id)
 
     def clear_verification_results(
@@ -938,6 +954,11 @@ class Benchmark:
         run_name: str | None = None,
     ) -> int:
         """Clear verification results."""
+        warnings.warn(
+            "clear_verification_results is deprecated. Use ResultsStore.clear() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._results_manager.clear_verification_results(question_ids, run_name)
 
     def export_verification_results(
@@ -948,6 +969,11 @@ class Benchmark:
         global_rubric: "Rubric | None" = None,
     ) -> str:
         """Export verification results in specified format."""
+        warnings.warn(
+            "export_verification_results is deprecated. Use ResultsStore.export() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._results_manager.export_verification_results(question_ids, run_name, format, global_rubric)
 
     def export_verification_results_to_file(
@@ -959,6 +985,11 @@ class Benchmark:
         global_rubric: "Rubric | None" = None,
     ) -> None:
         """Export verification results directly to a file."""
+        warnings.warn(
+            "export_verification_results_to_file is deprecated. Use ResultsStore.export_to_file() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._results_manager.export_results_to_file(file_path, question_ids, run_name, format, global_rubric)
 
     def load_verification_results_from_file(
@@ -967,18 +998,38 @@ class Benchmark:
         run_name: str | None = None,
     ) -> dict[str, VerificationResult]:
         """Load verification results from a previously exported file."""
+        warnings.warn(
+            "load_verification_results_from_file is deprecated. Use ResultsStore.from_file() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._results_manager.load_results_from_file(file_path, run_name)
 
     def get_verification_summary(self, run_name: str | None = None) -> dict[str, Any]:
         """Get summary statistics for verification results."""
+        warnings.warn(
+            "get_verification_summary is deprecated. Use ResultsStore.get_summary() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._results_manager.get_verification_summary(run_name)
 
     def get_all_run_names(self) -> list[str]:
         """Get all verification run names."""
+        warnings.warn(
+            "get_all_run_names is deprecated. Use ResultsStore.get_all_runs() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._results_manager.get_all_run_names()
 
     def get_results_statistics_by_run(self) -> dict[str, dict[str, Any]]:
         """Get verification statistics for each run."""
+        warnings.warn(
+            "get_results_statistics_by_run is deprecated. Use ResultsStore.get_statistics_by_run() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._results_manager.get_results_statistics_by_run()
 
     # ── GEPA optimization (delegated to benchmark_helpers) ───────────────

--- a/src/karenina/benchmark/benchmark.py
+++ b/src/karenina/benchmark/benchmark.py
@@ -672,8 +672,18 @@ class Benchmark:
         Returns:
             Rubric containing the question-specific traits, or None.
         """
-        traits = self._rubric_manager.get_question_rubric(question_id)
-        return Rubric.from_traits(traits)
+        raw = self._rubric_manager.get_question_rubric(question_id)
+        if raw is None:
+            return None
+        if isinstance(raw, dict):
+            return Rubric(
+                llm_traits=raw.get("llm_traits", []),
+                regex_traits=raw.get("regex_traits", []),
+                callable_traits=raw.get("callable_traits", []),
+                metric_traits=raw.get("metric_traits", []),
+                agentic_traits=raw.get("agentic_traits", []),
+            )
+        return Rubric.from_traits(raw)
 
     def clear_global_rubric(self) -> bool:
         """Remove the global rubric."""

--- a/src/karenina/benchmark/core/__init__.py
+++ b/src/karenina/benchmark/core/__init__.py
@@ -11,6 +11,7 @@ from .question_query import QuestionQueryBuilder
 from .questions import QuestionManager
 from .results import ResultsManager
 from .results_io import ResultsIOManager
+from .results_store import ResultsStore
 from .rubrics import RubricManager
 from .templates import TemplateManager
 from .verification_manager import VerificationManager
@@ -23,6 +24,7 @@ __all__ = [
     "QuestionQueryBuilder",
     "ResultsIOManager",
     "ResultsManager",
+    "ResultsStore",
     "RubricManager",
     "TemplateManager",
     "VerificationManager",

--- a/src/karenina/benchmark/core/results_store.py
+++ b/src/karenina/benchmark/core/results_store.py
@@ -1,0 +1,389 @@
+"""Standalone results store for accumulating verification results across runs.
+
+ResultsStore holds VerificationResultSets keyed by run name, providing
+query, filter, summary, and export capabilities independent of the
+Benchmark facade.
+"""
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from karenina.schemas.results.verification_result_set import VerificationResultSet
+from karenina.schemas.verification import VerificationResult
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ResultsStore"]
+
+
+class ResultsStore:
+    """Accumulates VerificationResultSets keyed by run name.
+
+    Each call to ``add()`` stores a full result set under a unique run name.
+    Query methods allow filtering by run, question, or recency. The store is
+    independent of the Benchmark facade and can be composed with it or used
+    on its own.
+
+    Example:
+        ```python
+        store = ResultsStore()
+        store.add(result_set, run_name="gpt4o_baseline")
+        store.add(result_set, run_name="claude_baseline")
+        latest = store.get_latest()
+        ```
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty results store."""
+        self._runs: dict[str, VerificationResultSet] = {}
+
+    # ========================================================================
+    # Add
+    # ========================================================================
+
+    def add(
+        self,
+        result_set: VerificationResultSet,
+        run_name: str | None = None,
+    ) -> str:
+        """Add a result set to the store.
+
+        Args:
+            result_set: The verification result set to store.
+            run_name: Key for this run. If None, a timestamped name is
+                generated automatically (``run_YYYY-MM-DDTHH:MM:SS``).
+
+        Returns:
+            The run name under which the result set was stored.
+
+        Raises:
+            ValueError: If ``run_name`` already exists in the store.
+        """
+        if run_name is None:
+            run_name = f"run_{datetime.now(tz=UTC).strftime('%Y-%m-%dT%H:%M:%S')}"
+            logger.info("Auto-generated run name: %s", run_name)
+
+        if run_name in self._runs:
+            raise ValueError(
+                f"Run name '{run_name}' already exists. Use a unique name or omit run_name to auto-generate one."
+            )
+
+        self._runs[run_name] = result_set
+        logger.info(
+            "Added %d results under run '%s'",
+            len(result_set.results),
+            run_name,
+        )
+        return run_name
+
+    # ========================================================================
+    # Query
+    # ========================================================================
+
+    def get_by_run(self, run_name: str) -> VerificationResultSet:
+        """Return the result set for a given run.
+
+        Args:
+            run_name: The run to look up.
+
+        Returns:
+            The VerificationResultSet stored under ``run_name``.
+
+        Raises:
+            KeyError: If the run name does not exist.
+        """
+        if run_name not in self._runs:
+            raise KeyError(f"No run named '{run_name}' in store")
+        return self._runs[run_name]
+
+    def get_by_question(
+        self,
+        question_id: str,
+    ) -> dict[str, list[VerificationResult]]:
+        """Collect results for a question across all runs.
+
+        Args:
+            question_id: The question ID to search for.
+
+        Returns:
+            Dict mapping run name to a list of matching VerificationResult
+            objects. Runs with no matches are omitted.
+        """
+        matches: dict[str, list[VerificationResult]] = {}
+        for run_name, result_set in self._runs.items():
+            hits = [r for r in result_set.results if r.metadata.question_id == question_id]
+            if hits:
+                matches[run_name] = hits
+        return matches
+
+    def get_latest(
+        self,
+        question_id: str | None = None,
+    ) -> dict[str, VerificationResult]:
+        """Return the most recent result per question.
+
+        Iterates runs in reverse insertion order and collects the first
+        result encountered for each question ID.
+
+        Args:
+            question_id: If provided, only return the latest result for
+                this specific question.
+
+        Returns:
+            Dict mapping question ID to the most recent VerificationResult.
+        """
+        latest: dict[str, VerificationResult] = {}
+        for result_set in reversed(list(self._runs.values())):
+            for result in result_set.results:
+                qid = result.metadata.question_id
+                if question_id is not None and qid != question_id:
+                    continue
+                if qid not in latest:
+                    latest[qid] = result
+        return latest
+
+    def has_results(
+        self,
+        question_id: str | None = None,
+        run_name: str | None = None,
+    ) -> bool:
+        """Check whether results exist, optionally filtered.
+
+        Args:
+            question_id: If provided, check only for this question.
+            run_name: If provided, check only in this run.
+
+        Returns:
+            True if at least one matching result exists.
+        """
+        if not self._runs:
+            return False
+
+        runs_to_check = {run_name: self._runs[run_name]} if run_name and run_name in self._runs else self._runs
+        if run_name and run_name not in self._runs:
+            return False
+
+        for result_set in runs_to_check.values():
+            for result in result_set.results:
+                if question_id is None or result.metadata.question_id == question_id:
+                    return True
+        return False
+
+    def get_all_runs(self) -> list[str]:
+        """Return run names in insertion order.
+
+        Returns:
+            List of run name strings.
+        """
+        return list(self._runs.keys())
+
+    # ========================================================================
+    # Clear
+    # ========================================================================
+
+    def clear(
+        self,
+        question_ids: list[str] | None = None,
+        run_name: str | None = None,
+    ) -> int:
+        """Remove results from the store.
+
+        Args:
+            question_ids: If provided, remove only results with these
+                question IDs (from all runs, or from ``run_name`` if given).
+            run_name: If provided, scope the clear to this run only.
+
+        Returns:
+            Number of individual results removed.
+        """
+        cleared = 0
+        runs_to_check = [run_name] if run_name else list(self._runs.keys())
+
+        for rn in runs_to_check:
+            if rn not in self._runs:
+                continue
+
+            if question_ids is None:
+                cleared += len(self._runs[rn].results)
+                del self._runs[rn]
+            else:
+                original = self._runs[rn].results
+                kept = [r for r in original if r.metadata.question_id not in question_ids]
+                cleared += len(original) - len(kept)
+                if kept:
+                    self._runs[rn] = VerificationResultSet(results=kept)
+                else:
+                    del self._runs[rn]
+
+        logger.info("Cleared %d results", cleared)
+        return cleared
+
+    # ========================================================================
+    # Summary and Statistics
+    # ========================================================================
+
+    def get_summary(self, run_name: str | None = None) -> dict[str, Any]:
+        """Return aggregate statistics across stored results.
+
+        Args:
+            run_name: If provided, scope statistics to this run.
+
+        Returns:
+            Dict with keys: total_results, total_runs, unique_questions,
+            completed_count, failed_count, success_rate.
+        """
+        if run_name is not None:
+            if run_name not in self._runs:
+                return self._empty_summary()
+            runs = {run_name: self._runs[run_name]}
+        else:
+            runs = self._runs
+
+        if not runs:
+            return self._empty_summary()
+
+        all_results = [r for rs in runs.values() for r in rs.results]
+        total = len(all_results)
+        completed = sum(1 for r in all_results if r.metadata.completed_without_errors)
+        failed = total - completed
+        question_ids = {r.metadata.question_id for r in all_results}
+
+        return {
+            "total_results": total,
+            "total_runs": len(runs),
+            "unique_questions": len(question_ids),
+            "completed_count": completed,
+            "failed_count": failed,
+            "success_rate": (completed / total * 100) if total else 0.0,
+        }
+
+    def get_statistics_by_run(self) -> dict[str, dict[str, Any]]:
+        """Return per-run summary statistics.
+
+        Returns:
+            Dict mapping each run name to its summary dict
+            (same shape as ``get_summary``).
+        """
+        return {rn: self.get_summary(run_name=rn) for rn in self._runs}
+
+    # ========================================================================
+    # Export and Import
+    # ========================================================================
+
+    def export(
+        self,
+        question_ids: list[str] | None = None,
+        run_name: str | None = None,
+    ) -> dict[str, Any]:
+        """Export results as a JSON-serializable dict.
+
+        Args:
+            question_ids: If provided, include only results with these
+                question IDs.
+            run_name: If provided, include only this run.
+
+        Returns:
+            Dict with a ``runs`` key mapping run names to lists of
+            serialized result dicts.
+        """
+        runs_to_export = {run_name: self._runs[run_name]} if run_name and run_name in self._runs else dict(self._runs)
+
+        exported_runs: dict[str, list[dict[str, Any]]] = {}
+        for rn, result_set in runs_to_export.items():
+            results_list = []
+            for result in result_set.results:
+                if question_ids and result.metadata.question_id not in question_ids:
+                    continue
+                results_list.append(result.model_dump())
+            if results_list:
+                exported_runs[rn] = results_list
+
+        return {"runs": exported_runs}
+
+    def export_to_file(
+        self,
+        file_path: str | Path,
+        **kwargs: Any,
+    ) -> None:
+        """Write exported results to a JSON file.
+
+        Args:
+            file_path: Destination path for the JSON file.
+            **kwargs: Passed through to ``export()``.
+        """
+        file_path = Path(file_path)
+        data = self.export(**kwargs)
+
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, default=str)
+
+        logger.info("Exported results to %s", file_path)
+
+    @classmethod
+    def from_file(cls, file_path: str | Path) -> "ResultsStore":
+        """Load a ResultsStore from a previously exported JSON file.
+
+        Args:
+            file_path: Path to the JSON file.
+
+        Returns:
+            A new ResultsStore populated with the loaded data.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            ValueError: If the file content is not valid.
+        """
+        file_path = Path(file_path)
+        if not file_path.exists():
+            raise FileNotFoundError(f"Results file not found: {file_path}")
+
+        with open(file_path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        if "runs" not in data:
+            raise ValueError("Invalid results file: missing 'runs' key")
+
+        store = cls()
+        for rn, results_list in data["runs"].items():
+            result_objects = [VerificationResult.model_validate(rd) for rd in results_list]
+            result_set = VerificationResultSet(results=result_objects)
+            store._runs[rn] = result_set
+
+        logger.info(
+            "Loaded %d runs from %s",
+            len(store._runs),
+            file_path,
+        )
+        return store
+
+    # ========================================================================
+    # Private Helpers
+    # ========================================================================
+
+    @staticmethod
+    def _empty_summary() -> dict[str, Any]:
+        """Return a summary dict with zero values.
+
+        Returns:
+            Dict with all summary fields set to zero.
+        """
+        return {
+            "total_results": 0,
+            "total_runs": 0,
+            "unique_questions": 0,
+            "completed_count": 0,
+            "failed_count": 0,
+            "success_rate": 0.0,
+        }
+
+    def __repr__(self) -> str:
+        """Return developer-friendly string representation."""
+        total = sum(len(rs.results) for rs in self._runs.values())
+        return f"ResultsStore(runs={len(self._runs)}, total_results={total})"
+
+    def __len__(self) -> int:
+        """Return total number of individual results across all runs."""
+        return sum(len(rs.results) for rs in self._runs.values())

--- a/src/karenina/benchmark/core/rubrics.py
+++ b/src/karenina/benchmark/core/rubrics.py
@@ -220,14 +220,15 @@ class RubricManager:
 
         return count
 
-    def validate_rubrics(self) -> tuple[bool, list[str]]:
-        """
-        Validate all rubrics are properly configured.
+    def validate_rubrics(self) -> tuple[bool, list[dict[str, str]]]:
+        """Validate all rubrics are properly configured.
 
         Returns:
-            Tuple of (all_valid, list_of_errors)
+            Tuple of (all_valid, errors) where each error is a dict
+            with ``"source"`` (trait name or scope like ``"global"``
+            or ``"question:<id>"``) and ``"error"`` (message).
         """
-        errors = []
+        errors: list[dict[str, str]] = []
 
         # Check global rubric
         global_rubric = self.get_global_rubric()
@@ -235,25 +236,60 @@ class RubricManager:
             # Validate LLM traits
             for trait in global_rubric.llm_traits:
                 if not trait.name or not trait.description:
-                    errors.append("Global LLM rubric trait missing name or description")
+                    errors.append(
+                        {
+                            "source": trait.name or "global",
+                            "error": "Global LLM rubric trait missing name or description",
+                        }
+                    )
                 if trait.kind == "score" and (trait.min_score is None or trait.max_score is None):
-                    errors.append(f"Score trait '{trait.name}' missing min/max scores")
+                    errors.append(
+                        {
+                            "source": trait.name or "global",
+                            "error": "Score trait missing min/max scores",
+                        }
+                    )
             # Validate regex traits
             for regex_trait in global_rubric.regex_traits:
                 if not regex_trait.name or not regex_trait.description:
-                    errors.append("Global regex rubric trait missing name or description")
+                    errors.append(
+                        {
+                            "source": regex_trait.name or "global",
+                            "error": "Global regex rubric trait missing name or description",
+                        }
+                    )
                 if not regex_trait.pattern:
-                    errors.append(f"Regex trait '{regex_trait.name}' missing pattern")
+                    errors.append(
+                        {
+                            "source": regex_trait.name or "global",
+                            "error": "Regex trait missing pattern",
+                        }
+                    )
             # Validate callable traits
             for callable_trait in global_rubric.callable_traits:
                 if not callable_trait.name or not callable_trait.description:
-                    errors.append("Global callable rubric trait missing name or description")
+                    errors.append(
+                        {
+                            "source": callable_trait.name or "global",
+                            "error": "Global callable rubric trait missing name or description",
+                        }
+                    )
             # Validate metric traits
             for metric_trait in global_rubric.metric_traits:
                 if not metric_trait.name or not metric_trait.description:
-                    errors.append("Global metric rubric trait missing name or description")
+                    errors.append(
+                        {
+                            "source": metric_trait.name or "global",
+                            "error": "Global metric rubric trait missing name or description",
+                        }
+                    )
                 if not metric_trait.metrics:
-                    errors.append(f"Metric trait '{metric_trait.name}' has no metrics defined")
+                    errors.append(
+                        {
+                            "source": metric_trait.name or "global",
+                            "error": "Metric trait has no metrics defined",
+                        }
+                    )
 
         # Check question-specific rubrics
         for q_id, q_data in self.base._questions_cache.items():
@@ -270,20 +306,40 @@ class RubricManager:
 
                 for trait in traits_to_validate:
                     if not trait.name or not trait.description:
-                        errors.append(f"Question {q_id} rubric trait missing name or description")
+                        errors.append(
+                            {
+                                "source": f"question:{q_id}",
+                                "error": "Rubric trait missing name or description",
+                            }
+                        )
                     # Check score fields for LLM traits
                     if (
                         isinstance(trait, LLMRubricTrait)
                         and trait.kind == "score"
                         and (trait.min_score is None or trait.max_score is None)
                     ):
-                        errors.append(f"Question {q_id} score trait '{trait.name}' missing min/max scores")
+                        errors.append(
+                            {
+                                "source": f"question:{q_id}",
+                                "error": f"Score trait '{trait.name}' missing min/max scores",
+                            }
+                        )
                     # Check regex traits
                     if isinstance(trait, RegexRubricTrait) and not trait.pattern:
-                        errors.append(f"Question {q_id} regex trait '{trait.name}' missing pattern")
+                        errors.append(
+                            {
+                                "source": f"question:{q_id}",
+                                "error": f"Regex trait '{trait.name}' missing pattern",
+                            }
+                        )
                     # Check metric traits
                     if isinstance(trait, MetricRubricTrait) and not trait.metrics:
-                        errors.append(f"Question {q_id} metric trait '{trait.name}' has no metrics defined")
+                        errors.append(
+                            {
+                                "source": f"question:{q_id}",
+                                "error": f"Metric trait '{trait.name}' has no metrics defined",
+                            }
+                        )
 
         return len(errors) == 0, errors
 
@@ -320,21 +376,65 @@ class RubricManager:
             "total_traits": global_traits_count + total_question_traits,
         }
 
-    def get_questions_with_rubric(self) -> list[str]:
+    def get_question_ids_with_rubric(self) -> list[str]:
         """Get list of question IDs that have question-specific rubrics."""
         return [q_id for q_id, q_data in self.base._questions_cache.items() if q_data.get("question_rubric")]
 
     def set_global_rubric(
         self,
-        traits: list[LLMRubricTrait | RegexRubricTrait | CallableRubricTrait | MetricRubricTrait | AgenticRubricTrait],
+        rubric: Rubric
+        | list[LLMRubricTrait | RegexRubricTrait | CallableRubricTrait | MetricRubricTrait | AgenticRubricTrait],
     ) -> None:
-        """
-        Set the global rubric with a list of traits.
+        """Set the global rubric, replacing any existing traits.
 
         Args:
-            traits: List of rubric traits (LLM, regex, callable, metric, or agentic)
+            rubric: A Rubric object or a flat list of trait instances.
         """
+        if isinstance(rubric, Rubric):
+            traits: list[
+                LLMRubricTrait | RegexRubricTrait | CallableRubricTrait | MetricRubricTrait | AgenticRubricTrait
+            ] = []
+            traits.extend(rubric.llm_traits)
+            traits.extend(rubric.regex_traits)
+            traits.extend(rubric.callable_traits)
+            traits.extend(rubric.metric_traits)
+            traits.extend(rubric.agentic_traits)
+        else:
+            traits = rubric
         add_global_rubric_to_benchmark(self.base._checkpoint, traits)
+
+    def set_question_rubric(
+        self,
+        question_id: str,
+        rubric: Rubric
+        | list[LLMRubricTrait | RegexRubricTrait | CallableRubricTrait | MetricRubricTrait | AgenticRubricTrait],
+    ) -> None:
+        """Set the question-specific rubric, replacing any existing traits.
+
+        Clears existing question rubric traits and then adds all traits
+        from the provided Rubric or list.
+
+        Args:
+            question_id: The question ID.
+            rubric: A Rubric object or a flat list of trait instances.
+
+        Raises:
+            ValueError: If question not found.
+        """
+        self.remove_question_rubric(question_id)
+        if isinstance(rubric, Rubric):
+            trait_list: list[
+                LLMRubricTrait | RegexRubricTrait | CallableRubricTrait | MetricRubricTrait | AgenticRubricTrait
+            ] = []
+            trait_list.extend(rubric.llm_traits)
+            trait_list.extend(rubric.regex_traits)
+            trait_list.extend(rubric.callable_traits)
+            trait_list.extend(rubric.metric_traits)
+            trait_list.extend(rubric.agentic_traits)
+        else:
+            trait_list = rubric
+        for trait in trait_list:
+            self.add_question_rubric_trait(question_id, trait)
 
     def update_global_rubric_trait(
         self,

--- a/src/karenina/benchmark/task_eval/models.py
+++ b/src/karenina/benchmark/task_eval/models.py
@@ -528,7 +528,10 @@ class TaskEvalResult(BaseModel):
         return "\n".join(lines)
 
     def summary(self) -> str:
-        """Return a concise summary of the evaluation results."""
+        """Return a concise summary of the evaluation results.
+
+        Aggregates across global evaluation and all per-step evaluations.
+        """
         total_traces = 0
         passed_traces = 0
         total_template_verifications = 0
@@ -569,7 +572,10 @@ class TaskEvalResult(BaseModel):
         return " | ".join(parts) if parts else "No evaluations performed"
 
     def summary_compact(self) -> str:
-        """Return a very compact one-line summary."""
+        """Return a very compact one-line summary.
+
+        Reports global evaluation statistics only (excludes per-step evaluations).
+        """
         if self.global_eval:
             stats = self.global_eval.get_summary_stats()
             parts = []

--- a/src/karenina/benchmark/verification/runner.py
+++ b/src/karenina/benchmark/verification/runner.py
@@ -16,6 +16,7 @@ from karenina.schemas.verification.config import (
     DEFAULT_DEEP_JUDGMENT_MAX_EXCERPTS,
     DEFAULT_DEEP_JUDGMENT_RETRY_ATTEMPTS,
     DEFAULT_RUBRIC_MAX_EXCERPTS,
+    DeepJudgmentRubricCustomConfig,
 )
 from karenina.utils.checkpoint import generate_template_id
 
@@ -50,7 +51,7 @@ def run_single_model_verification(
     # Deep-judgment rubric configuration (NEW)
     deep_judgment_rubric_mode: str = "disabled",
     deep_judgment_rubric_global_excerpts: bool = True,
-    deep_judgment_rubric_config: dict[str, Any] | None = None,
+    deep_judgment_rubric_config: DeepJudgmentRubricCustomConfig | None = None,
     deep_judgment_rubric_max_excerpts_default: int = DEFAULT_RUBRIC_MAX_EXCERPTS,
     deep_judgment_rubric_fuzzy_match_threshold_default: float = DEFAULT_DEEP_JUDGMENT_FUZZY_THRESHOLD,
     deep_judgment_rubric_excerpt_retry_attempts_default: int = DEFAULT_DEEP_JUDGMENT_RETRY_ATTEMPTS,

--- a/src/karenina/benchmark/verification/stages/core/base.py
+++ b/src/karenina/benchmark/verification/stages/core/base.py
@@ -30,6 +30,7 @@ from karenina.schemas.verification.config import (
     DEFAULT_DEEP_JUDGMENT_MAX_EXCERPTS,
     DEFAULT_DEEP_JUDGMENT_RETRY_ATTEMPTS,
     DEFAULT_RUBRIC_MAX_EXCERPTS,
+    DeepJudgmentRubricCustomConfig,
 )
 
 if TYPE_CHECKING:
@@ -299,7 +300,7 @@ class VerificationContext:
     # Deep-Judgment Rubric Configuration (NEW - runtime control of deep judgment for rubrics)
     deep_judgment_rubric_mode: str = "disabled"  # Mode: disabled, enable_all, use_checkpoint, custom
     deep_judgment_rubric_global_excerpts: bool = True  # For enable_all mode: enable/disable excerpts
-    deep_judgment_rubric_config: dict[str, Any] | None = None  # For custom mode: nested trait config
+    deep_judgment_rubric_config: DeepJudgmentRubricCustomConfig | None = None  # For custom mode: per-trait config
     deep_judgment_rubric_max_excerpts_default: int = DEFAULT_RUBRIC_MAX_EXCERPTS
     deep_judgment_rubric_fuzzy_match_threshold_default: float = DEFAULT_DEEP_JUDGMENT_FUZZY_THRESHOLD
     deep_judgment_rubric_excerpt_retry_attempts_default: int = DEFAULT_DEEP_JUDGMENT_RETRY_ATTEMPTS

--- a/src/karenina/benchmark/verification/stages/helpers/deep_judgment_helpers.py
+++ b/src/karenina/benchmark/verification/stages/helpers/deep_judgment_helpers.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from karenina.schemas.entities import LLMRubricTrait
 from karenina.schemas.verification import DeepJudgmentTraitConfig
+from karenina.schemas.verification.config import DeepJudgmentRubricCustomConfig
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -84,25 +85,23 @@ def resolve_deep_judgment_config_for_trait(
         )
 
     elif mode == "custom":
-        # Navigate nested config structure
-        config_dict = getattr(config, "deep_judgment_rubric_config", None) or {}
+        # Navigate typed config structure
+        custom_config: DeepJudgmentRubricCustomConfig | None = getattr(config, "deep_judgment_rubric_config", None)
+
+        if custom_config is None:
+            return DeepJudgmentTraitConfig(enabled=False)
 
         # Try question-specific first
         if (
             question_id
-            and "question_specific" in config_dict
-            and question_id in config_dict["question_specific"]
-            and trait.name in config_dict["question_specific"][question_id]
+            and question_id in custom_config.question_specific
+            and trait.name in custom_config.question_specific[question_id]
         ):
-            trait_config = config_dict["question_specific"][question_id][trait.name]
-            # Validate dict against model
-            return DeepJudgmentTraitConfig(**trait_config)
+            return custom_config.question_specific[question_id][trait.name]
 
         # Fall back to global
-        if "global" in config_dict and trait.name in config_dict["global"]:
-            trait_config = config_dict["global"][trait.name]
-            # Validate dict against model
-            return DeepJudgmentTraitConfig(**trait_config)
+        if trait.name in custom_config.global_traits:
+            return custom_config.global_traits[trait.name]
 
         # No config found, disabled
         return DeepJudgmentTraitConfig(enabled=False)

--- a/src/karenina/cli/interactive.py
+++ b/src/karenina/cli/interactive.py
@@ -387,10 +387,13 @@ def _configure_deep_judgment_rubric(rubric_enabled: bool) -> dict[str, Any]:
         import json
         from pathlib import Path
 
+        from karenina.schemas.verification.config import DeepJudgmentRubricCustomConfig
+
         try:
             config_path = Path(config_path_str)
             with open(config_path) as f:
-                result["config"] = json.load(f)
+                raw_dict = json.load(f)
+            result["config"] = DeepJudgmentRubricCustomConfig.model_validate(raw_dict)
             console.print(f"[green]✓ Loaded custom config from {config_path}[/green]")
         except Exception as e:
             cli_error(f"loading config: {e}", e)

--- a/src/karenina/cli/verify_config.py
+++ b/src/karenina/cli/verify_config.py
@@ -93,13 +93,16 @@ def build_config_from_cli_args(
         VerificationConfig with CLI overrides applied
     """
     # CLI-specific: load custom rubric config JSON if a file path was provided
-    rubric_config_dict = None
+    rubric_config_obj = None
     if deep_judgment_rubric_config is not None:
         import json
 
+        from karenina.schemas.verification.config import DeepJudgmentRubricCustomConfig
+
         try:
             with open(deep_judgment_rubric_config) as f:
-                rubric_config_dict = json.load(f)
+                raw_dict = json.load(f)
+            rubric_config_obj = DeepJudgmentRubricCustomConfig.model_validate(raw_dict)
         except (FileNotFoundError, json.JSONDecodeError, ValueError) as e:
             raise ValueError(f"Failed to load custom rubric config from {deep_judgment_rubric_config}: {e}") from e
 
@@ -145,7 +148,7 @@ def build_config_from_cli_args(
         deep_judgment_rubric_retry_attempts=deep_judgment_rubric_retry_attempts,
         deep_judgment_rubric_search=deep_judgment_rubric_search,
         deep_judgment_rubric_search_tool=deep_judgment_rubric_search_tool,
-        deep_judgment_rubric_config=rubric_config_dict,
+        deep_judgment_rubric_config=rubric_config_obj,
     )
 
 

--- a/src/karenina/integrations/gepa/scoring.py
+++ b/src/karenina/integrations/gepa/scoring.py
@@ -67,21 +67,22 @@ def compute_objective_scores(
 
             if isinstance(trait_result, bool):
                 raw_score = 1.0 if trait_result else 0.0
-                # Invert for lower-is-better traits
-                score = raw_score if higher_is_better else 1.0 - raw_score
+                # Invert only when explicitly lower-is-better (None treated as True)
+                score = raw_score if higher_is_better is not False else 1.0 - raw_score
                 objectives[f"{model_name}:{trait_name}"] = score
 
             elif isinstance(trait_result, int | float):
                 # Normalize using trait's max_score, defaulting to 5 for backwards compatibility
                 max_score = trait_max_scores.get(trait_name, 5)
                 raw_score = float(trait_result) / float(max_score)
-                # Invert for lower-is-better traits
-                score = raw_score if higher_is_better else 1.0 - raw_score
+                # Invert only when explicitly lower-is-better (None treated as True)
+                score = raw_score if higher_is_better is not False else 1.0 - raw_score
                 objectives[f"{model_name}:{trait_name}"] = score
 
             elif isinstance(trait_result, dict):
-                # Metric trait - expand based on metric_config
-                # Note: Metric traits (precision/recall/F1) are inherently higher-is-better
+                # Metric trait: expand based on metric_config.
+                # MetricRubricTrait.higher_is_better defaults to None (directionality
+                # not applicable), so no score inversion is performed here.
                 enabled_metrics = config.metric_config.get_enabled_metrics()
                 for metric_name in enabled_metrics:
                     if metric_name in trait_result:

--- a/src/karenina/schemas/entities/rubric.py
+++ b/src/karenina/schemas/entities/rubric.py
@@ -844,6 +844,49 @@ class Rubric(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    @classmethod
+    def from_traits(
+        cls,
+        traits: list[LLMRubricTrait | RegexRubricTrait | CallableRubricTrait | MetricRubricTrait | AgenticRubricTrait]
+        | None,
+    ) -> "Rubric | None":
+        """Create a Rubric from a flat list of traits, categorizing by type.
+
+        Args:
+            traits: Flat list of trait objects. If None, returns None.
+
+        Returns:
+            Rubric with traits sorted into typed lists, or None if input is None.
+        """
+        if traits is None:
+            return None
+
+        llm_traits: list[LLMRubricTrait] = []
+        regex_traits: list[RegexRubricTrait] = []
+        callable_traits: list[CallableRubricTrait] = []
+        metric_traits: list[MetricRubricTrait] = []
+        agentic_traits: list[AgenticRubricTrait] = []
+
+        for trait in traits:
+            if isinstance(trait, LLMRubricTrait):
+                llm_traits.append(trait)
+            elif isinstance(trait, RegexRubricTrait):
+                regex_traits.append(trait)
+            elif isinstance(trait, CallableRubricTrait):
+                callable_traits.append(trait)
+            elif isinstance(trait, MetricRubricTrait):
+                metric_traits.append(trait)
+            elif isinstance(trait, AgenticRubricTrait):
+                agentic_traits.append(trait)
+
+        return cls(
+            llm_traits=llm_traits,
+            regex_traits=regex_traits,
+            callable_traits=callable_traits,
+            metric_traits=metric_traits,
+            agentic_traits=agentic_traits,
+        )
+
     @model_validator(mode="after")
     def validate_trait_names(self) -> "Rubric":
         """Reject duplicate trait names (within and across types) and dots in agentic names.

--- a/src/karenina/schemas/entities/rubric.py
+++ b/src/karenina/schemas/entities/rubric.py
@@ -88,12 +88,13 @@ class LLMRubricTrait(BaseModel):
     )
 
     # Directionality field
-    higher_is_better: bool = Field(
-        ...,
+    higher_is_better: bool | None = Field(
+        default=True,
         description="Whether higher values indicate better performance. "
         "For boolean: True means True is good. "
         "For score: True means higher scores are better. "
-        "For literal: True means higher indices (later classes) are better.",
+        "For literal: True means higher indices (later classes) are better. "
+        "None means directionality does not apply.",
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -125,7 +126,7 @@ class LLMRubricTrait(BaseModel):
     @classmethod
     def set_legacy_defaults(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Set default for higher_is_better when loading legacy data."""
-        if isinstance(values, dict) and ("higher_is_better" not in values or values.get("higher_is_better") is None):
+        if isinstance(values, dict) and "higher_is_better" not in values:
             values["higher_is_better"] = True
         return values
 
@@ -195,9 +196,11 @@ class RegexRubricTrait(BaseModel):
     invert_result: bool = Field(False, description="Whether to invert the boolean result (for negative matching)")
 
     # Directionality field
-    higher_is_better: bool = Field(
-        ...,
-        description="Whether a regex match indicates a positive outcome. True: match = good. False: match = bad.",
+    higher_is_better: bool | None = Field(
+        default=True,
+        description="Whether a regex match indicates a positive outcome. "
+        "True: match = good. False: match = bad. "
+        "None means directionality does not apply.",
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -206,7 +209,7 @@ class RegexRubricTrait(BaseModel):
     @classmethod
     def set_legacy_defaults(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Set default for higher_is_better when loading legacy data."""
-        if isinstance(values, dict) and ("higher_is_better" not in values or values.get("higher_is_better") is None):
+        if isinstance(values, dict) and "higher_is_better" not in values:
             values["higher_is_better"] = True
         return values
 
@@ -300,10 +303,11 @@ class CallableRubricTrait(BaseModel):
     )
 
     # Directionality field
-    higher_is_better: bool = Field(
-        ...,
+    higher_is_better: bool | None = Field(
+        default=True,
         description="Whether higher return values indicate better performance. "
-        "True: high value = good. False: high value = bad.",
+        "True: high value = good. False: high value = bad. "
+        "None means directionality does not apply.",
     )
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
@@ -325,7 +329,7 @@ class CallableRubricTrait(BaseModel):
     def set_legacy_defaults(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Set defaults for higher_is_better and validate literal kind requires classes."""
         if isinstance(values, dict):
-            if "higher_is_better" not in values or values.get("higher_is_better") is None:
+            if "higher_is_better" not in values:
                 values["higher_is_better"] = True
 
             # Literal kind requires classes
@@ -574,6 +578,13 @@ class MetricRubricTrait(BaseModel):
         True, description="Whether to deduplicate repeated excerpts/instructions (case-insensitive exact match)"
     )
 
+    # Directionality field
+    higher_is_better: bool | None = Field(
+        default=None,
+        description="Whether higher metric values indicate better performance. "
+        "None means directionality does not apply (default for metrics).",
+    )
+
     model_config = ConfigDict(extra="forbid")
 
     @field_validator("metrics")
@@ -738,7 +749,7 @@ class AgenticRubricTrait(BaseModel):
         # Template kind: do not inject legacy default
         if not isinstance(kind, str):
             return values
-        if "higher_is_better" not in values or values.get("higher_is_better") is None:
+        if "higher_is_better" not in values:
             values["higher_is_better"] = True
         return values
 
@@ -937,15 +948,12 @@ class Rubric(BaseModel):
         return max_scores
 
     def get_trait_directionalities(self) -> dict[str, bool | None]:
-        """Get higher_is_better for LLM, regex, callable, and agentic traits.
-
-        Note: MetricRubricTraits are excluded as metrics (precision/recall/F1)
-        are inherently 'higher is better'.
+        """Get higher_is_better for all trait types.
 
         Returns:
-            Dict mapping trait name to higher_is_better value. Template kind
-            agentic traits map to None because directionality is not meaningful
-            for structured results.
+            Dict mapping trait name to higher_is_better value. None means
+            directionality does not apply (e.g., template kind agentic traits
+            or metric traits where it was not explicitly set).
         """
         directionalities: dict[str, bool | None] = {}
 
@@ -961,10 +969,13 @@ class Rubric(BaseModel):
         for callable_trait in self.callable_traits:
             directionalities[callable_trait.name] = callable_trait.higher_is_better
 
+        metric_trait: MetricRubricTrait
+        for metric_trait in self.metric_traits:
+            directionalities[metric_trait.name] = metric_trait.higher_is_better
+
         for agentic_trait in self.agentic_traits:
             directionalities[agentic_trait.name] = agentic_trait.higher_is_better
 
-        # MetricRubricTraits always have higher_is_better=True (implicit)
         return directionalities
 
     def validate_evaluation(self, evaluation: dict[str, int | bool]) -> bool:

--- a/src/karenina/schemas/results/judgment.py
+++ b/src/karenina/schemas/results/judgment.py
@@ -7,7 +7,7 @@ including excerpt extraction, reasoning traces, and hallucination risk assessmen
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -582,21 +582,44 @@ class JudgmentResults(BaseModel):
 
         return {qid: JudgmentResults(results=results) for qid, results in grouped.items()}
 
-    def group_by_model(self) -> dict[str, JudgmentResults]:
-        """
-        Group results by answering model.
+    def group_by_model(self, by: Literal["answering", "parsing", "both"] = "answering") -> dict[str, JudgmentResults]:
+        """Group results by model(s).
+
+        Args:
+            by: How to group results:
+                - "answering": Group by answering model (includes MCP servers if attached)
+                - "parsing": Group by parsing model
+                - "both": Group by both answering and parsing models
 
         Returns:
-            Dictionary mapping model names to JudgmentResults instances
+            Dictionary mapping model identifier(s) to JudgmentResults instances.
         """
         grouped: dict[str, list[VerificationResult]] = {}
         for result in self.results:
-            model = result.metadata.answering_model
-            if model not in grouped:
-                grouped[model] = []
-            grouped[model].append(result)
+            answering_model = result.metadata.answering_model
+            parsing_model = result.metadata.parsing_model
 
-        return {model: JudgmentResults(results=results) for model, results in grouped.items()}
+            if by in ("answering", "both"):
+                mcp_servers = result.template.answering_mcp_servers if result.template else None
+                if mcp_servers and len(mcp_servers) > 0:
+                    answering_key = f"{answering_model} + MCP[{','.join(sorted(mcp_servers))}]"
+                else:
+                    answering_key = answering_model
+
+            if by == "answering":
+                key = answering_key
+            elif by == "parsing":
+                key = parsing_model
+            elif by == "both":
+                key = f"{answering_key} / {parsing_model}"
+            else:
+                raise ValueError(f"Invalid grouping mode: {by}. Must be 'answering', 'parsing', or 'both'")
+
+            if key not in grouped:
+                grouped[key] = []
+            grouped[key].append(result)
+
+        return {key: JudgmentResults(results=results) for key, results in grouped.items()}
 
     # ========================================================================
     # Summary Statistics

--- a/src/karenina/schemas/results/rubric.py
+++ b/src/karenina/schemas/results/rubric.py
@@ -630,21 +630,44 @@ class RubricResults(BaseModel):
 
         return {qid: RubricResults(results=results) for qid, results in grouped.items()}
 
-    def group_by_model(self) -> dict[str, RubricResults]:
-        """
-        Group results by answering model.
+    def group_by_model(self, by: Literal["answering", "parsing", "both"] = "answering") -> dict[str, RubricResults]:
+        """Group results by model(s).
+
+        Args:
+            by: How to group results:
+                - "answering": Group by answering model (includes MCP servers if attached)
+                - "parsing": Group by parsing model
+                - "both": Group by both answering and parsing models
 
         Returns:
-            Dictionary mapping model names to RubricResults instances
+            Dictionary mapping model identifier(s) to RubricResults instances.
         """
         grouped: dict[str, list[VerificationResult]] = {}
         for result in self.results:
-            model = result.metadata.answering_model
-            if model not in grouped:
-                grouped[model] = []
-            grouped[model].append(result)
+            answering_model = result.metadata.answering_model
+            parsing_model = result.metadata.parsing_model
 
-        return {model: RubricResults(results=results) for model, results in grouped.items()}
+            if by in ("answering", "both"):
+                mcp_servers = result.template.answering_mcp_servers if result.template else None
+                if mcp_servers and len(mcp_servers) > 0:
+                    answering_key = f"{answering_model} + MCP[{','.join(sorted(mcp_servers))}]"
+                else:
+                    answering_key = answering_model
+
+            if by == "answering":
+                key = answering_key
+            elif by == "parsing":
+                key = parsing_model
+            elif by == "both":
+                key = f"{answering_key} / {parsing_model}"
+            else:
+                raise ValueError(f"Invalid grouping mode: {by}. Must be 'answering', 'parsing', or 'both'")
+
+            if key not in grouped:
+                grouped[key] = []
+            grouped[key].append(result)
+
+        return {key: RubricResults(results=results) for key, results in grouped.items()}
 
     # ========================================================================
     # Summary Statistics

--- a/src/karenina/schemas/results/template.py
+++ b/src/karenina/schemas/results/template.py
@@ -7,7 +7,7 @@ including embedding checks, regex validation, abstention detection, and MCP metr
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -645,21 +645,44 @@ class TemplateResults(BaseModel):
 
         return {qid: TemplateResults(results=results) for qid, results in grouped.items()}
 
-    def group_by_model(self) -> dict[str, TemplateResults]:
-        """
-        Group results by answering model.
+    def group_by_model(self, by: Literal["answering", "parsing", "both"] = "answering") -> dict[str, TemplateResults]:
+        """Group results by model(s).
+
+        Args:
+            by: How to group results:
+                - "answering": Group by answering model (includes MCP servers if attached)
+                - "parsing": Group by parsing model
+                - "both": Group by both answering and parsing models
 
         Returns:
-            Dictionary mapping model names to TemplateResults instances
+            Dictionary mapping model identifier(s) to TemplateResults instances.
         """
         grouped: dict[str, list[VerificationResult]] = {}
         for result in self.results:
-            model = result.metadata.answering_model
-            if model not in grouped:
-                grouped[model] = []
-            grouped[model].append(result)
+            answering_model = result.metadata.answering_model
+            parsing_model = result.metadata.parsing_model
 
-        return {model: TemplateResults(results=results) for model, results in grouped.items()}
+            if by in ("answering", "both"):
+                mcp_servers = result.template.answering_mcp_servers if result.template else None
+                if mcp_servers and len(mcp_servers) > 0:
+                    answering_key = f"{answering_model} + MCP[{','.join(sorted(mcp_servers))}]"
+                else:
+                    answering_key = answering_model
+
+            if by == "answering":
+                key = answering_key
+            elif by == "parsing":
+                key = parsing_model
+            elif by == "both":
+                key = f"{answering_key} / {parsing_model}"
+            else:
+                raise ValueError(f"Invalid grouping mode: {by}. Must be 'answering', 'parsing', or 'both'")
+
+            if key not in grouped:
+                grouped[key] = []
+            grouped[key].append(result)
+
+        return {key: TemplateResults(results=results) for key, results in grouped.items()}
 
     # ========================================================================
     # Summary Statistics

--- a/src/karenina/schemas/results/verification_result_set.py
+++ b/src/karenina/schemas/results/verification_result_set.py
@@ -401,12 +401,15 @@ class VerificationResultSet(BaseModel):
 
         return {key: VerificationResultSet(results=results) for key, results in grouped.items()}
 
-    def group_by_replicate(self) -> dict[int, VerificationResultSet]:
-        """
-        Group results by replicate number.
+    def group_by_replicate(self) -> dict[int | None, VerificationResultSet]:
+        """Group results by replicate number.
+
+        Results with ``replicate=None`` are grouped under the ``None`` key
+        rather than being coerced to ``0``.
 
         Returns:
-            Dictionary mapping replicate numbers to VerificationResultSet instances
+            Dictionary mapping replicate numbers (or None) to
+            VerificationResultSet instances.
 
         Example:
             ```python
@@ -415,9 +418,9 @@ class VerificationResultSet(BaseModel):
                 print(f"Replicate {rep_num}: {len(rep_results)} results")
             ```
         """
-        grouped: dict[int, list[VerificationResult]] = {}
+        grouped: dict[int | None, list[VerificationResult]] = {}
         for result in self.results:
-            rep = result.metadata.replicate or 0
+            rep = result.metadata.replicate
             if rep not in grouped:
                 grouped[rep] = []
             grouped[rep].append(result)
@@ -1197,187 +1200,14 @@ class VerificationResultSet(BaseModel):
         return self.results[index]
 
     def __repr__(self) -> str:
-        """
-        Enhanced string representation with detailed statistics.
+        """Lightweight string representation showing result count.
 
-        Fetches comprehensive data from get_summary() and formats it for display.
-        Shows overview, completion status, evaluation types, template pass rates,
-        and replicate statistics.
+        For detailed statistics, use ``get_summary()`` directly.
         """
-        if not self.results:
+        n = len(self.results)
+        if n == 0:
             return "VerificationResultSet(empty)"
-
-        # Helper function to format time
-        def format_time(seconds: float) -> str:
-            """Format seconds as H:M:S, omitting hours/minutes if zero."""
-            hours = int(seconds // 3600)
-            minutes = int((seconds % 3600) // 60)
-            secs = seconds % 60
-
-            if hours > 0:
-                return f"{hours}h {minutes}m {secs:.1f}s"
-            elif minutes > 0:
-                return f"{minutes}m {secs:.1f}s"
-            else:
-                return f"{secs:.1f}s"
-
-        # Helper function to format token counts with dot separators
-        def format_tokens(count: int) -> str:
-            """Format token count with dot separators (thousands)."""
-            return f"{count:,}".replace(",", ".")
-
-        # Get comprehensive summary
-        summary = self.get_summary()
-
-        lines = ["VerificationResultSet("]
-
-        # === OVERVIEW ===
-        lines.append("  === OVERVIEW ===")
-        lines.append(f"  Total Results: {summary['num_results']}")
-        lines.append(f"  Questions: {summary['num_questions']}")
-        lines.append(f"  Models: {summary['num_models']} answering x {summary['num_parsing_models']} parsing")
-
-        if summary["num_replicates"] > 0:
-            lines.append(f"  Replicates: {summary['num_replicates']}")
-
-        if summary["total_execution_time"] > 0:
-            lines.append(f"  Total Execution Time: {format_time(summary['total_execution_time'])}")
-
-        # Token usage breakdown
-        tokens = summary["tokens"]
-        if tokens["total_input"] > 0 or tokens["total_output"] > 0:
-            lines.append(
-                f"  Total Tokens: {format_tokens(tokens['total_input'])} input, "
-                f"{format_tokens(tokens['total_output'])} output"
-            )
-
-            if tokens["template_input"] > 0 or tokens["template_output"] > 0:
-                lines.append(
-                    f"    └─ Templates: {format_tokens(tokens['template_input'])} input, "
-                    f"{format_tokens(tokens['template_output'])} output"
-                )
-
-            if tokens["rubric_input"] > 0 or tokens["rubric_output"] > 0:
-                lines.append(
-                    f"    └─ Rubrics: {format_tokens(tokens['rubric_input'])} input, "
-                    f"{format_tokens(tokens['rubric_output'])} output"
-                )
-
-        # === COMPLETION STATUS ===
-        lines.append("")
-        lines.append("  === COMPLETION STATUS ===")
-        lines.append("  By Model Combination:")
-
-        for combo_key, stats in sorted(summary["completion_by_combo"].items()):
-            answering, parsing, mcp_key = combo_key
-            # Format MCP suffix
-            mcp_suffix = f" + {', '.join(mcp_key)}" if mcp_key else ""
-
-            combo_str = f"{answering} / {parsing}{mcp_suffix}"
-            lines.append(
-                f"    {combo_str:40} {stats['completed']}/{stats['total']} completed ({stats['completion_pct']:.1f}%)"
-            )
-
-        lines.append(
-            f"  Overall: {summary['num_completed']}/{summary['num_results']} "
-            f"completed ({(summary['num_completed'] / summary['num_results'] * 100) if summary['num_results'] > 0 else 0:.1f}%)"
-        )
-
-        # === EVALUATION TYPES ===
-        lines.append("")
-        lines.append("  === EVALUATION TYPES ===")
-
-        if summary["num_with_template"] > 0:
-            lines.append(f"  Template Verification: {summary['num_with_template']} results")
-
-        if summary["num_with_rubric"] > 0 and summary["rubric_traits"]:
-            traits = summary["rubric_traits"]
-            lines.append(f"  Rubric Evaluation: {summary['num_with_rubric']} results")
-
-            # Global traits breakdown
-            global_traits = traits.get("global_traits", {})
-            global_llm = global_traits.get("llm", {}).get("count", 0)
-            global_regex = global_traits.get("regex", {}).get("count", 0)
-            global_callable = global_traits.get("callable", {}).get("count", 0)
-            global_metric = global_traits.get("metric", {}).get("count", 0)
-            global_total = global_llm + global_regex + global_callable + global_metric
-
-            if global_total > 0:
-                lines.append(f"    Global: {global_total}")
-                breakdown = []
-                if global_llm > 0:
-                    breakdown.append(f"LLM: {global_llm}")
-                if global_regex > 0:
-                    breakdown.append(f"Regex: {global_regex}")
-                if global_callable > 0:
-                    breakdown.append(f"Callable: {global_callable}")
-                if global_metric > 0:
-                    breakdown.append(f"Metric: {global_metric}")
-                if breakdown:
-                    lines.append(f"      └─ {', '.join(breakdown)}")
-
-            # Question-specific traits breakdown
-            qs_traits = traits.get("question_specific_traits", {})
-            qs_llm = qs_traits.get("llm", {}).get("count", 0)
-            qs_regex = qs_traits.get("regex", {}).get("count", 0)
-            qs_callable = qs_traits.get("callable", {}).get("count", 0)
-            qs_metric = qs_traits.get("metric", {}).get("count", 0)
-            qs_total = qs_llm + qs_regex + qs_callable + qs_metric
-
-            if qs_total > 0:
-                lines.append(f"    Question-Specific: {qs_total}")
-                breakdown = []
-                if qs_llm > 0:
-                    breakdown.append(f"LLM: {qs_llm}")
-                if qs_regex > 0:
-                    breakdown.append(f"Regex: {qs_regex}")
-                if qs_callable > 0:
-                    breakdown.append(f"Callable: {qs_callable}")
-                if qs_metric > 0:
-                    breakdown.append(f"Metric: {qs_metric}")
-                if breakdown:
-                    lines.append(f"      └─ {', '.join(breakdown)}")
-
-        if summary["num_with_judgment"] > 0:
-            lines.append(f"  Deep Judgment: {summary['num_with_judgment']} results")
-
-        # === TEMPLATE PASS RATES ===
-        if summary["template_pass_by_combo"]:
-            lines.append("")
-            lines.append("  === TEMPLATE PASS RATES ===")
-            lines.append("  By Model Combination (+ MCP if used):")
-
-            for combo_key, stats in sorted(summary["template_pass_by_combo"].items()):
-                answering, parsing, mcp_key = combo_key
-                mcp_suffix = f" + {', '.join(mcp_key)}" if mcp_key else ""
-
-                combo_str = f"{answering} / {parsing}{mcp_suffix}"
-                lines.append(f"    {combo_str:40} {stats['passed']}/{stats['total']} passed ({stats['pass_pct']:.1f}%)")
-
-            if summary["template_pass_overall"]:
-                overall = summary["template_pass_overall"]
-                lines.append(f"  Overall: {overall['passed']}/{overall['total']} passed ({overall['pass_pct']:.1f}%)")
-
-        # === REPLICATE STATISTICS ===
-        replicate_stats = summary.get("replicate_stats")
-        if replicate_stats and replicate_stats.get("replicate_pass_rates"):
-            lines.append("")
-            lines.append("  === REPLICATE STATISTICS ===")
-            lines.append("  Template Pass Rate by Replicate:")
-
-            for rep_num in sorted(replicate_stats["replicate_pass_rates"].keys()):
-                stats = replicate_stats["replicate_pass_rates"][rep_num]
-                lines.append(
-                    f"    Replicate {rep_num}: {stats['passed']}/{stats['total']} passed ({stats['pass_pct']:.1f}%)"
-                )
-
-            if replicate_stats.get("replicate_summary"):
-                rep_sum = replicate_stats["replicate_summary"]
-                lines.append(f"  Summary: mean={rep_sum['mean']:.3f}, std={rep_sum['std']:.3f}")
-
-        lines.append(")")
-
-        return "\n".join(lines)
+        return f"VerificationResultSet({n} result{'s' if n != 1 else ''})"
 
     def __str__(self) -> str:
         """String representation (same as repr for developer-friendly output)."""

--- a/src/karenina/schemas/verification/__init__.py
+++ b/src/karenina/schemas/verification/__init__.py
@@ -24,6 +24,7 @@ from .config import (
     DEFAULT_EMBEDDING_THRESHOLD,
     DEFAULT_PARSING_SYSTEM_PROMPT,
     DEFAULT_RUBRIC_MAX_EXCERPTS,
+    DeepJudgmentRubricCustomConfig,
     DeepJudgmentTraitConfig,
     VerificationConfig,
 )
@@ -72,6 +73,7 @@ __all__ = [
     "DEFAULT_RUBRIC_MAX_EXCERPTS",
     # Configuration
     "VerificationConfig",
+    "DeepJudgmentRubricCustomConfig",
     "DeepJudgmentTraitConfig",
     "PromptConfig",
     # Preset utilities

--- a/src/karenina/schemas/verification/config.py
+++ b/src/karenina/schemas/verification/config.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
 
 from ..config.models import (
     FewShotConfig,
@@ -63,6 +63,15 @@ class DeepJudgmentTraitConfig(BaseModel):
     fuzzy_match_threshold: float | None = None
     excerpt_retry_attempts: int | None = None
     search_enabled: bool = False
+
+
+class DeepJudgmentRubricCustomConfig(BaseModel):
+    """Per-trait deep judgment configuration for custom mode."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    global_traits: dict[str, DeepJudgmentTraitConfig] = Field(default_factory=dict, alias="global")
+    question_specific: dict[str, dict[str, DeepJudgmentTraitConfig]] = Field(default_factory=dict)
 
 
 class VerificationConfig(BaseModel):
@@ -155,18 +164,7 @@ class VerificationConfig(BaseModel):
     # - "custom": Use per-trait configuration from deep_judgment_rubric_config
 
     deep_judgment_rubric_global_excerpts: bool = True  # For enable_all mode: enable/disable excerpts globally
-    deep_judgment_rubric_config: dict[str, Any] | None = None  # For custom mode: nested trait config
-    # Expected structure for custom mode:
-    # {
-    #   "global": {
-    #     "TraitName": {"enabled": True, "excerpt_enabled": True, ...}
-    #   },
-    #   "question_specific": {
-    #     "question-id": {
-    #       "TraitName": {"enabled": True, ...}
-    #     }
-    #   }
-    # }
+    deep_judgment_rubric_config: DeepJudgmentRubricCustomConfig | None = None  # For custom mode: per-trait config
 
     # Few-shot prompting settings
     few_shot_config: FewShotConfig | None = None  # New flexible configuration
@@ -239,6 +237,18 @@ class VerificationConfig(BaseModel):
 
     # Scenario execution settings
     scenario_turn_limit: int = Field(default=20, ge=1)  # Max turns before forced termination in scenario execution
+
+    @model_validator(mode="after")
+    def _validate_custom_mode_has_config(self) -> "VerificationConfig":
+        """Validate that custom mode has the required config.
+
+        Raises:
+            ValueError: If deep_judgment_rubric_mode is 'custom' but
+                deep_judgment_rubric_config is None.
+        """
+        if self.deep_judgment_rubric_mode == "custom" and self.deep_judgment_rubric_config is None:
+            raise ValueError("deep_judgment_rubric_config is required when deep_judgment_rubric_mode is 'custom'")
+        return self
 
     @field_validator("db_config", mode="before")
     @classmethod
@@ -532,8 +542,8 @@ class VerificationConfig(BaseModel):
             # Warning about sequential evaluation
             lines.append("    ⚠️  Deep judgment traits are ALWAYS evaluated sequentially (one-by-one)")
             if self.deep_judgment_rubric_mode == "custom" and self.deep_judgment_rubric_config:
-                global_traits = self.deep_judgment_rubric_config.get("global", {})
-                question_configs = self.deep_judgment_rubric_config.get("question_specific", {})
+                global_traits = self.deep_judgment_rubric_config.global_traits
+                question_configs = self.deep_judgment_rubric_config.question_specific
                 lines.append(f"    └─ {len(global_traits)} global traits, {len(question_configs)} question configs")
 
         # Abstention
@@ -678,7 +688,7 @@ class VerificationConfig(BaseModel):
         deep_judgment_rubric_retry_attempts: int | None = None,
         deep_judgment_rubric_search: bool | None = None,
         deep_judgment_rubric_search_tool: str | None = None,
-        deep_judgment_rubric_config: dict[str, Any] | None = None,
+        deep_judgment_rubric_config: DeepJudgmentRubricCustomConfig | dict[str, Any] | None = None,
     ) -> "VerificationConfig":
         """
         Create a VerificationConfig by applying overrides to an optional base config.

--- a/src/karenina/storage/rubric_serializer.py
+++ b/src/karenina/storage/rubric_serializer.py
@@ -165,6 +165,7 @@ def _deserialize_metric_trait(trait_data: dict[str, Any]) -> Any:
         tp_instructions=trait_data.get("tp_instructions", []),
         tn_instructions=trait_data.get("tn_instructions", []),
         repeated_extraction=trait_data.get("repeated_extraction", True),
+        higher_is_better=trait_data.get("higher_is_better"),
     )
 
 

--- a/src/karenina/utils/checkpoint_trait_converters.py
+++ b/src/karenina/utils/checkpoint_trait_converters.py
@@ -65,6 +65,7 @@ def _convert_metric_trait_to_rating(trait: MetricRubricTrait, rubric_type: str) 
         SchemaOrgPropertyValue(name="metrics", value=trait.metrics),
         SchemaOrgPropertyValue(name="repeated_extraction", value=trait.repeated_extraction),
         SchemaOrgPropertyValue(name="evaluation_mode", value=trait.evaluation_mode),
+        SchemaOrgPropertyValue(name="higher_is_better", value=trait.higher_is_better),
     ]
 
     # Add instruction lists (only if non-empty)
@@ -342,6 +343,7 @@ def _convert_rating_to_metric_trait(rating: SchemaOrgRating) -> MetricRubricTrai
     evaluation_mode: Literal["tp_only", "full_matrix"] = "tp_only"  # Default for backward compatibility
     tp_instructions = []
     tn_instructions = []
+    higher_is_better: bool | None = None  # Default for MetricRubricTrait
     summary: str | None = None
 
     if rating.additionalProperty:
@@ -366,6 +368,8 @@ def _convert_rating_to_metric_trait(rating: SchemaOrgRating) -> MetricRubricTrai
                     tn_instructions = json.loads(prop.value)
                 except (json.JSONDecodeError, TypeError):
                     tn_instructions = prop.value if isinstance(prop.value, list) else []
+            elif prop.name == "higher_is_better":
+                higher_is_better = prop.value
             elif prop.name == "summary":
                 summary = prop.value
 
@@ -378,6 +382,7 @@ def _convert_rating_to_metric_trait(rating: SchemaOrgRating) -> MetricRubricTrai
         tp_instructions=tp_instructions,
         tn_instructions=tn_instructions,
         repeated_extraction=repeated_extraction,
+        higher_is_better=higher_is_better,
     )
 
 

--- a/tests/unit/benchmark/core/test_results_store.py
+++ b/tests/unit/benchmark/core/test_results_store.py
@@ -1,0 +1,383 @@
+"""Tests for standalone ResultsStore.
+
+Tests cover:
+- Adding result sets with explicit or auto-generated run names
+- Querying results by run, question, and recency
+- Clearing results (all or filtered)
+- Summary and statistics generation
+- Export to dict and round-trip file I/O
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from karenina.benchmark.core.results_store import ResultsStore
+from karenina.schemas.results.verification_result_set import VerificationResultSet
+from karenina.schemas.verification import (
+    VerificationResult,
+    VerificationResultMetadata,
+    VerificationResultTemplate,
+)
+from karenina.schemas.verification.model_identity import ModelIdentity
+
+
+def _make_result(
+    question_id: str = "q1",
+    passed: bool = True,
+    execution_time: float = 1.0,
+) -> VerificationResult:
+    """Create a minimal VerificationResult for testing."""
+    timestamp = datetime.now().isoformat()
+    answering = ModelIdentity(interface="langchain", model_name="test-model")
+    parsing = ModelIdentity(interface="langchain", model_name="test-model")
+    result_id = VerificationResultMetadata.compute_result_id(
+        question_id=question_id,
+        answering=answering,
+        parsing=parsing,
+        timestamp=timestamp,
+    )
+    return VerificationResult(
+        metadata=VerificationResultMetadata(
+            question_id=question_id,
+            template_id="tpl_hash",
+            completed_without_errors=passed,
+            error=None if passed else "Test error",
+            question_text="Test question",
+            answering=answering,
+            parsing=parsing,
+            execution_time=execution_time,
+            timestamp=timestamp,
+            result_id=result_id,
+        ),
+        template=VerificationResultTemplate(
+            raw_llm_response="response",
+            parsed_llm_response={"value": "x"},
+            parsed_gt_response={"value": "x"},
+            verify_result=passed,
+            verify_granular_result={"value": passed},
+        ),
+    )
+
+
+def _make_result_set(results: list[VerificationResult]) -> VerificationResultSet:
+    """Create a VerificationResultSet from results."""
+    return VerificationResultSet(results=results)
+
+
+@pytest.mark.unit
+class TestResultsStoreAdd:
+    """Tests for adding result sets to the store."""
+
+    def test_add_with_run_name(self):
+        """Adding a result set with an explicit run name stores it under that key."""
+        store = ResultsStore()
+        rs = _make_result_set([_make_result("q1")])
+        store.add(rs, run_name="my_run")
+
+        assert "my_run" in store.get_all_runs()
+
+    def test_add_auto_generates_name(self):
+        """Adding without a run name generates a timestamped name."""
+        store = ResultsStore()
+        rs = _make_result_set([_make_result("q1")])
+        name = store.add(rs)
+
+        assert name.startswith("run_")
+        assert name in store.get_all_runs()
+
+    def test_add_returns_run_name(self):
+        """add() returns the run name used (explicit or generated)."""
+        store = ResultsStore()
+        rs = _make_result_set([_make_result("q1")])
+
+        explicit = store.add(rs, run_name="explicit")
+        assert explicit == "explicit"
+
+        auto = store.add(rs)
+        assert auto.startswith("run_")
+
+    def test_add_duplicate_run_name_raises(self):
+        """Adding with a run name that already exists raises ValueError."""
+        store = ResultsStore()
+        rs = _make_result_set([_make_result("q1")])
+        store.add(rs, run_name="dup")
+
+        with pytest.raises(ValueError, match="already exists"):
+            store.add(rs, run_name="dup")
+
+
+@pytest.mark.unit
+class TestResultsStoreQuery:
+    """Tests for querying results from the store."""
+
+    def test_get_by_run(self):
+        """get_by_run returns the VerificationResultSet for a given run."""
+        store = ResultsStore()
+        rs = _make_result_set([_make_result("q1"), _make_result("q2")])
+        store.add(rs, run_name="run_a")
+
+        fetched = store.get_by_run("run_a")
+        assert len(fetched.results) == 2
+
+    def test_get_by_run_missing_raises(self):
+        """get_by_run raises KeyError for a nonexistent run name."""
+        store = ResultsStore()
+
+        with pytest.raises(KeyError):
+            store.get_by_run("no_such_run")
+
+    def test_get_by_question(self):
+        """get_by_question collects results across runs for one question."""
+        store = ResultsStore()
+        store.add(
+            _make_result_set([_make_result("q1"), _make_result("q2")]),
+            run_name="run_a",
+        )
+        store.add(
+            _make_result_set([_make_result("q1"), _make_result("q3")]),
+            run_name="run_b",
+        )
+
+        by_q1 = store.get_by_question("q1")
+        assert "run_a" in by_q1
+        assert "run_b" in by_q1
+        assert len(by_q1["run_a"]) == 1
+        assert len(by_q1["run_b"]) == 1
+
+    def test_get_by_question_no_matches(self):
+        """get_by_question returns empty dict when question is not found."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="run_a")
+
+        assert store.get_by_question("nonexistent") == {}
+
+    def test_get_latest(self):
+        """get_latest returns the most recent result per question."""
+        store = ResultsStore()
+        r1 = _make_result("q1")
+        r2 = _make_result("q1")
+        store.add(_make_result_set([r1]), run_name="run_old")
+        store.add(_make_result_set([r2]), run_name="run_new")
+
+        latest = store.get_latest()
+        # Should contain q1 from the latest run (run_new)
+        assert "q1" in latest
+        assert latest["q1"] is r2
+
+    def test_get_latest_with_question_filter(self):
+        """get_latest with question_id filters to that question only."""
+        store = ResultsStore()
+        store.add(
+            _make_result_set([_make_result("q1"), _make_result("q2")]),
+            run_name="run_a",
+        )
+
+        latest = store.get_latest(question_id="q2")
+        assert "q2" in latest
+        assert "q1" not in latest
+
+    def test_get_latest_empty_store(self):
+        """get_latest on empty store returns empty dict."""
+        store = ResultsStore()
+        assert store.get_latest() == {}
+
+    def test_has_results_empty(self):
+        """has_results returns False on empty store."""
+        store = ResultsStore()
+        assert store.has_results() is False
+
+    def test_has_results_with_data(self):
+        """has_results returns True when results exist."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="r")
+        assert store.has_results() is True
+
+    def test_has_results_by_question(self):
+        """has_results filters by question_id."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="r")
+        assert store.has_results(question_id="q1") is True
+        assert store.has_results(question_id="q99") is False
+
+    def test_has_results_by_run(self):
+        """has_results filters by run_name."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="r")
+        assert store.has_results(run_name="r") is True
+        assert store.has_results(run_name="no_run") is False
+
+    def test_get_all_runs_ordered(self):
+        """get_all_runs returns run names in insertion order."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="alpha")
+        store.add(_make_result_set([_make_result("q1")]), run_name="beta")
+        store.add(_make_result_set([_make_result("q1")]), run_name="gamma")
+
+        assert store.get_all_runs() == ["alpha", "beta", "gamma"]
+
+
+@pytest.mark.unit
+class TestResultsStoreClear:
+    """Tests for clearing results from the store."""
+
+    def test_clear_all(self):
+        """clear() with no args removes all runs."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="r1")
+        store.add(_make_result_set([_make_result("q2")]), run_name="r2")
+
+        cleared = store.clear()
+        assert cleared == 2  # two result objects total
+        assert store.get_all_runs() == []
+
+    def test_clear_by_run(self):
+        """clear(run_name=...) removes only that run."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="keep")
+        store.add(_make_result_set([_make_result("q2")]), run_name="remove")
+
+        cleared = store.clear(run_name="remove")
+        assert cleared == 1
+        assert store.get_all_runs() == ["keep"]
+
+    def test_clear_by_question_ids(self):
+        """clear(question_ids=...) removes matching results from all runs."""
+        store = ResultsStore()
+        store.add(
+            _make_result_set([_make_result("q1"), _make_result("q2")]),
+            run_name="r1",
+        )
+
+        cleared = store.clear(question_ids=["q1"])
+        assert cleared == 1
+
+        # q2 should remain in r1
+        remaining = store.get_by_run("r1")
+        assert len(remaining.results) == 1
+        assert remaining.results[0].metadata.question_id == "q2"
+
+    def test_clear_by_question_removes_empty_run(self):
+        """Clearing all questions from a run removes the run entry entirely."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="r1")
+
+        store.clear(question_ids=["q1"])
+        assert "r1" not in store.get_all_runs()
+
+    def test_clear_nonexistent_run(self):
+        """Clearing a nonexistent run returns 0."""
+        store = ResultsStore()
+        assert store.clear(run_name="nope") == 0
+
+
+@pytest.mark.unit
+class TestResultsStoreSummary:
+    """Tests for summary and statistics methods."""
+
+    def test_get_summary_empty(self):
+        """get_summary on empty store returns zeros."""
+        store = ResultsStore()
+        summary = store.get_summary()
+        assert summary["total_results"] == 0
+        assert summary["total_runs"] == 0
+
+    def test_get_summary_with_data(self):
+        """get_summary returns correct aggregate counts."""
+        store = ResultsStore()
+        store.add(
+            _make_result_set(
+                [
+                    _make_result("q1", passed=True),
+                    _make_result("q2", passed=False),
+                ]
+            ),
+            run_name="r1",
+        )
+        store.add(
+            _make_result_set([_make_result("q1", passed=True)]),
+            run_name="r2",
+        )
+
+        summary = store.get_summary()
+        assert summary["total_results"] == 3
+        assert summary["total_runs"] == 2
+        assert summary["unique_questions"] == 2
+
+    def test_get_summary_for_run(self):
+        """get_summary(run_name=...) scopes to that run."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="r1")
+        store.add(
+            _make_result_set([_make_result("q2"), _make_result("q3")]),
+            run_name="r2",
+        )
+
+        summary = store.get_summary(run_name="r2")
+        assert summary["total_results"] == 2
+        assert summary["total_runs"] == 1
+
+    def test_get_statistics_by_run(self):
+        """get_statistics_by_run returns per-run summaries."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="r1")
+        store.add(
+            _make_result_set([_make_result("q2"), _make_result("q3")]),
+            run_name="r2",
+        )
+
+        stats = store.get_statistics_by_run()
+        assert "r1" in stats
+        assert "r2" in stats
+        assert stats["r1"]["total_results"] == 1
+        assert stats["r2"]["total_results"] == 2
+
+    def test_export_returns_serializable(self):
+        """export() returns a JSON-serializable dict."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="r1")
+
+        exported = store.export()
+        # Must be serializable
+        json_str = json.dumps(exported)
+        assert isinstance(json.loads(json_str), dict)
+        assert "r1" in exported["runs"]
+
+    def test_export_filters_by_run(self):
+        """export(run_name=...) includes only that run."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="r1")
+        store.add(_make_result_set([_make_result("q2")]), run_name="r2")
+
+        exported = store.export(run_name="r1")
+        assert "r1" in exported["runs"]
+        assert "r2" not in exported["runs"]
+
+    def test_export_filters_by_question(self):
+        """export(question_ids=...) includes only matching results."""
+        store = ResultsStore()
+        store.add(
+            _make_result_set([_make_result("q1"), _make_result("q2")]),
+            run_name="r1",
+        )
+
+        exported = store.export(question_ids=["q1"])
+        results_in_r1 = exported["runs"]["r1"]
+        assert len(results_in_r1) == 1
+
+    def test_export_to_file_and_from_file_roundtrip(self, tmp_path: Path):
+        """export_to_file then from_file produces equivalent store."""
+        store = ResultsStore()
+        store.add(
+            _make_result_set([_make_result("q1"), _make_result("q2")]),
+            run_name="run_a",
+        )
+
+        file_path = tmp_path / "results.json"
+        store.export_to_file(file_path)
+
+        loaded = ResultsStore.from_file(file_path)
+        assert loaded.get_all_runs() == ["run_a"]
+        assert len(loaded.get_by_run("run_a").results) == 2

--- a/tests/unit/benchmark/core/test_rubric_manager_api.py
+++ b/tests/unit/benchmark/core/test_rubric_manager_api.py
@@ -1,0 +1,142 @@
+"""Tests for RubricManager API improvements."""
+
+import pytest
+
+from karenina.benchmark import Benchmark
+from karenina.schemas.entities.rubric import (
+    LLMRubricTrait,
+    RegexRubricTrait,
+    Rubric,
+)
+
+
+def _create_benchmark():
+    """Create a fresh Benchmark for testing."""
+    return Benchmark.create(name="test_rubric_api")
+
+
+def _create_benchmark_with_question():
+    """Create a Benchmark with one question."""
+    b = Benchmark.create(name="test_rubric_api")
+    b.add_question(question="What is 2+2?", raw_answer="4", question_id="q1")
+    return b, "q1"
+
+
+@pytest.mark.unit
+class TestRubricManagerSetGlobalRubric:
+    """Test set_global_rubric accepts both Rubric and list."""
+
+    def test_accepts_rubric_object(self):
+        """set_global_rubric should accept a Rubric object."""
+        b = _create_benchmark()
+        rubric = Rubric(
+            llm_traits=[LLMRubricTrait(name="t1", description="d1", kind="boolean")],
+            regex_traits=[RegexRubricTrait(name="t2", description="d2", pattern=r"\d+")],
+        )
+        b._rubric_manager.set_global_rubric(rubric)
+        result = b._rubric_manager.get_global_rubric()
+        assert result is not None
+        assert len(result.llm_traits) == 1
+        assert len(result.regex_traits) == 1
+
+    def test_accepts_trait_list(self):
+        """set_global_rubric should accept a flat list of traits."""
+        b = _create_benchmark()
+        traits = [
+            LLMRubricTrait(name="t1", description="d1", kind="boolean"),
+            RegexRubricTrait(name="t2", description="d2", pattern=r"\d+"),
+        ]
+        b._rubric_manager.set_global_rubric(traits)
+        result = b._rubric_manager.get_global_rubric()
+        assert result is not None
+        assert len(result.llm_traits) == 1
+        assert len(result.regex_traits) == 1
+
+
+@pytest.mark.unit
+class TestRubricManagerSetQuestionRubric:
+    """Test set_question_rubric on RubricManager."""
+
+    def test_set_question_rubric_with_rubric(self):
+        """set_question_rubric should accept a Rubric object."""
+        b, q_id = _create_benchmark_with_question()
+        rubric = Rubric(
+            llm_traits=[LLMRubricTrait(name="t1", description="d1", kind="boolean")],
+        )
+        b._rubric_manager.set_question_rubric(q_id, rubric)
+        raw = b._rubric_manager.get_question_rubric(q_id)
+        assert raw is not None
+        # get_question_rubric returns dict or list from cache
+        if isinstance(raw, dict):
+            all_traits = []
+            for v in raw.values():
+                if isinstance(v, list):
+                    all_traits.extend(v)
+            assert len(all_traits) == 1
+        else:
+            assert len(raw) == 1
+
+    def test_set_question_rubric_replaces_existing(self):
+        """set_question_rubric should clear existing then set new."""
+        b, q_id = _create_benchmark_with_question()
+        rubric1 = Rubric(
+            llm_traits=[LLMRubricTrait(name="t1", description="d1", kind="boolean")],
+        )
+        rubric2 = Rubric(
+            regex_traits=[RegexRubricTrait(name="t2", description="d2", pattern=r"\d+")],
+        )
+        b._rubric_manager.set_question_rubric(q_id, rubric1)
+        b._rubric_manager.set_question_rubric(q_id, rubric2)
+        raw = b._rubric_manager.get_question_rubric(q_id)
+        # Collect all traits from whatever format is returned
+        if isinstance(raw, dict):
+            all_traits = []
+            for v in raw.values():
+                if isinstance(v, list):
+                    all_traits.extend(v)
+        else:
+            all_traits = list(raw)
+        assert len(all_traits) == 1
+        assert all_traits[0].name == "t2"
+
+
+@pytest.mark.unit
+class TestRubricManagerRename:
+    """Test get_questions_with_rubric rename."""
+
+    def test_get_question_ids_with_rubric_exists(self):
+        """Renamed method should exist and return list[str]."""
+        b = _create_benchmark()
+        result = b._rubric_manager.get_question_ids_with_rubric()
+        assert isinstance(result, list)
+
+    def test_old_name_does_not_exist(self):
+        """Old method name should not exist."""
+        b = _create_benchmark()
+        assert not hasattr(b._rubric_manager, "get_questions_with_rubric")
+
+
+@pytest.mark.unit
+class TestValidateRubricsErrorShape:
+    """Test validate_rubrics returns dict-based errors."""
+
+    def test_returns_dict_errors(self):
+        """validate_rubrics errors should be list[dict[str, str]]."""
+        b, q_id = _create_benchmark_with_question()
+        # Inject a trait with empty description into the cache directly
+        # (bypasses Pydantic constructor validation)
+        bad_trait = LLMRubricTrait.model_construct(name="bad_trait", description="", kind="boolean")
+        b._questions_cache[q_id]["question_rubric"] = {
+            "llm_traits": [bad_trait],
+            "regex_traits": [],
+            "callable_traits": [],
+            "metric_traits": [],
+            "agentic_traits": [],
+        }
+        valid, errors = b._rubric_manager.validate_rubrics()
+        assert valid is False
+        assert len(errors) > 0
+        assert isinstance(errors[0], dict)
+        assert "source" in errors[0]
+        assert "error" in errors[0]
+        assert errors[0]["source"] == f"question:{q_id}"

--- a/tests/unit/benchmark/core/test_rubric_manager_api.py
+++ b/tests/unit/benchmark/core/test_rubric_manager_api.py
@@ -140,3 +140,38 @@ class TestValidateRubricsErrorShape:
         assert "source" in errors[0]
         assert "error" in errors[0]
         assert errors[0]["source"] == f"question:{q_id}"
+
+
+@pytest.mark.unit
+class TestFacadeGetQuestionRubric:
+    """Test get_question_rubric facade method."""
+
+    def test_returns_none_when_no_rubric(self):
+        """Facade should return None when no rubric is set."""
+        b, q_id = _create_benchmark_with_question()
+        assert b.get_question_rubric(q_id) is None
+
+    def test_returns_rubric_when_set(self):
+        """Facade should return a Rubric after one is set."""
+        b, q_id = _create_benchmark_with_question()
+        rubric = Rubric(llm_traits=[LLMRubricTrait(name="t", description="d", kind="boolean")])
+        b.set_question_rubric(q_id, rubric)
+        result = b.get_question_rubric(q_id)
+        assert isinstance(result, Rubric)
+        assert len(result.llm_traits) == 1
+
+    def test_handles_dict_format_from_cache(self):
+        """Facade should handle dict format stored in the questions cache."""
+        b, q_id = _create_benchmark_with_question()
+        # Simulate dict format that can appear from JSON-loaded data
+        b._questions_cache[q_id]["question_rubric"] = {
+            "llm_traits": [LLMRubricTrait(name="t1", description="d1", kind="boolean")],
+            "regex_traits": [RegexRubricTrait(name="t2", description="d2", pattern=r"\d+")],
+            "callable_traits": [],
+            "metric_traits": [],
+            "agentic_traits": [],
+        }
+        result = b.get_question_rubric(q_id)
+        assert isinstance(result, Rubric)
+        assert len(result.llm_traits) == 1
+        assert len(result.regex_traits) == 1

--- a/tests/unit/benchmark/core/test_rubrics.py
+++ b/tests/unit/benchmark/core/test_rubrics.py
@@ -557,15 +557,15 @@ class TestGetRubricStatistics:
 
 
 @pytest.mark.unit
-class TestGetQuestionsWithRubric:
-    """Tests for get_questions_with_rubric method."""
+class TestGetQuestionIdsWithRubric:
+    """Tests for get_question_ids_with_rubric method."""
 
     def test_get_questions_empty(self) -> None:
         """Test getting questions with rubrics from empty benchmark."""
         benchmark = Benchmark.create(name="test")
         manager = RubricManager(benchmark)
 
-        assert manager.get_questions_with_rubric() == []
+        assert manager.get_question_ids_with_rubric() == []
 
     def test_get_questions_with_rubrics(self) -> None:
         """Test getting list of question IDs with rubrics."""
@@ -583,7 +583,7 @@ class TestGetQuestionsWithRubric:
             q_id3, LLMRubricTrait(name="trait", description="Trait", kind="boolean", higher_is_better=True)
         )
 
-        questions = manager.get_questions_with_rubric()
+        questions = manager.get_question_ids_with_rubric()
         assert len(questions) == 2
         assert q_id1 in questions
         assert q_id3 in questions

--- a/tests/unit/benchmark/test_facade_api.py
+++ b/tests/unit/benchmark/test_facade_api.py
@@ -1,0 +1,107 @@
+"""Tests for facade API changes (deprecations)."""
+
+import warnings
+
+import pytest
+
+from karenina.benchmark import Benchmark
+
+
+def _create_benchmark():
+    return Benchmark.create(name="test_facade_api")
+
+
+@pytest.mark.unit
+class TestFacadeResultDeprecations:
+    """Test that facade result methods emit deprecation warnings."""
+
+    def test_store_verification_results_warns(self):
+        b = _create_benchmark()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            b.store_verification_results({})
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "ResultsStore" in str(w[0].message)
+
+    def test_get_verification_results_warns(self):
+        b = _create_benchmark()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            b.get_verification_results()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+    def test_get_verification_history_warns(self):
+        b = _create_benchmark()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            b.get_verification_history()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+    def test_clear_verification_results_warns(self):
+        b = _create_benchmark()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            b.clear_verification_results()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "ResultsStore" in str(w[0].message)
+
+    def test_export_verification_results_warns(self):
+        b = _create_benchmark()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            b.export_verification_results()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "ResultsStore" in str(w[0].message)
+
+    def test_export_verification_results_to_file_warns(self, tmp_path):
+        b = _create_benchmark()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            b.export_verification_results_to_file(tmp_path / "out.json")
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "ResultsStore" in str(w[0].message)
+
+    def test_load_verification_results_from_file_warns(self, tmp_path):
+        b = _create_benchmark()
+        # Create a minimal valid results file
+        results_file = tmp_path / "results.json"
+        results_file.write_text("{}")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            b.load_verification_results_from_file(results_file)
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "ResultsStore" in str(w[0].message)
+
+    def test_get_verification_summary_warns(self):
+        b = _create_benchmark()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            b.get_verification_summary()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "ResultsStore" in str(w[0].message)
+
+    def test_get_all_run_names_warns(self):
+        b = _create_benchmark()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            b.get_all_run_names()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "ResultsStore" in str(w[0].message)
+
+    def test_get_results_statistics_by_run_warns(self):
+        b = _create_benchmark()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            b.get_results_statistics_by_run()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "ResultsStore" in str(w[0].message)

--- a/tests/unit/schemas/entities/test_higher_is_better.py
+++ b/tests/unit/schemas/entities/test_higher_is_better.py
@@ -1,0 +1,166 @@
+"""Tests for higher_is_better unification across all trait types."""
+
+import cloudpickle
+import pytest
+
+from karenina.schemas.entities.rubric import (
+    AgenticRubricTrait,
+    CallableRubricTrait,
+    LLMRubricTrait,
+    MetricRubricTrait,
+    RegexRubricTrait,
+    Rubric,
+)
+
+
+def _make_callable_code() -> bytes:
+    """Create serialized callable code for test CallableRubricTraits."""
+    return cloudpickle.dumps(lambda _text: True)
+
+
+@pytest.mark.unit
+class TestHigherIsBetterUnification:
+    """Test that all trait types support higher_is_better: bool | None."""
+
+    def test_llm_trait_accepts_none(self):
+        """LLMRubricTrait should accept None for higher_is_better."""
+        trait = LLMRubricTrait(
+            name="test",
+            description="test trait",
+            kind="boolean",
+            higher_is_better=None,
+        )
+        assert trait.higher_is_better is None
+
+    def test_llm_trait_defaults_to_true(self):
+        """LLMRubricTrait should default to True when not specified."""
+        trait = LLMRubricTrait(name="test", description="test trait", kind="boolean")
+        assert trait.higher_is_better is True
+
+    def test_regex_trait_accepts_none(self):
+        """RegexRubricTrait should accept None for higher_is_better."""
+        trait = RegexRubricTrait(
+            name="test",
+            description="test trait",
+            pattern=r"\d+",
+            higher_is_better=None,
+        )
+        assert trait.higher_is_better is None
+
+    def test_regex_trait_defaults_to_true(self):
+        """RegexRubricTrait should default to True when not specified."""
+        trait = RegexRubricTrait(name="test", description="test trait", pattern=r"\d+")
+        assert trait.higher_is_better is True
+
+    def test_callable_trait_accepts_none(self):
+        """CallableRubricTrait should accept None for higher_is_better."""
+        trait = CallableRubricTrait(
+            name="test",
+            description="test trait",
+            callable_code=_make_callable_code(),
+            kind="boolean",
+            higher_is_better=None,
+        )
+        assert trait.higher_is_better is None
+
+    def test_callable_trait_defaults_to_true(self):
+        """CallableRubricTrait should default to True when not specified."""
+        trait = CallableRubricTrait(
+            name="test",
+            description="test trait",
+            callable_code=_make_callable_code(),
+            kind="boolean",
+        )
+        assert trait.higher_is_better is True
+
+    def test_agentic_trait_preserves_none(self):
+        """AgenticRubricTrait should preserve explicit None (not coerce to True)."""
+        trait = AgenticRubricTrait(
+            name="test",
+            description="test trait",
+            kind="boolean",
+            higher_is_better=None,
+        )
+        assert trait.higher_is_better is None
+
+    def test_metric_trait_has_higher_is_better(self):
+        """MetricRubricTrait should have higher_is_better field defaulting to None."""
+        trait = MetricRubricTrait(
+            name="test",
+            description="test trait",
+            metrics=["precision"],
+            tp_instructions=["check this"],
+        )
+        assert trait.higher_is_better is None
+
+    def test_metric_trait_accepts_true(self):
+        """MetricRubricTrait should accept True for higher_is_better."""
+        trait = MetricRubricTrait(
+            name="test",
+            description="test trait",
+            metrics=["precision"],
+            tp_instructions=["check this"],
+            higher_is_better=True,
+        )
+        assert trait.higher_is_better is True
+
+    def test_legacy_data_without_field_defaults_to_true(self):
+        """Legacy data missing higher_is_better should still get True."""
+        trait = LLMRubricTrait.model_validate({"name": "test", "description": "test", "kind": "boolean"})
+        assert trait.higher_is_better is True
+
+    def test_get_trait_directionalities_includes_metric(self):
+        """Rubric.get_trait_directionalities() should include metric traits."""
+        rubric = Rubric(
+            llm_traits=[
+                LLMRubricTrait(
+                    name="clarity",
+                    description="clear",
+                    kind="boolean",
+                    higher_is_better=True,
+                )
+            ],
+            metric_traits=[
+                MetricRubricTrait(
+                    name="precision",
+                    description="prec",
+                    metrics=["precision"],
+                    tp_instructions=["check this"],
+                )
+            ],
+        )
+        dirs = rubric.get_trait_directionalities()
+        assert "clarity" in dirs
+        assert dirs["clarity"] is True
+        assert "precision" in dirs
+        assert dirs["precision"] is None
+
+    def test_get_trait_directionalities_none_values(self):
+        """Traits with higher_is_better=None should appear as None in directionalities."""
+        rubric = Rubric(
+            llm_traits=[
+                LLMRubricTrait(
+                    name="word_count",
+                    description="wc",
+                    kind="boolean",
+                    higher_is_better=None,
+                )
+            ],
+        )
+        dirs = rubric.get_trait_directionalities()
+        assert dirs["word_count"] is None
+
+    def test_agentic_template_kind_still_none(self):
+        """AgenticRubricTrait with template kind should still have higher_is_better=None."""
+        from pydantic import BaseModel
+
+        class MyOutput(BaseModel):
+            result: str
+
+        trait = AgenticRubricTrait(
+            name="test",
+            description="test",
+            kind=MyOutput,
+            higher_is_better=None,
+        )
+        assert trait.higher_is_better is None

--- a/tests/unit/schemas/entities/test_higher_is_better.py
+++ b/tests/unit/schemas/entities/test_higher_is_better.py
@@ -164,3 +164,37 @@ class TestHigherIsBetterUnification:
             higher_is_better=None,
         )
         assert trait.higher_is_better is None
+
+
+@pytest.mark.unit
+class TestRubricFromTraits:
+    """Test Rubric.from_traits() factory method."""
+
+    def test_from_mixed_traits(self):
+        """from_traits should categorize a flat list into typed trait lists."""
+        llm = LLMRubricTrait(name="clarity", description="clear", kind="boolean")
+        regex = RegexRubricTrait(name="has_number", description="num", pattern=r"\d+")
+        metric = MetricRubricTrait(
+            name="precision", description="prec", metrics=["precision"], tp_instructions=["check this"]
+        )
+
+        rubric = Rubric.from_traits([llm, regex, metric])
+
+        assert len(rubric.llm_traits) == 1
+        assert rubric.llm_traits[0].name == "clarity"
+        assert len(rubric.regex_traits) == 1
+        assert rubric.regex_traits[0].name == "has_number"
+        assert len(rubric.metric_traits) == 1
+        assert rubric.metric_traits[0].name == "precision"
+        assert len(rubric.callable_traits) == 0
+        assert len(rubric.agentic_traits) == 0
+
+    def test_from_empty_traits(self):
+        """from_traits with empty list should produce empty Rubric."""
+        rubric = Rubric.from_traits([])
+        assert len(rubric.llm_traits) == 0
+        assert len(rubric.regex_traits) == 0
+
+    def test_from_none_returns_none(self):
+        """from_traits with None should return None."""
+        assert Rubric.from_traits(None) is None

--- a/tests/unit/schemas/test_answer_schemas.py
+++ b/tests/unit/schemas/test_answer_schemas.py
@@ -266,16 +266,25 @@ def test_llm_rubric_trait_deep_judgment_fields() -> None:
 
 @pytest.mark.unit
 def test_llm_rubric_trait_default_higher_is_better() -> None:
-    """Test that higher_is_better defaults to True when None or missing."""
-    trait = LLMRubricTrait.model_validate(
+    """Test that higher_is_better defaults to True when missing, preserves None."""
+    # Missing higher_is_better defaults to True (legacy compat)
+    trait_missing = LLMRubricTrait.model_validate(
+        {
+            "name": "test",
+            "kind": "boolean",
+        }
+    )
+    assert trait_missing.higher_is_better is True
+
+    # Explicit None is preserved (directionality does not apply)
+    trait_none = LLMRubricTrait.model_validate(
         {
             "name": "test",
             "kind": "boolean",
             "higher_is_better": None,
         }
     )
-
-    assert trait.higher_is_better is True
+    assert trait_none.higher_is_better is None
 
 
 @pytest.mark.unit

--- a/tests/unit/schemas/test_api_design_fixes.py
+++ b/tests/unit/schemas/test_api_design_fixes.py
@@ -1,0 +1,361 @@
+"""Tests for type improvements: repr, config, group_by_model, group_by_replicate."""
+
+import pytest
+from pydantic import ValidationError
+
+from karenina.schemas.results.verification_result_set import VerificationResultSet
+from karenina.schemas.verification.config import (
+    DeepJudgmentRubricCustomConfig,
+    DeepJudgmentTraitConfig,
+    VerificationConfig,
+)
+from karenina.schemas.verification.model_identity import ModelIdentity
+from karenina.schemas.verification.result import VerificationResult
+from karenina.schemas.verification.result_components import (
+    VerificationResultMetadata,
+    VerificationResultTemplate,
+)
+
+
+def _make_model_identity(model_name: str = "gpt-4") -> ModelIdentity:
+    """Create a ModelIdentity for testing."""
+    return ModelIdentity(interface="langchain", model_name=model_name)
+
+
+def _make_result(
+    question_id="q1",
+    answering_model="gpt-4",
+    parsing_model="gpt-4",
+    replicate=1,
+    mcp_servers=None,
+):
+    """Create a real VerificationResult for testing."""
+    metadata = VerificationResultMetadata(
+        question_id=question_id,
+        template_id="tmpl_test",
+        completed_without_errors=True,
+        question_text="Test question?",
+        answering=_make_model_identity(model_name=answering_model),
+        parsing=_make_model_identity(model_name=parsing_model),
+        execution_time=1.0,
+        timestamp="2026-01-01T00:00:00",
+        result_id="test_result_id",
+        replicate=replicate,
+    )
+    template = VerificationResultTemplate(
+        raw_llm_response="test response",
+        template_verification_performed=True,
+        verify_result=True,
+        answering_mcp_servers=mcp_servers,
+    )
+    return VerificationResult(metadata=metadata, template=template)
+
+
+def _make_minimal_config(**overrides):
+    """Create a minimal VerificationConfig with required fields."""
+    from karenina.schemas.config import ModelConfig
+
+    defaults = {
+        "answering_models": [],
+        "parsing_models": [
+            ModelConfig(
+                id="parsing",
+                model_name="gpt-4",
+                model_provider="openai",
+                interface="langchain",
+                system_prompt="test",
+                temperature=0.1,
+            )
+        ],
+        "parsing_only": True,
+    }
+    defaults.update(overrides)
+    return VerificationConfig(**defaults)
+
+
+# =============================================================================
+# Sub-task A: VerificationResultSet.__repr__
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestVerificationResultSetRepr:
+    """Tests for the simplified __repr__ method."""
+
+    def test_empty_repr(self):
+        """Empty result set should show 'empty'."""
+        rs = VerificationResultSet(results=[])
+        assert repr(rs) == "VerificationResultSet(empty)"
+
+    def test_single_result_repr(self):
+        """Single result should use singular 'result'."""
+        rs = VerificationResultSet(results=[_make_result()])
+        result = repr(rs)
+        assert result == "VerificationResultSet(1 result)"
+
+    def test_multiple_results_repr(self):
+        """Multiple results should use plural 'results'."""
+        rs = VerificationResultSet(results=[_make_result(), _make_result()])
+        result = repr(rs)
+        assert result == "VerificationResultSet(2 results)"
+
+    def test_repr_is_concise(self):
+        """Repr should not contain expensive summary data."""
+        rs = VerificationResultSet(results=[_make_result() for _ in range(10)])
+        result = repr(rs)
+        # Should be a short string, not a multi-line summary
+        assert "\n" not in result
+        assert "10 results" in result
+
+
+# =============================================================================
+# Sub-task B: group_by_replicate preserves None
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGroupByReplicate:
+    """Tests for group_by_replicate preserving None keys."""
+
+    def test_none_replicate_preserved_as_key(self):
+        """Results with None replicate should use None as key, not 0."""
+        r1 = _make_result(replicate=None)
+        r2 = _make_result(replicate=1)
+        rs = VerificationResultSet(results=[r1, r2])
+
+        grouped = rs.group_by_replicate()
+        assert None in grouped
+        assert 1 in grouped
+        assert 0 not in grouped
+
+    def test_all_none_replicates(self):
+        """All None replicates should group under single None key."""
+        results = [_make_result(replicate=None) for _ in range(3)]
+        rs = VerificationResultSet(results=results)
+
+        grouped = rs.group_by_replicate()
+        assert list(grouped.keys()) == [None]
+        assert len(grouped[None]) == 3
+
+    def test_integer_replicates_unchanged(self):
+        """Integer replicates should still work as before."""
+        r1 = _make_result(replicate=1)
+        r2 = _make_result(replicate=2)
+        r3 = _make_result(replicate=1)
+        rs = VerificationResultSet(results=[r1, r2, r3])
+
+        grouped = rs.group_by_replicate()
+        assert set(grouped.keys()) == {1, 2}
+        assert len(grouped[1]) == 2
+        assert len(grouped[2]) == 1
+
+
+# =============================================================================
+# Sub-task C: View-level group_by_model with 'by' parameter
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestViewGroupByModel:
+    """Tests for the 'by' parameter on view-level group_by_model methods."""
+
+    def test_template_results_group_by_answering(self):
+        """TemplateResults.group_by_model(by='answering') groups by answering model."""
+        from karenina.schemas.results.template import TemplateResults
+
+        r1 = _make_result(answering_model="gpt-4", parsing_model="gpt-3.5")
+        r2 = _make_result(answering_model="claude-3", parsing_model="gpt-3.5")
+        tr = TemplateResults(results=[r1, r2])
+
+        grouped = tr.group_by_model(by="answering")
+        assert "langchain:gpt-4" in grouped
+        assert "langchain:claude-3" in grouped
+
+    def test_template_results_group_by_parsing(self):
+        """TemplateResults.group_by_model(by='parsing') groups by parsing model."""
+        from karenina.schemas.results.template import TemplateResults
+
+        r1 = _make_result(answering_model="gpt-4", parsing_model="gpt-3.5")
+        r2 = _make_result(answering_model="gpt-4", parsing_model="claude-3")
+        tr = TemplateResults(results=[r1, r2])
+
+        grouped = tr.group_by_model(by="parsing")
+        assert "langchain:gpt-3.5" in grouped
+        assert "langchain:claude-3" in grouped
+
+    def test_template_results_group_by_both(self):
+        """TemplateResults.group_by_model(by='both') groups by answering / parsing."""
+        from karenina.schemas.results.template import TemplateResults
+
+        r1 = _make_result(answering_model="gpt-4", parsing_model="gpt-3.5")
+        r2 = _make_result(answering_model="gpt-4", parsing_model="claude-3")
+        tr = TemplateResults(results=[r1, r2])
+
+        grouped = tr.group_by_model(by="both")
+        assert "langchain:gpt-4 / langchain:gpt-3.5" in grouped
+        assert "langchain:gpt-4 / langchain:claude-3" in grouped
+
+    def test_template_results_group_by_answering_with_mcp(self):
+        """MCP servers should be appended to the answering model key."""
+        from karenina.schemas.results.template import TemplateResults
+
+        r1 = _make_result(answering_model="gpt-4", mcp_servers=["server1", "server2"])
+        r2 = _make_result(answering_model="gpt-4", mcp_servers=None)
+        tr = TemplateResults(results=[r1, r2])
+
+        grouped = tr.group_by_model(by="answering")
+        assert "langchain:gpt-4 + MCP[server1,server2]" in grouped
+        assert "langchain:gpt-4" in grouped
+
+    def test_rubric_results_group_by_parsing(self):
+        """RubricResults.group_by_model supports the 'by' parameter."""
+        from karenina.schemas.results.rubric import RubricResults
+
+        r1 = _make_result(answering_model="gpt-4", parsing_model="gpt-3.5")
+        r2 = _make_result(answering_model="gpt-4", parsing_model="claude-3")
+        rr = RubricResults(results=[r1, r2])
+
+        grouped = rr.group_by_model(by="parsing")
+        assert "langchain:gpt-3.5" in grouped
+        assert "langchain:claude-3" in grouped
+
+    def test_judgment_results_group_by_both(self):
+        """JudgmentResults.group_by_model supports the 'by' parameter."""
+        from karenina.schemas.results.judgment import JudgmentResults
+
+        r1 = _make_result(answering_model="gpt-4", parsing_model="gpt-3.5")
+        r2 = _make_result(answering_model="claude-3", parsing_model="gpt-3.5")
+        jr = JudgmentResults(results=[r1, r2])
+
+        grouped = jr.group_by_model(by="both")
+        assert "langchain:gpt-4 / langchain:gpt-3.5" in grouped
+        assert "langchain:claude-3 / langchain:gpt-3.5" in grouped
+
+    def test_default_is_answering(self):
+        """Default 'by' parameter should be 'answering'."""
+        from karenina.schemas.results.template import TemplateResults
+
+        r1 = _make_result(answering_model="gpt-4", parsing_model="gpt-3.5")
+        tr = TemplateResults(results=[r1])
+
+        # Call without explicit 'by' argument
+        grouped = tr.group_by_model()
+        assert "langchain:gpt-4" in grouped
+
+    def test_invalid_by_raises(self):
+        """Invalid 'by' value should raise ValueError."""
+        from karenina.schemas.results.template import TemplateResults
+
+        r1 = _make_result()
+        tr = TemplateResults(results=[r1])
+
+        with pytest.raises(ValueError, match="Invalid grouping mode"):
+            tr.group_by_model(by="invalid")
+
+
+# =============================================================================
+# Sub-task D: DeepJudgmentRubricCustomConfig
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDeepJudgmentRubricCustomConfig:
+    """Tests for the new typed config model."""
+
+    def test_valid_config_creation(self):
+        """Can create config with global traits and question-specific traits."""
+        config = DeepJudgmentRubricCustomConfig(
+            **{
+                "global": {
+                    "Accuracy": DeepJudgmentTraitConfig(enabled=True, excerpt_enabled=True),
+                },
+                "question_specific": {
+                    "q-123": {
+                        "Completeness": DeepJudgmentTraitConfig(enabled=False),
+                    }
+                },
+            }
+        )
+        assert "Accuracy" in config.global_traits
+        assert config.global_traits["Accuracy"].enabled is True
+        assert "q-123" in config.question_specific
+        assert config.question_specific["q-123"]["Completeness"].enabled is False
+
+    def test_empty_config_defaults(self):
+        """Empty config should have empty dicts."""
+        config = DeepJudgmentRubricCustomConfig()
+        assert config.global_traits == {}
+        assert config.question_specific == {}
+
+    def test_extra_fields_forbidden(self):
+        """Extra fields should be rejected."""
+        with pytest.raises(ValidationError):
+            DeepJudgmentRubricCustomConfig(unknown_field="value")
+
+    def test_custom_mode_requires_config(self):
+        """Custom mode without config should raise validation error."""
+        with pytest.raises(ValidationError, match="deep_judgment_rubric_config is required"):
+            _make_minimal_config(
+                deep_judgment_rubric_mode="custom",
+                deep_judgment_rubric_config=None,
+            )
+
+    def test_custom_mode_with_config_succeeds(self):
+        """Custom mode with config should succeed."""
+        config = _make_minimal_config(
+            deep_judgment_rubric_mode="custom",
+            deep_judgment_rubric_config=DeepJudgmentRubricCustomConfig(
+                **{
+                    "global": {
+                        "Accuracy": DeepJudgmentTraitConfig(enabled=True),
+                    }
+                }
+            ),
+        )
+        assert config.deep_judgment_rubric_mode == "custom"
+        assert config.deep_judgment_rubric_config is not None
+
+    def test_non_custom_mode_without_config_ok(self):
+        """Non-custom modes should not require config."""
+        config = _make_minimal_config(
+            deep_judgment_rubric_mode="enable_all",
+            deep_judgment_rubric_config=None,
+        )
+        assert config.deep_judgment_rubric_mode == "enable_all"
+        assert config.deep_judgment_rubric_config is None
+
+    def test_dict_accepted_and_coerced(self):
+        """Raw dicts should be coerced to the typed model by Pydantic."""
+        config = _make_minimal_config(
+            deep_judgment_rubric_mode="custom",
+            deep_judgment_rubric_config={
+                "global": {
+                    "Accuracy": {"enabled": True, "excerpt_enabled": True},
+                },
+                "question_specific": {},
+            },
+        )
+        assert isinstance(config.deep_judgment_rubric_config, DeepJudgmentRubricCustomConfig)
+        assert config.deep_judgment_rubric_config.global_traits["Accuracy"].enabled is True
+
+    def test_from_overrides_accepts_dict(self):
+        """from_overrides should accept a raw dict for deep_judgment_rubric_config."""
+        raw_dict = {
+            "global": {
+                "Accuracy": {"enabled": True},
+            },
+            "question_specific": {},
+        }
+        config = VerificationConfig.from_overrides(
+            answering_model="gpt-4",
+            answering_provider="openai",
+            answering_id="answering",
+            answering_interface="langchain",
+            parsing_model="gpt-4",
+            parsing_provider="openai",
+            parsing_id="parsing",
+            parsing_interface="langchain",
+            deep_judgment_rubric_mode="custom",
+            deep_judgment_rubric_config=raw_dict,
+        )
+        assert isinstance(config.deep_judgment_rubric_config, DeepJudgmentRubricCustomConfig)

--- a/tests/unit/schemas/test_callable_trait.py
+++ b/tests/unit/schemas/test_callable_trait.py
@@ -1046,13 +1046,27 @@ def test_callable_trait_invert_result_preserved() -> None:
 
 
 @pytest.mark.unit
-def test_callable_trait_higher_is_better_none_defaults_to_true() -> None:
-    """Test that higher_is_better=None defaults to True (old checkpoint data)."""
+def test_callable_trait_higher_is_better_none_preserved() -> None:
+    """Test that explicit higher_is_better=None is preserved (directionality not applicable)."""
     trait = CallableRubricTrait(
         name="test",
         kind="boolean",
         callable_code=cloudpickle.dumps(lambda _t: True),
         higher_is_better=None,
+    )
+
+    assert trait.higher_is_better is None
+
+
+@pytest.mark.unit
+def test_callable_trait_higher_is_better_missing_defaults_to_true() -> None:
+    """Test that missing higher_is_better defaults to True (old checkpoint data)."""
+    trait = CallableRubricTrait.model_validate(
+        {
+            "name": "test",
+            "kind": "boolean",
+            "callable_code": cloudpickle.dumps(lambda _t: True),
+        }
     )
 
     assert trait.higher_is_better is True

--- a/tests/unit/schemas/test_regex_trait.py
+++ b/tests/unit/schemas/test_regex_trait.py
@@ -653,12 +653,25 @@ def test_regex_trait_pattern_types(name: str, pattern: str, match_text: str, no_
 
 
 @pytest.mark.unit
-def test_regex_trait_higher_is_better_none_defaults_to_true() -> None:
-    """Test that higher_is_better=None defaults to True (old checkpoint data)."""
+def test_regex_trait_higher_is_better_none_preserved() -> None:
+    """Test that explicit higher_is_better=None is preserved (directionality not applicable)."""
     trait = RegexRubricTrait(
         name="test",
         pattern=r"\w+",
         higher_is_better=None,
+    )
+
+    assert trait.higher_is_better is None
+
+
+@pytest.mark.unit
+def test_regex_trait_higher_is_better_missing_defaults_to_true() -> None:
+    """Test that missing higher_is_better defaults to True (old checkpoint data)."""
+    trait = RegexRubricTrait.model_validate(
+        {
+            "name": "test",
+            "pattern": r"\w+",
+        }
     )
 
     assert trait.higher_is_better is True

--- a/tests/unit/schemas/test_verification_config.py
+++ b/tests/unit/schemas/test_verification_config.py
@@ -966,7 +966,9 @@ def test_deep_judgment_rubric_enable_all_mode() -> None:
 
 @pytest.mark.unit
 def test_deep_judgment_rubric_custom_mode() -> None:
-    """Test deep_judgment_rubric_mode='custom' with config."""
+    """Test deep_judgment_rubric_mode='custom' with config dict (auto-coerced)."""
+    from karenina.schemas.verification.config import DeepJudgmentRubricCustomConfig
+
     custom_config = {
         "global": {
             "Clarity": {"enabled": True, "excerpt_enabled": False},
@@ -996,7 +998,11 @@ def test_deep_judgment_rubric_custom_mode() -> None:
     )
 
     assert config.deep_judgment_rubric_mode == "custom"
-    assert config.deep_judgment_rubric_config == custom_config
+    assert isinstance(config.deep_judgment_rubric_config, DeepJudgmentRubricCustomConfig)
+    assert "Clarity" in config.deep_judgment_rubric_config.global_traits
+    assert config.deep_judgment_rubric_config.global_traits["Clarity"].enabled is True
+    assert config.deep_judgment_rubric_config.global_traits["Clarity"].excerpt_enabled is False
+    assert "q-123" in config.deep_judgment_rubric_config.question_specific
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- **Unify `higher_is_better`** as `bool | None` across all rubric trait types (`None` = directionality does not apply). Add field to `MetricRubricTrait`, fix legacy validators, update GEPA scoring and checkpoint serialization.
- **Add `ResultsStore`** standalone class for cross-run result management, independent of `Benchmark` facade. Deprecate 10 facade result methods with warnings pointing to `ResultsStore`.
- **Improve `RubricManager` API**: `set_global_rubric`/`set_question_rubric` accept both `Rubric` and trait lists. Add `get_question_rubric` to facade. Rename internal `get_questions_with_rubric` to `get_question_ids_with_rubric`.
- **Unify `validate_rubrics` error shape** to `list[dict[str, str]]` with `{"source", "error"}` keys, matching `validate_templates`.
- **Type improvements**: simplify `VerificationResultSet.__repr__`, preserve `None` in `group_by_replicate`, add typed `DeepJudgmentRubricCustomConfig` model, add `by` parameter to view-level `group_by_model` methods.
- **Docstring fixes**: clarify `summary()` vs `summary_compact()` scope in `TaskEvalResult`.

## Note

The duplicate config router mount fix for `karenina-server` (removing `/api/config` prefix) is staged but not committed here since the server is a sibling submodule.

## Test plan

- [x] 4189 tests pass, 40 skipped, no regressions
- [x] New tests for `higher_is_better` unification (13 tests)
- [x] New tests for `Rubric.from_traits()` (3 tests)
- [x] New tests for RubricManager API changes (10 tests)
- [x] New tests for `ResultsStore` (29 tests)
- [x] New tests for facade deprecation warnings (10 tests)
- [x] New tests for type improvements (23 tests)
- [x] All pre-commit hooks pass (ruff, mypy, vulture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)