### PR TITLE
Dead code cleanup and design decisions

### DIFF
--- a/docs/core_concepts/few-shot.md
+++ b/docs/core_concepts/few-shot.md
@@ -79,9 +79,10 @@ Phase 1: Storage
 Phase 2: Resolution (at verification time)
   FewShotConfig.resolve_examples_for_question()
     ├─ Input: available examples from question, question ID, question text
-    ├─ Apply mode (all / k-shot / custom / none)
+    ├─ Check source (pool / global / both / disabled)
+    ├─ Apply mode (all / k-shot / custom)
     ├─ Apply exclusions
-    └─ Append external examples (question-specific, then global)
+    └─ Append global examples
 
 Phase 3: Injection (GenerateAnswer stage)
   _construct_few_shot_prompt()
@@ -108,25 +109,37 @@ print(f"Stored {len(question.few_shot_examples)} examples on question")
 
 **Injection** happens inside the GenerateAnswer stage. The resolved examples are formatted into a prompt string and sent as the user message. If no examples are resolved (or few-shot is disabled), the question text is sent unmodified.
 
-## 4. The Five Selection Modes
+## 4. The Source Field
 
-`FewShotConfig` supports five modes that control which examples are included in the prompt. Four modes apply globally; the fifth (`inherit`) is for per-question delegation.
+`FewShotConfig.source` controls where examples come from. It replaces the old `enabled` toggle with a richer set of options:
+
+| Source | Behavior | Best for |
+|--------|----------|----------|
+| `"pool"` | Use only per-question stored examples | Questions with curated example pools |
+| `"global"` | Use only global examples | Uniform examples across all questions |
+| `"both"` | Use per-question stored examples and global examples | Combining per-question and shared examples |
+| `"disabled"` | No examples used | Establishing a zero-shot baseline |
+
+## 5. The Three Selection Modes
+
+`FewShotConfig.pool_mode` controls which stored examples are selected from the per-question pool. Three modes apply globally; a fourth (`inherit`) is for per-question delegation.
 
 | Mode | Behavior | Best for |
 |------|----------|----------|
 | `all` | Use every example attached to the question | Small, curated example sets (2 to 5 examples) |
 | `k-shot` | Randomly sample *k* examples; uses question ID as seed for reproducibility | Large example pools where using all would be costly |
 | `custom` | Select specific examples by index position or MD5 hash | Curated selections where exact control matters |
-| `none` | No examples used | Disabling few-shot for specific questions or globally |
 | `inherit` | Delegate to the global mode and k value | Per-question default; questions without explicit config inherit automatically |
+
+To disable few-shot entirely, set `source="disabled"` instead of using a mode.
 
 ### `all` mode (default)
 
-Uses every example attached to the question. This is the default `global_mode`.
+Uses every example attached to the question. This is the default `pool_mode`.
 
 ```python
-all_config = FewShotConfig(global_mode="all")
-print(f"Mode: {all_config.global_mode}, enabled: {all_config.enabled}")
+all_config = FewShotConfig(pool_mode="all")
+print(f"Mode: {all_config.pool_mode}, source: {all_config.source}")
 ```
 
 ### `k-shot` mode
@@ -134,11 +147,11 @@ print(f"Mode: {all_config.global_mode}, enabled: {all_config.enabled}")
 Randomly samples *k* examples. The question ID seeds the random selection, so the same question always gets the same examples across runs.
 
 ```python
-k_shot_config = FewShotConfig(global_mode="k-shot", global_k=3)
-print(f"Mode: {k_shot_config.global_mode}, k: {k_shot_config.global_k}")
+k_shot_config = FewShotConfig(pool_mode="k-shot", pool_k=3)
+print(f"Mode: {k_shot_config.pool_mode}, k: {k_shot_config.pool_k}")
 ```
 
-If a question has fewer examples than *k*, all examples are used (no error). The default `global_k` is `3`.
+If a question has fewer examples than *k*, all examples are used (no error). The default `pool_k` is `3`.
 
 ### `custom` mode
 
@@ -146,7 +159,7 @@ Selects examples by integer index or MD5 hash of the example's question text:
 
 ```python
 custom_config = FewShotConfig(
-    global_mode="custom",
+    pool_mode="custom",
     question_configs={
         "question_1": QuestionFewShotConfig(
             mode="custom",
@@ -164,22 +177,23 @@ example_hash = FewShotConfig.generate_example_hash("How many chromosomes in a hu
 print(f"Hash: {example_hash}")
 ```
 
-### `none` mode
+### Disabling few-shot
 
-Disables few-shot entirely, globally or per-question:
+To disable few-shot entirely (globally or per-question), set `source="disabled"`:
 
 ```python
 # Globally disabled
-none_config = FewShotConfig(global_mode="none")
+none_config = FewShotConfig(source="disabled")
 
-# Disabled for one question, enabled for the rest
+# Disabled for one question via per-question override (source="disabled" at question level)
+# For the rest, the global source applies
 mixed_config = FewShotConfig(
-    global_mode="all",
+    pool_mode="all",
     question_configs={
-        "question_3": QuestionFewShotConfig(mode="none"),
+        "question_3": QuestionFewShotConfig(mode="custom", selected_examples=[]),
     },
 )
-print(f"Global: {none_config.global_mode}")
+print(f"Source: {none_config.source}")
 print(f"question_3 mode: {mixed_config.question_configs['question_3'].mode}")
 ```
 
@@ -192,18 +206,18 @@ default_q = QuestionFewShotConfig()
 print(f"Default per-question mode: {default_q.mode}")
 ```
 
-## 5. Per-Question Overrides
+## 6. Per-Question Overrides
 
 Each question can override the global settings independently. This is how you run different strategies for different parts of the benchmark:
 
 ```python
 override_config = FewShotConfig(
-    global_mode="k-shot",
-    global_k=3,
+    pool_mode="k-shot",
+    pool_k=3,
     question_configs={
         "question_1": QuestionFewShotConfig(mode="all"),           # use all examples
         "question_2": QuestionFewShotConfig(mode="k-shot", k=5),   # sample 5 instead of 3
-        "question_3": QuestionFewShotConfig(mode="none"),           # disable entirely
+        "question_3": QuestionFewShotConfig(mode="custom", selected_examples=[]),  # no examples
         # question_4 inherits: k-shot with k=3
     },
 )
@@ -218,7 +232,7 @@ You can also exclude specific examples while keeping the mode:
 
 ```python
 exclusion_config = FewShotConfig(
-    global_mode="all",
+    pool_mode="all",
     question_configs={
         "question_1": QuestionFewShotConfig(
             mode="all",
@@ -231,7 +245,7 @@ print(f"question_1 exclusions: {exclusion_config.question_configs['question_1'].
 
 Exclusions accept both integer indices and MD5 hash strings, just like `selected_examples` in custom mode.
 
-## 6. Resolution in Action
+## 7. Resolution in Action
 
 `FewShotConfig.resolve_examples_for_question()` takes the stored examples and applies the mode logic. Here is a complete resolution example:
 
@@ -246,12 +260,12 @@ examples = [
 ]
 
 # Resolve with "all" mode
-config_all = FewShotConfig(global_mode="all")
+config_all = FewShotConfig(pool_mode="all")
 resolved = config_all.resolve_examples_for_question("q1", available_examples=examples)
 print(f"all mode: {len(resolved)} examples")
 
 # Resolve with k-shot (k=2)
-config_k = FewShotConfig(global_mode="k-shot", global_k=2)
+config_k = FewShotConfig(pool_mode="k-shot", pool_k=2)
 resolved_k = config_k.resolve_examples_for_question("q1", available_examples=examples)
 print(f"k-shot (k=2): {len(resolved_k)} examples -> {[e['answer'] for e in resolved_k]}")
 
@@ -259,43 +273,33 @@ print(f"k-shot (k=2): {len(resolved_k)} examples -> {[e['answer'] for e in resol
 resolved_k2 = config_k.resolve_examples_for_question("q1", available_examples=examples)
 print(f"Reproducible: {resolved_k == resolved_k2}")
 
-# Resolve with "none" mode
-config_none = FewShotConfig(global_mode="none")
+# Resolve with source="disabled"
+config_none = FewShotConfig(source="disabled")
 resolved_none = config_none.resolve_examples_for_question("q1", available_examples=examples)
-print(f"none mode: {len(resolved_none)} examples")
+print(f"disabled source: {len(resolved_none)} examples")
 ```
 
-## 7. External Examples
+## 8. Global Examples
 
-External examples are question-answer pairs that do not come from the question's stored example list. They are appended after the resolved stored examples.
-
-Two levels exist: **global** external examples (appended to every question) and **question-specific** external examples (appended to one question only).
+Global examples are question-answer pairs that are appended to every question's resolved examples. They are defined at the `FewShotConfig` level and appear after the per-question stored examples.
 
 ```python
-external_config = FewShotConfig(
-    global_mode="k-shot",
-    global_k=2,
-    global_external_examples=[
+global_config = FewShotConfig(
+    pool_mode="k-shot",
+    pool_k=2,
+    global_examples=[
         {"question": "What is the capital of France?", "answer": "Paris"},
     ],
-    question_configs={
-        "q1": QuestionFewShotConfig(
-            mode="k-shot",
-            external_examples=[
-                {"question": "What gene does imatinib target?", "answer": "BCR-ABL1"},
-            ],
-        ),
-    },
 )
 
-resolved = external_config.resolve_examples_for_question("q1", available_examples=examples)
+resolved = global_config.resolve_examples_for_question("q1", available_examples=examples)
 print(f"Total examples for q1: {len(resolved)}")
-print(f"Last two (external): {[e['answer'] for e in resolved[-2:]]}")
+print(f"Last one (global): {resolved[-1]['answer']}")
 ```
 
-The resolution order is: resolved stored examples, then question-specific external, then global external.
+The resolution order is: resolved stored examples, then global examples.
 
-## 8. Convenience Constructors
+## 9. Convenience Constructors
 
 `FewShotConfig` provides class methods for common setup patterns:
 
@@ -305,26 +309,26 @@ by_index = FewShotConfig.from_index_selections({
     "question_1": [0, 2, 4],
     "question_2": [1, 3],
 })
-print(f"from_index_selections: global_mode={by_index.global_mode}, "
+print(f"from_index_selections: pool_mode={by_index.pool_mode}, "
       f"questions={list(by_index.question_configs.keys())}")
 
 # Custom selections by hash
 by_hash = FewShotConfig.from_hash_selections({
     "question_1": [FewShotConfig.generate_example_hash("example question text")],
 })
-print(f"from_hash_selections: global_mode={by_hash.global_mode}")
+print(f"from_hash_selections: pool_mode={by_hash.pool_mode}")
 
 # Different k per question
 per_q_k = FewShotConfig.k_shot_for_questions({
     "question_1": 5,
     "question_2": 2,
-}, global_k=3)
-print(f"k_shot_for_questions: global_mode={per_q_k.global_mode}, global_k={per_q_k.global_k}")
+}, pool_k=3)
+print(f"k_shot_for_questions: pool_mode={per_q_k.pool_mode}, pool_k={per_q_k.pool_k}")
 ```
 
-`from_index_selections` and `from_hash_selections` default to `global_mode="custom"`; `k_shot_for_questions` defaults to `global_mode="k-shot"`.
+`from_index_selections` and `from_hash_selections` default to `pool_mode="custom"`; `k_shot_for_questions` defaults to `pool_mode="k-shot"`.
 
-## 9. Using FewShotConfig in Verification
+## 10. Using FewShotConfig in Verification
 
 Pass the config to `VerificationConfig` via the `few_shot_config` field:
 
@@ -337,8 +341,8 @@ config = VerificationConfig(
         ModelConfig(id="judge", model_provider="anthropic", model_name="claude-haiku-4-5"),
     ],
     few_shot_config=FewShotConfig(
-        global_mode="k-shot",
-        global_k=3,
+        pool_mode="k-shot",
+        pool_k=3,
     ),
 )
 
@@ -346,7 +350,7 @@ print(f"Few-shot enabled: {config.is_few_shot_enabled()}")
 print(f"Config: {config.get_few_shot_config()}")
 ```
 
-When `few_shot_config` is `None` (the default) or `enabled=False`, the pipeline sends the question text directly to the answering model with no examples prepended.
+When `few_shot_config` is `None` (the default) or `source="disabled"`, the pipeline sends the question text directly to the answering model with no examples prepended.
 
 ```python
 config_no_fs = VerificationConfig(
@@ -364,14 +368,14 @@ print(f"Few-shot enabled (no config): {config_no_fs.is_few_shot_enabled()}")
 
 `VerificationConfig` validates few-shot settings at construction time:
 
-- In `k-shot` mode, `global_k` must be at least 1
+- In `k-shot` mode, `pool_k` must be at least 1
 - Per-question `k` values must be at least 1 when specified
 - `validate_selections()` checks that index and hash selections reference valid examples (call this explicitly after construction if you want bounds checking)
 
 ```python
 # validate_selections returns a list of error messages (empty if valid)
 fs_config = FewShotConfig(
-    global_mode="custom",
+    pool_mode="custom",
     question_configs={
         "q1": QuestionFewShotConfig(mode="custom", selected_examples=[0, 1, 99]),
     },
@@ -380,39 +384,38 @@ errors = fs_config.validate_selections({"q1": examples[:3]})
 print(f"Validation errors: {errors}")
 ```
 
-## 10. Choosing the Right Mode
+## 11. Choosing the Right Mode
 
 | Situation | Recommended mode | Rationale |
 |-----------|-----------------|-----------|
 | 2 to 5 hand-picked examples per question | `all` | Small set; include everything |
 | 10+ examples per question, cost-sensitive | `k-shot` | Limits prompt length while preserving reproducibility |
 | Ablation study: which examples help most? | `custom` | Exact control over which examples appear |
-| Baseline comparison without examples | `none` | Clean zero-shot baseline |
+| Baseline comparison without examples | `source="disabled"` | Clean zero-shot baseline |
 | Most questions share a strategy, a few differ | Per-question overrides with `inherit` default | Global mode covers the common case; overrides handle exceptions |
 
 **Litmus test for whether few-shot helps**: if the answering model already produces responses that your template can parse and verify, few-shot examples add cost without benefit. Try a zero-shot run first. Add examples when you observe format mismatches, verbose responses where concise ones are expected, or inconsistent answer styles across similar questions.
 
-## 11. FewShotConfig Field Reference
+## 12. FewShotConfig Field Reference
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enabled` | `bool` | `True` | Master switch; when `False`, no examples are used regardless of mode |
-| `global_mode` | `Literal["all", "k-shot", "custom", "none"]` | `"all"` | Default mode for all questions |
-| `global_k` | `int` | `3` | Number of examples for `k-shot` mode |
+| `source` | `Literal["pool", "global", "both", "disabled"]` | `"both"` | Controls where examples come from: per-question pool, global list, both, or disabled entirely |
+| `pool_mode` | `Literal["all", "k-shot", "custom"]` | `"all"` | Default selection mode for per-question example pools |
+| `pool_k` | `int` | `3` | Number of examples for `k-shot` mode |
 | `question_configs` | `dict[str, QuestionFewShotConfig]` | `{}` | Per-question overrides keyed by question ID |
-| `global_external_examples` | `list[dict[str, str]]` | `[]` | External examples appended to every question |
+| `global_examples` | `list[dict[str, str]]` | `[]` | Examples appended to every question |
 
 ### QuestionFewShotConfig Fields
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `mode` | `Literal["all", "k-shot", "custom", "none", "inherit"]` | `"inherit"` | Selection mode for this question |
+| `mode` | `Literal["all", "k-shot", "custom", "inherit"]` | `"inherit"` | Selection mode for this question |
 | `k` | `int \| None` | `None` | Override global k for this question (k-shot mode) |
 | `selected_examples` | `list[str \| int] \| None` | `None` | Indices or MD5 hashes for custom mode |
-| `external_examples` | `list[dict[str, str]] \| None` | `None` | Question-specific external examples |
 | `excluded_examples` | `list[str \| int] \| None` | `None` | Indices or hashes of examples to exclude |
 
-## 12. Provenance in Results
+## 13. Provenance in Results
 
 When few-shot is active, the verification result records provenance metadata so you can trace which results used few-shot prompting:
 
@@ -423,7 +426,7 @@ When few-shot is active, the verification result records provenance metadata so 
 
 These fields enable filtering and grouping in analysis (e.g., comparing accuracy with and without few-shot examples across the same benchmark).
 
-## 13. Next Steps
+## 14. Next Steps
 
 - [Answer Templates](../answer-templates/): what few-shot examples help the answering model produce
 - [Verification Pipeline](../verification-pipeline/): where GenerateAnswer fits in the 13-stage pipeline

--- a/docs/notebooks/core_concepts/few-shot.ipynb
+++ b/docs/notebooks/core_concepts/few-shot.ipynb
@@ -93,9 +93,10 @@
     "Phase 2: Resolution (at verification time)\n",
     "  FewShotConfig.resolve_examples_for_question()\n",
     "    ├─ Input: available examples from question, question ID, question text\n",
-    "    ├─ Apply mode (all / k-shot / custom / none)\n",
+    "    ├─ Check source (pool / global / both / disabled)\n",
+    "    ├─ Apply mode (all / k-shot / custom)\n",
     "    ├─ Apply exclusions\n",
-    "    └─ Append external examples (question-specific, then global)\n",
+    "    └─ Append global examples\n",
     "\n",
     "Phase 3: Injection (GenerateAnswer stage)\n",
     "  _construct_few_shot_prompt()\n",
@@ -149,21 +150,33 @@
     "\n",
     "**Injection** happens inside the GenerateAnswer stage. The resolved examples are formatted into a prompt string and sent as the user message. If no examples are resolved (or few-shot is disabled), the question text is sent unmodified.\n",
     "\n",
-    "## 4. The Five Selection Modes\n",
+    "## 4. The Source Field\n",
     "\n",
-    "`FewShotConfig` supports five modes that control which examples are included in the prompt. Four modes apply globally; the fifth (`inherit`) is for per-question delegation.\n",
+    "`FewShotConfig.source` controls where examples come from. It replaces the old `enabled` toggle with a richer set of options:\n",
+    "\n",
+    "| Source | Behavior | Best for |\n",
+    "|--------|----------|----------|\n",
+    "| `\"pool\"` | Use only per-question stored examples | Questions with curated example pools |\n",
+    "| `\"global\"` | Use only global examples | Uniform examples across all questions |\n",
+    "| `\"both\"` | Use per-question stored examples and global examples | Combining per-question and shared examples |\n",
+    "| `\"disabled\"` | No examples used | Establishing a zero-shot baseline |\n",
+    "\n",
+    "## 5. The Three Selection Modes\n",
+    "\n",
+    "`FewShotConfig.pool_mode` controls which stored examples are selected from the per-question pool. Three modes apply globally; a fourth (`inherit`) is for per-question delegation.\n",
     "\n",
     "| Mode | Behavior | Best for |\n",
     "|------|----------|----------|\n",
     "| `all` | Use every example attached to the question | Small, curated example sets (2 to 5 examples) |\n",
     "| `k-shot` | Randomly sample *k* examples; uses question ID as seed for reproducibility | Large example pools where using all would be costly |\n",
     "| `custom` | Select specific examples by index position or MD5 hash | Curated selections where exact control matters |\n",
-    "| `none` | No examples used | Disabling few-shot for specific questions or globally |\n",
     "| `inherit` | Delegate to the global mode and k value | Per-question default; questions without explicit config inherit automatically |\n",
+    "\n",
+    "To disable few-shot entirely, set `source=\"disabled\"` instead of using a mode.\n",
     "\n",
     "### `all` mode (default)\n",
     "\n",
-    "Uses every example attached to the question. This is the default `global_mode`."
+    "Uses every example attached to the question. This is the default `pool_mode`."
    ]
   },
   {
@@ -188,8 +201,8 @@
     }
    ],
    "source": [
-    "all_config = FewShotConfig(global_mode=\"all\")\n",
-    "print(f\"Mode: {all_config.global_mode}, enabled: {all_config.enabled}\")"
+    "all_config = FewShotConfig(pool_mode=\"all\")\n",
+    "print(f\"Mode: {all_config.pool_mode}, source: {all_config.source}\")"
    ]
   },
   {
@@ -224,8 +237,8 @@
     }
    ],
    "source": [
-    "k_shot_config = FewShotConfig(global_mode=\"k-shot\", global_k=3)\n",
-    "print(f\"Mode: {k_shot_config.global_mode}, k: {k_shot_config.global_k}\")"
+    "k_shot_config = FewShotConfig(pool_mode=\"k-shot\", pool_k=3)\n",
+    "print(f\"Mode: {k_shot_config.pool_mode}, k: {k_shot_config.pool_k}\")"
    ]
   },
   {
@@ -233,7 +246,7 @@
    "id": "3f80823d",
    "metadata": {},
    "source": [
-    "If a question has fewer examples than *k*, all examples are used (no error). The default `global_k` is `3`.\n",
+    "If a question has fewer examples than *k*, all examples are used (no error). The default `pool_k` is `3`.\n",
     "\n",
     "### `custom` mode\n",
     "\n",
@@ -263,7 +276,7 @@
    ],
    "source": [
     "custom_config = FewShotConfig(\n",
-    "    global_mode=\"custom\",\n",
+    "    pool_mode=\"custom\",\n",
     "    question_configs={\n",
     "        \"question_1\": QuestionFewShotConfig(\n",
     "            mode=\"custom\",\n",
@@ -313,9 +326,9 @@
    "id": "66b9dd97",
    "metadata": {},
    "source": [
-    "### `none` mode\n",
+    "### Disabling few-shot\n",
     "\n",
-    "Disables few-shot entirely, globally or per-question:"
+    "To disable few-shot entirely (globally or per-question), set `source=\"disabled\"`:"
    ]
   },
   {
@@ -342,16 +355,17 @@
    ],
    "source": [
     "# Globally disabled\n",
-    "none_config = FewShotConfig(global_mode=\"none\")\n",
+    "none_config = FewShotConfig(source=\"disabled\")\n",
     "\n",
-    "# Disabled for one question, enabled for the rest\n",
+    "# Disabled for one question via per-question override (source=\"disabled\" at question level)\n",
+    "# For the rest, the global source applies\n",
     "mixed_config = FewShotConfig(\n",
-    "    global_mode=\"all\",\n",
+    "    pool_mode=\"all\",\n",
     "    question_configs={\n",
-    "        \"question_3\": QuestionFewShotConfig(mode=\"none\"),\n",
+    "        \"question_3\": QuestionFewShotConfig(mode=\"custom\", selected_examples=[]),\n",
     "    },\n",
     ")\n",
-    "print(f\"Global: {none_config.global_mode}\")\n",
+    "print(f\"Source: {none_config.source}\")\n",
     "print(f\"question_3 mode: {mixed_config.question_configs['question_3'].mode}\")"
    ]
   },
@@ -396,7 +410,7 @@
    "id": "91bcbb96",
    "metadata": {},
    "source": [
-    "## 5. Per-Question Overrides\n",
+    "## 6. Per-Question Overrides\n",
     "\n",
     "Each question can override the global settings independently. This is how you run different strategies for different parts of the benchmark:"
    ]
@@ -427,12 +441,12 @@
    ],
    "source": [
     "override_config = FewShotConfig(\n",
-    "    global_mode=\"k-shot\",\n",
-    "    global_k=3,\n",
+    "    pool_mode=\"k-shot\",\n",
+    "    pool_k=3,\n",
     "    question_configs={\n",
     "        \"question_1\": QuestionFewShotConfig(mode=\"all\"),           # use all examples\n",
     "        \"question_2\": QuestionFewShotConfig(mode=\"k-shot\", k=5),   # sample 5 instead of 3\n",
-    "        \"question_3\": QuestionFewShotConfig(mode=\"none\"),           # disable entirely\n",
+    "        \"question_3\": QuestionFewShotConfig(mode=\"custom\", selected_examples=[]),  # no examples\n",
     "        # question_4 inherits: k-shot with k=3\n",
     "    },\n",
     ")\n",
@@ -474,7 +488,7 @@
    ],
    "source": [
     "exclusion_config = FewShotConfig(\n",
-    "    global_mode=\"all\",\n",
+    "    pool_mode=\"all\",\n",
     "    question_configs={\n",
     "        \"question_1\": QuestionFewShotConfig(\n",
     "            mode=\"all\",\n",
@@ -492,7 +506,7 @@
    "source": [
     "Exclusions accept both integer indices and MD5 hash strings, just like `selected_examples` in custom mode.\n",
     "\n",
-    "## 6. Resolution in Action\n",
+    "## 7. Resolution in Action\n",
     "\n",
     "`FewShotConfig.resolve_examples_for_question()` takes the stored examples and applies the mode logic. Here is a complete resolution example:"
    ]
@@ -532,12 +546,12 @@
     "]\n",
     "\n",
     "# Resolve with \"all\" mode\n",
-    "config_all = FewShotConfig(global_mode=\"all\")\n",
+    "config_all = FewShotConfig(pool_mode=\"all\")\n",
     "resolved = config_all.resolve_examples_for_question(\"q1\", available_examples=examples)\n",
     "print(f\"all mode: {len(resolved)} examples\")\n",
     "\n",
     "# Resolve with k-shot (k=2)\n",
-    "config_k = FewShotConfig(global_mode=\"k-shot\", global_k=2)\n",
+    "config_k = FewShotConfig(pool_mode=\"k-shot\", pool_k=2)\n",
     "resolved_k = config_k.resolve_examples_for_question(\"q1\", available_examples=examples)\n",
     "print(f\"k-shot (k=2): {len(resolved_k)} examples -> {[e['answer'] for e in resolved_k]}\")\n",
     "\n",
@@ -545,10 +559,10 @@
     "resolved_k2 = config_k.resolve_examples_for_question(\"q1\", available_examples=examples)\n",
     "print(f\"Reproducible: {resolved_k == resolved_k2}\")\n",
     "\n",
-    "# Resolve with \"none\" mode\n",
-    "config_none = FewShotConfig(global_mode=\"none\")\n",
+    "# Resolve with source=\"disabled\"\n",
+    "config_none = FewShotConfig(source=\"disabled\")\n",
     "resolved_none = config_none.resolve_examples_for_question(\"q1\", available_examples=examples)\n",
-    "print(f\"none mode: {len(resolved_none)} examples\")"
+    "print(f\"disabled source: {len(resolved_none)} examples\")"
    ]
   },
   {
@@ -556,11 +570,9 @@
    "id": "e797bf35",
    "metadata": {},
    "source": [
-    "## 7. External Examples\n",
+    "## 8. Global Examples\n",
     "\n",
-    "External examples are question-answer pairs that do not come from the question's stored example list. They are appended after the resolved stored examples.\n",
-    "\n",
-    "Two levels exist: **global** external examples (appended to every question) and **question-specific** external examples (appended to one question only)."
+    "Global examples are question-answer pairs that are appended to every question's resolved examples. They are defined at the `FewShotConfig` level and appear after the per-question stored examples."
    ]
   },
   {
@@ -586,25 +598,17 @@
     }
    ],
    "source": [
-    "external_config = FewShotConfig(\n",
-    "    global_mode=\"k-shot\",\n",
-    "    global_k=2,\n",
-    "    global_external_examples=[\n",
+    "global_config = FewShotConfig(\n",
+    "    pool_mode=\"k-shot\",\n",
+    "    pool_k=2,\n",
+    "    global_examples=[\n",
     "        {\"question\": \"What is the capital of France?\", \"answer\": \"Paris\"},\n",
     "    ],\n",
-    "    question_configs={\n",
-    "        \"q1\": QuestionFewShotConfig(\n",
-    "            mode=\"k-shot\",\n",
-    "            external_examples=[\n",
-    "                {\"question\": \"What gene does imatinib target?\", \"answer\": \"BCR-ABL1\"},\n",
-    "            ],\n",
-    "        ),\n",
-    "    },\n",
     ")\n",
     "\n",
-    "resolved = external_config.resolve_examples_for_question(\"q1\", available_examples=examples)\n",
+    "resolved = global_config.resolve_examples_for_question(\"q1\", available_examples=examples)\n",
     "print(f\"Total examples for q1: {len(resolved)}\")\n",
-    "print(f\"Last two (external): {[e['answer'] for e in resolved[-2:]]}\")"
+    "print(f\"Last one (global): {resolved[-1]['answer']}\")"
    ]
   },
   {
@@ -612,9 +616,9 @@
    "id": "f0da6f0a",
    "metadata": {},
    "source": [
-    "The resolution order is: resolved stored examples, then question-specific external, then global external.\n",
+    "The resolution order is: resolved stored examples, then global examples.\n",
     "\n",
-    "## 8. Convenience Constructors\n",
+    "## 9. Convenience Constructors\n",
     "\n",
     "`FewShotConfig` provides class methods for common setup patterns:"
    ]
@@ -648,21 +652,21 @@
     "    \"question_1\": [0, 2, 4],\n",
     "    \"question_2\": [1, 3],\n",
     "})\n",
-    "print(f\"from_index_selections: global_mode={by_index.global_mode}, \"\n",
+    "print(f\"from_index_selections: pool_mode={by_index.pool_mode}, \"\n",
     "      f\"questions={list(by_index.question_configs.keys())}\")\n",
     "\n",
     "# Custom selections by hash\n",
     "by_hash = FewShotConfig.from_hash_selections({\n",
     "    \"question_1\": [FewShotConfig.generate_example_hash(\"example question text\")],\n",
     "})\n",
-    "print(f\"from_hash_selections: global_mode={by_hash.global_mode}\")\n",
+    "print(f\"from_hash_selections: pool_mode={by_hash.pool_mode}\")\n",
     "\n",
     "# Different k per question\n",
     "per_q_k = FewShotConfig.k_shot_for_questions({\n",
     "    \"question_1\": 5,\n",
     "    \"question_2\": 2,\n",
-    "}, global_k=3)\n",
-    "print(f\"k_shot_for_questions: global_mode={per_q_k.global_mode}, global_k={per_q_k.global_k}\")"
+    "}, pool_k=3)\n",
+    "print(f\"k_shot_for_questions: pool_mode={per_q_k.pool_mode}, pool_k={per_q_k.pool_k}\")"
    ]
   },
   {
@@ -670,9 +674,9 @@
    "id": "19f32f98",
    "metadata": {},
    "source": [
-    "`from_index_selections` and `from_hash_selections` default to `global_mode=\"custom\"`; `k_shot_for_questions` defaults to `global_mode=\"k-shot\"`.\n",
+    "`from_index_selections` and `from_hash_selections` default to `pool_mode=\"custom\"`; `k_shot_for_questions` defaults to `pool_mode=\"k-shot\"`.\n",
     "\n",
-    "## 9. Using FewShotConfig in Verification\n",
+    "## 10. Using FewShotConfig in Verification\n",
     "\n",
     "Pass the config to `VerificationConfig` via the `few_shot_config` field:"
    ]
@@ -708,8 +712,8 @@
     "        ModelConfig(id=\"judge\", model_provider=\"anthropic\", model_name=\"claude-haiku-4-5\"),\n",
     "    ],\n",
     "    few_shot_config=FewShotConfig(\n",
-    "        global_mode=\"k-shot\",\n",
-    "        global_k=3,\n",
+    "        pool_mode=\"k-shot\",\n",
+    "        pool_k=3,\n",
     "    ),\n",
     ")\n",
     "\n",
@@ -722,7 +726,7 @@
    "id": "cd02d3b0",
    "metadata": {},
    "source": [
-    "When `few_shot_config` is `None` (the default) or `enabled=False`, the pipeline sends the question text directly to the answering model with no examples prepended."
+    "When `few_shot_config` is `None` (the default) or `source=\"disabled\"`, the pipeline sends the question text directly to the answering model with no examples prepended."
    ]
   },
   {
@@ -767,7 +771,7 @@
     "\n",
     "`VerificationConfig` validates few-shot settings at construction time:\n",
     "\n",
-    "- In `k-shot` mode, `global_k` must be at least 1\n",
+    "- In `k-shot` mode, `pool_k` must be at least 1\n",
     "- Per-question `k` values must be at least 1 when specified\n",
     "- `validate_selections()` checks that index and hash selections reference valid examples (call this explicitly after construction if you want bounds checking)"
    ]
@@ -796,7 +800,7 @@
    "source": [
     "# validate_selections returns a list of error messages (empty if valid)\n",
     "fs_config = FewShotConfig(\n",
-    "    global_mode=\"custom\",\n",
+    "    pool_mode=\"custom\",\n",
     "    question_configs={\n",
     "        \"q1\": QuestionFewShotConfig(mode=\"custom\", selected_examples=[0, 1, 99]),\n",
     "    },\n",
@@ -810,39 +814,38 @@
    "id": "27c00333",
    "metadata": {},
    "source": [
-    "## 10. Choosing the Right Mode\n",
+    "## 11. Choosing the Right Mode\n",
     "\n",
     "| Situation | Recommended mode | Rationale |\n",
     "|-----------|-----------------|-----------|\n",
     "| 2 to 5 hand-picked examples per question | `all` | Small set; include everything |\n",
     "| 10+ examples per question, cost-sensitive | `k-shot` | Limits prompt length while preserving reproducibility |\n",
     "| Ablation study: which examples help most? | `custom` | Exact control over which examples appear |\n",
-    "| Baseline comparison without examples | `none` | Clean zero-shot baseline |\n",
+    "| Baseline comparison without examples | `source=\"disabled\"` | Clean zero-shot baseline |\n",
     "| Most questions share a strategy, a few differ | Per-question overrides with `inherit` default | Global mode covers the common case; overrides handle exceptions |\n",
     "\n",
     "**Litmus test for whether few-shot helps**: if the answering model already produces responses that your template can parse and verify, few-shot examples add cost without benefit. Try a zero-shot run first. Add examples when you observe format mismatches, verbose responses where concise ones are expected, or inconsistent answer styles across similar questions.\n",
     "\n",
-    "## 11. FewShotConfig Field Reference\n",
+    "## 12. FewShotConfig Field Reference\n",
     "\n",
     "| Field | Type | Default | Description |\n",
     "|-------|------|---------|-------------|\n",
-    "| `enabled` | `bool` | `True` | Master switch; when `False`, no examples are used regardless of mode |\n",
-    "| `global_mode` | `Literal[\"all\", \"k-shot\", \"custom\", \"none\"]` | `\"all\"` | Default mode for all questions |\n",
-    "| `global_k` | `int` | `3` | Number of examples for `k-shot` mode |\n",
+    "| `source` | `Literal[\"pool\", \"global\", \"both\", \"disabled\"]` | `\"both\"` | Controls where examples come from: per-question pool, global list, both, or disabled entirely |\n",
+    "| `pool_mode` | `Literal[\"all\", \"k-shot\", \"custom\"]` | `\"all\"` | Default selection mode for per-question example pools |\n",
+    "| `pool_k` | `int` | `3` | Number of examples for `k-shot` mode |\n",
     "| `question_configs` | `dict[str, QuestionFewShotConfig]` | `{}` | Per-question overrides keyed by question ID |\n",
-    "| `global_external_examples` | `list[dict[str, str]]` | `[]` | External examples appended to every question |\n",
+    "| `global_examples` | `list[dict[str, str]]` | `[]` | Examples appended to every question |\n",
     "\n",
     "### QuestionFewShotConfig Fields\n",
     "\n",
     "| Field | Type | Default | Description |\n",
     "|-------|------|---------|-------------|\n",
-    "| `mode` | `Literal[\"all\", \"k-shot\", \"custom\", \"none\", \"inherit\"]` | `\"inherit\"` | Selection mode for this question |\n",
+    "| `mode` | `Literal[\"all\", \"k-shot\", \"custom\", \"inherit\"]` | `\"inherit\"` | Selection mode for this question |\n",
     "| `k` | `int \\| None` | `None` | Override global k for this question (k-shot mode) |\n",
     "| `selected_examples` | `list[str \\| int] \\| None` | `None` | Indices or MD5 hashes for custom mode |\n",
-    "| `external_examples` | `list[dict[str, str]] \\| None` | `None` | Question-specific external examples |\n",
     "| `excluded_examples` | `list[str \\| int] \\| None` | `None` | Indices or hashes of examples to exclude |\n",
     "\n",
-    "## 12. Provenance in Results\n",
+    "## 13. Provenance in Results\n",
     "\n",
     "When few-shot is active, the verification result records provenance metadata so you can trace which results used few-shot prompting:\n",
     "\n",
@@ -853,7 +856,7 @@
     "\n",
     "These fields enable filtering and grouping in analysis (e.g., comparing accuracy with and without few-shot examples across the same benchmark).\n",
     "\n",
-    "## 13. Next Steps\n",
+    "## 14. Next Steps\n",
     "\n",
     "- [Answer Templates](../answer-templates/): what few-shot examples help the answering model produce\n",
     "- [Verification Pipeline](../verification-pipeline/): where GenerateAnswer fits in the 13-stage pipeline\n",

--- a/docs/notebooks/creating-benchmarks/scaled-authoring.ipynb
+++ b/docs/notebooks/creating-benchmarks/scaled-authoring.ipynb
@@ -34,7 +34,7 @@
     "# Mocks LLM-dependent operations so examples execute without API keys.\n",
     "import tempfile\n",
     "from pathlib import Path\n",
-    "from unittest.mock import patch\n",
+    "from unittest.mock import MagicMock, patch\n",
     "\n",
     "# Mock for generate_all_templates — returns pre-built template results\n",
     "_mock_template_results = {}\n",
@@ -112,7 +112,9 @@
    "id": "0d24ff75",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from karenina.benchmark.authoring.questions import extract_questions_from_file"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -326,7 +328,9 @@
    "id": "03d0f773",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from karenina.integrations.adele import QuestionClassifier"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -415,7 +419,7 @@
    "source": [
     "### FewShotConfig for Verification\n",
     "\n",
-    "`FewShotConfig` controls *which* examples are used during verification. Global external examples are appended to every question. The `global_k` parameter limits how many per-question examples are included."
+    "`FewShotConfig` controls *which* examples are used during verification. Global examples are appended to every question. The `pool_k` parameter limits how many per-question examples are included."
    ]
   },
   {
@@ -425,19 +429,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from karenina.schemas import FewShotConfig\n",
+    "from karenina.schemas import FewShotConfig, QuestionFewShotConfig\n",
     "\n",
     "few_shot_config = FewShotConfig(\n",
-    "    global_mode=\"k-shot\",\n",
-    "    global_k=2,\n",
-    "    global_external_examples=[\n",
+    "    pool_mode=\"k-shot\",\n",
+    "    pool_k=2,\n",
+    "    global_examples=[\n",
     "        {\"question\": \"What class of drug is aspirin?\", \"answer\": \"NSAID\"},\n",
     "    ],\n",
     ")\n",
     "\n",
-    "print(f\"Mode: {few_shot_config.global_mode}\")\n",
-    "print(f\"K: {few_shot_config.global_k}\")\n",
-    "print(f\"Global external examples: {len(few_shot_config.global_external_examples)}\")"
+    "print(f\"Mode: {few_shot_config.pool_mode}\")\n",
+    "print(f\"K: {few_shot_config.pool_k}\")\n",
+    "print(f\"Global examples: {len(few_shot_config.global_examples)}\")"
    ]
   },
   {
@@ -487,7 +491,6 @@
    "outputs": [],
    "source": [
     "import shutil\n",
-    "\n",
     "shutil.rmtree(tmpdir, ignore_errors=True)"
    ]
   },

--- a/docs/notebooks/running-verification/few-shot-configuration.ipynb
+++ b/docs/notebooks/running-verification/few-shot-configuration.ipynb
@@ -12,9 +12,9 @@
     "**What you'll learn:**\n",
     "\n",
     "- Add few-shot examples when creating questions\n",
-    "- Configure `FewShotConfig` with global modes (all, k-shot, custom, none)\n",
+    "- Configure `FewShotConfig` with source and pool modes (all, k-shot, custom)\n",
     "- Override per-question with `QuestionFewShotConfig` and `inherit` mode\n",
-    "- Add global external examples\n",
+    "- Add global examples\n",
     "- Select examples by index with `from_index_selections()`\n",
     "- Resolve final examples with `resolve_examples_for_question()`\n",
     "- Attach `FewShotConfig` to `VerificationConfig`"
@@ -41,7 +41,7 @@
     "# This cell is hidden in the rendered documentation.\n",
     "# No LLM mocking needed: FewShotConfig is pure configuration and resolve is deterministic.\n",
     "from karenina import Benchmark\n",
-    "from karenina.schemas.config.models import FewShotConfig, ModelConfig, QuestionFewShotConfig\n",
+    "from karenina.schemas.config.models import FewShotConfig, QuestionFewShotConfig, ModelConfig\n",
     "from karenina.schemas.verification.config import VerificationConfig\n",
     "\n",
     "_benchmark = Benchmark.create(name=\"Drug QA\", description=\"Few-shot demo\", version=\"1.0.0\")\n",
@@ -198,13 +198,14 @@
     }
    ],
    "source": [
+    "from karenina.schemas.config.models import FewShotConfig\n",
     "\n",
-    "config_all = FewShotConfig(global_mode=\"all\")\n",
+    "config_all = FewShotConfig(pool_mode=\"all\")\n",
     "resolved = config_all.resolve_examples_for_question(\n",
     "    question_id=_q2_id, available_examples=_examples_by_qid[_q2_id],\n",
     ")\n",
     "\n",
-    "print(f\"Mode: {config_all.global_mode}\")\n",
+    "print(f\"Mode: {config_all.pool_mode}\")\n",
     "print(f\"Available: {len(_examples_by_qid[_q2_id])}, Resolved: {len(resolved)}\")\n",
     "for ex in resolved:\n",
     "    print(f\"  Q: {ex['question'][:45]}  A: {ex['answer']}\")"
@@ -249,12 +250,12 @@
     }
    ],
    "source": [
-    "config_kshot = FewShotConfig(global_mode=\"k-shot\", global_k=2)\n",
+    "config_kshot = FewShotConfig(pool_mode=\"k-shot\", pool_k=2)\n",
     "resolved = config_kshot.resolve_examples_for_question(\n",
     "    question_id=_q2_id, available_examples=_examples_by_qid[_q2_id],\n",
     ")\n",
     "\n",
-    "print(f\"Mode: {config_kshot.global_mode}, k={config_kshot.global_k}\")\n",
+    "print(f\"Mode: {config_kshot.pool_mode}, k={config_kshot.pool_k}\")\n",
     "print(f\"Available: {len(_examples_by_qid[_q2_id])}, Resolved: {len(resolved)}\")\n",
     "for ex in resolved:\n",
     "    print(f\"  Q: {ex['question'][:45]}  A: {ex['answer']}\")"
@@ -308,7 +309,7 @@
     "    question_id=_q1_id, available_examples=_examples_by_qid[_q1_id],\n",
     ")\n",
     "\n",
-    "print(f\"Mode: {config_custom.global_mode}\")\n",
+    "print(f\"Mode: {config_custom.pool_mode}\")\n",
     "print(f\"Q1 resolved ({len(resolved_q1)} examples):\")\n",
     "for ex in resolved_q1:\n",
     "    print(f\"  Q: {ex['question'][:45]}  A: {ex['answer']}\")"
@@ -321,9 +322,9 @@
    "source": [
     "---\n",
     "\n",
-    "## Global Mode: None\n",
+    "## Disabling Few-Shot\n",
     "\n",
-    "Disabling few-shot entirely returns an empty list for all questions:"
+    "Setting `source=\"disabled\"` turns off few-shot entirely, returning an empty list for all questions:"
    ]
   },
   {
@@ -349,12 +350,12 @@
     }
    ],
    "source": [
-    "config_none = FewShotConfig(global_mode=\"none\")\n",
+    "config_none = FewShotConfig(source=\"disabled\")\n",
     "resolved = config_none.resolve_examples_for_question(\n",
     "    question_id=_q1_id, available_examples=_examples_by_qid[_q1_id],\n",
     ")\n",
     "\n",
-    "print(f\"Mode: {config_none.global_mode}\")\n",
+    "print(f\"Source: {config_none.source}\")\n",
     "print(f\"Resolved examples: {len(resolved)}\")"
    ]
   },
@@ -363,7 +364,7 @@
    "id": "790918ec",
    "metadata": {},
    "source": [
-    "Use `none` to establish a zero-shot baseline for comparison.\n",
+    "Use `source=\"disabled\"` to establish a zero-shot baseline for comparison.\n",
     "\n",
     "---\n",
     "\n",
@@ -397,12 +398,13 @@
     }
    ],
    "source": [
+    "from karenina.schemas.config.models import QuestionFewShotConfig\n",
     "\n",
     "config_mixed = FewShotConfig(\n",
-    "    global_mode=\"all\",\n",
+    "    pool_mode=\"all\",\n",
     "    question_configs={\n",
     "        _q1_id: QuestionFewShotConfig(mode=\"k-shot\", k=1),   # Sample 1 example\n",
-    "        _q3_id: QuestionFewShotConfig(mode=\"none\"),            # Disable for q3\n",
+    "        _q3_id: QuestionFewShotConfig(mode=\"custom\", selected_examples=[]),  # No examples for q3\n",
     "        # q2, q4: inherit global \"all\" mode\n",
     "    },\n",
     ")\n",
@@ -424,9 +426,9 @@
     "\n",
     "---\n",
     "\n",
-    "## Global External Examples\n",
+    "## Global Examples\n",
     "\n",
-    "Global external examples are appended to every question's resolved examples, regardless of mode:"
+    "Global examples are appended to every question's resolved examples, regardless of mode:"
    ]
   },
   {
@@ -454,18 +456,18 @@
     }
    ],
    "source": [
-    "config_external = FewShotConfig(\n",
-    "    global_mode=\"k-shot\", global_k=1,\n",
-    "    global_external_examples=[\n",
+    "config_global = FewShotConfig(\n",
+    "    pool_mode=\"k-shot\", pool_k=1,\n",
+    "    global_examples=[\n",
     "        {\"question\": \"What is the capital of France?\", \"answer\": \"Paris\"},\n",
     "        {\"question\": \"What is 2 + 2?\", \"answer\": \"4\"},\n",
     "    ],\n",
     ")\n",
-    "resolved = config_external.resolve_examples_for_question(\n",
+    "resolved = config_global.resolve_examples_for_question(\n",
     "    question_id=_q1_id, available_examples=_examples_by_qid[_q1_id],\n",
     ")\n",
     "\n",
-    "print(f\"Total resolved: {len(resolved)} (1 from k-shot + 2 global external)\")\n",
+    "print(f\"Total resolved: {len(resolved)} (1 from k-shot + 2 global)\")\n",
     "for ex in resolved:\n",
     "    print(f\"  Q: {ex['question'][:45]}  A: {ex['answer']}\")"
    ]
@@ -475,7 +477,7 @@
    "id": "7fd0959f",
    "metadata": {},
    "source": [
-    "Resolution order: stored examples first, then question-specific external, then global external. Add question-specific external examples via `QuestionFewShotConfig.external_examples`.\n",
+    "Resolution order: stored examples first, then global examples.\n",
     "\n",
     "---\n",
     "\n",
@@ -513,7 +515,7 @@
     "config_bulk = FewShotConfig.from_index_selections({\n",
     "    _q1_id: [0, 1], _q2_id: [0, 2, 3], _q3_id: [1], _q4_id: [0, 3],\n",
     "})\n",
-    "print(f\"Custom bulk (mode={config_bulk.global_mode}):\")\n",
+    "print(f\"Custom bulk (mode={config_bulk.pool_mode}):\")\n",
     "for qid, label in [(_q1_id, \"q1\"), (_q2_id, \"q2\"), (_q3_id, \"q3\"), (_q4_id, \"q4\")]:\n",
     "    resolved = config_bulk.resolve_examples_for_question(\n",
     "        question_id=qid, available_examples=_examples_by_qid[qid],\n",
@@ -549,9 +551,9 @@
    "source": [
     "config_varied_k = FewShotConfig.k_shot_for_questions(\n",
     "    question_k_mapping={_q1_id: 1, _q2_id: 3, _q4_id: 2},\n",
-    "    global_k=2,\n",
+    "    pool_k=2,\n",
     ")\n",
-    "print(f\"Varied k-shot (mode={config_varied_k.global_mode}):\")\n",
+    "print(f\"Varied k-shot (mode={config_varied_k.pool_mode}):\")\n",
     "for qid, label in [(_q1_id, \"q1\"), (_q2_id, \"q2\"), (_q3_id, \"q3\"), (_q4_id, \"q4\")]:\n",
     "    effective = config_varied_k.get_effective_config(qid)\n",
     "    print(f\"  {label}: k={effective.k}\")"
@@ -593,8 +595,8 @@
    ],
    "source": [
     "config_preview = FewShotConfig(\n",
-    "    global_mode=\"all\",\n",
-    "    global_external_examples=[\n",
+    "    pool_mode=\"all\",\n",
+    "    global_examples=[\n",
     "        {\"question\": \"Format example\", \"answer\": \"Short, precise answer\"},\n",
     "    ],\n",
     "    question_configs={_q2_id: QuestionFewShotConfig(mode=\"k-shot\", k=2)},\n",
@@ -603,12 +605,12 @@
     "resolved_q1 = config_preview.resolve_examples_for_question(\n",
     "    question_id=_q1_id, available_examples=_examples_by_qid[_q1_id],\n",
     ")\n",
-    "print(f\"Q1 (inherits 'all'): {len(resolved_q1)} examples (3 stored + 1 external)\")\n",
+    "print(f\"Q1 (inherits 'all'): {len(resolved_q1)} examples (3 stored + 1 global)\")\n",
     "\n",
     "resolved_q2 = config_preview.resolve_examples_for_question(\n",
     "    question_id=_q2_id, available_examples=_examples_by_qid[_q2_id],\n",
     ")\n",
-    "print(f\"Q2 (k-shot, k=2):   {len(resolved_q2)} examples (2 sampled + 1 external)\")"
+    "print(f\"Q2 (k-shot, k=2):   {len(resolved_q2)} examples (2 sampled + 1 global)\")"
    ]
   },
   {
@@ -650,11 +652,13 @@
     }
    ],
    "source": [
+    "from karenina.schemas.verification.config import VerificationConfig\n",
+    "from karenina.schemas.config.models import ModelConfig\n",
     "\n",
     "few_shot = FewShotConfig(\n",
-    "    global_mode=\"k-shot\",\n",
-    "    global_k=2,\n",
-    "    question_configs={_q3_id: QuestionFewShotConfig(mode=\"none\")},\n",
+    "    pool_mode=\"k-shot\",\n",
+    "    pool_k=2,\n",
+    "    question_configs={_q3_id: QuestionFewShotConfig(mode=\"custom\", selected_examples=[])},\n",
     ")\n",
     "\n",
     "config = VerificationConfig(\n",
@@ -670,9 +674,9 @@
     "    few_shot_config=few_shot,\n",
     ")\n",
     "\n",
-    "print(f\"Few-shot enabled: {config.few_shot_config.enabled}\")\n",
-    "print(f\"Global mode:      {config.few_shot_config.global_mode}\")\n",
-    "print(f\"Global k:         {config.few_shot_config.global_k}\")\n",
+    "print(f\"Source:           {config.few_shot_config.source}\")\n",
+    "print(f\"Pool mode:        {config.few_shot_config.pool_mode}\")\n",
+    "print(f\"Pool k:           {config.few_shot_config.pool_k}\")\n",
     "print(f\"Per-question:     {len(config.few_shot_config.question_configs)} overrides\")"
    ]
   },
@@ -681,13 +685,13 @@
    "id": "ab5236e5",
    "metadata": {},
    "source": [
-    "When `few_shot_config` is `None` (the default) or `enabled=False`, no examples are prepended.\n",
+    "When `few_shot_config` is `None` (the default) or `source=\"disabled\"`, no examples are prepended.\n",
     "\n",
     "---\n",
     "\n",
     "## Tuning Strategy\n",
     "\n",
-    "- Start with `global_mode=\"none\"` to establish a zero-shot baseline\n",
+    "- Start with `source=\"disabled\"` to establish a zero-shot baseline\n",
     "- If the answering model produces poorly formatted responses, add 2 to 3 examples per question\n",
     "- Use `resolve_examples_for_question()` to preview before running full verification\n",
     "- Increase *k* incrementally; more examples increase prompt cost without guaranteed improvement\n",

--- a/docs/superpowers/plans/2026-03-24-dead-code-cleanup.md
+++ b/docs/superpowers/plans/2026-03-24-dead-code-cleanup.md
@@ -1,0 +1,940 @@
+# Dead Code Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clean up dead code paths, wire in unused PromptConfig.generation, add instruction shortcuts, restructure FewShotConfig, and remove runner auto-upgrade.
+
+**Architecture:** Four independent changes, ordered by complexity. Each is TDD: write failing test, implement, verify, commit. The FewShotConfig restructure (Task 4) has the widest ripple effects across models.py, config.py, task_helpers.py, interactive.py, and test files.
+
+**Tech Stack:** Python 3.13, Pydantic v2, pytest
+
+**Spec:** `docs/superpowers/specs/2026-03-24-dead-code-design-decisions.md`
+
+---
+
+## Task 1: Remove Runner Auto-Upgrade
+
+**Files:**
+- Modify: `src/karenina/benchmark/verification/runner.py:211-220`
+- Test: `tests/unit/benchmark/verification/test_runner_auto_upgrade.py` (create)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/benchmark/verification/test_runner_auto_upgrade.py`:
+
+```python
+"""Tests for runner evaluation_mode auto-upgrade removal."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from karenina.schemas.entities.rubric import LLMRubricTrait, Rubric
+
+
+@pytest.mark.unit
+class TestRunnerAutoUpgrade:
+    """Verify that runner no longer auto-upgrades template_only to template_and_rubric."""
+
+    def test_template_only_with_rubric_warns_and_does_not_upgrade(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Rubric traits with template_only should warn, not upgrade."""
+        from karenina.benchmark.verification.runner import run_single_model_verification
+        from karenina.schemas.config import ModelConfig
+
+        rubric = Rubric(llm_traits=[LLMRubricTrait(name="clarity", description="Is the response clear?")])
+        answering = ModelConfig(id="test", model_name="test", model_provider="openai", system_prompt="You are helpful.")
+        parsing = ModelConfig(id="test", model_name="test", model_provider="openai", system_prompt="Parse.")
+
+        # Mock StageOrchestrator to avoid running the full pipeline
+        with (
+            patch("karenina.benchmark.verification.runner.StageOrchestrator") as mock_orch,
+            caplog.at_level(logging.WARNING),
+        ):
+            mock_orch.from_config.return_value.execute.return_value = None
+            run_single_model_verification(
+                question_id="q1",
+                question_text="What is 2+2?",
+                template_code="class Answer(BaseAnswer): value: str",
+                answering_model=answering,
+                parsing_model=parsing,
+                evaluation_mode="template_only",
+                rubric=rubric,
+            )
+
+        assert any("template_only" in r.message and "Rubric" in r.message for r in caplog.records)
+        # Verify evaluation_mode was NOT changed: from_config should receive "template_only"
+        call_kwargs = mock_orch.from_config.call_args
+        assert call_kwargs.kwargs.get("evaluation_mode", call_kwargs[1].get("evaluation_mode")) == "template_only"
+
+    def test_template_only_without_rubric_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """No rubric traits should produce no warning."""
+        from karenina.benchmark.verification.runner import run_single_model_verification
+        from karenina.schemas.config import ModelConfig
+
+        answering = ModelConfig(id="test", model_name="test", model_provider="openai", system_prompt="You are helpful.")
+        parsing = ModelConfig(id="test", model_name="test", model_provider="openai", system_prompt="Parse.")
+
+        with (
+            patch("karenina.benchmark.verification.runner.StageOrchestrator") as mock_orch,
+            caplog.at_level(logging.WARNING),
+        ):
+            mock_orch.from_config.return_value.execute.return_value = None
+            run_single_model_verification(
+                question_id="q1",
+                question_text="What is 2+2?",
+                template_code="class Answer(BaseAnswer): value: str",
+                answering_model=answering,
+                parsing_model=parsing,
+                evaluation_mode="template_only",
+            )
+
+        assert not any("template_only" in r.message for r in caplog.records)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/unit/benchmark/verification/test_runner_auto_upgrade.py -v`
+
+Expected: First test FAILS (no warning emitted because the auto-upgrade happens silently).
+
+- [ ] **Step 3: Implement the change**
+
+In `src/karenina/benchmark/verification/runner.py`, replace lines 211-220 (the auto-upgrade block):
+
+```python
+# OLD (lines 211-220):
+_has_rubric_traits = rubric and (...)
+_has_dynamic_rubric_traits = ...
+if (...) and evaluation_mode == "template_only":
+    evaluation_mode = "template_and_rubric"
+
+# NEW:
+_has_rubric_traits = rubric and (
+    rubric.llm_traits
+    or rubric.regex_traits
+    or rubric.callable_traits
+    or rubric.metric_traits
+    or rubric.agentic_traits
+)
+_has_dynamic_rubric_traits = dynamic_rubric is not None and not dynamic_rubric.is_empty()
+if (_has_rubric_traits or _has_dynamic_rubric_traits) and evaluation_mode == "template_only":
+    logger.warning(
+        "Rubric traits were provided but evaluation_mode='template_only'. "
+        "Rubric evaluation will be skipped. Set evaluation_mode='template_and_rubric' "
+        "to evaluate rubric traits."
+    )
+```
+
+The only change: replace `evaluation_mode = "template_and_rubric"` with `logger.warning(...)`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/unit/benchmark/verification/test_runner_auto_upgrade.py -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Run existing runner tests to check for regressions**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/unit/benchmark/verification/ -v -x`
+
+Expected: PASS (no existing tests depend on the auto-upgrade)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/karenina/benchmark/verification/runner.py tests/unit/benchmark/verification/test_runner_auto_upgrade.py
+git commit -m "fix: replace silent evaluation_mode auto-upgrade with warning"
+```
+
+---
+
+## Task 2: Wire In PromptConfig.generation
+
+**Files:**
+- Modify: `src/karenina/benchmark/verification/stages/pipeline/generate_answer.py:268-272`
+- Test: `tests/unit/benchmark/verification/stages/test_generate_answer_prompt_config.py` (create)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/benchmark/verification/stages/test_generate_answer_prompt_config.py`:
+
+```python
+"""Tests for PromptConfig.generation wiring in GenerateAnswerStage."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import VerificationContext
+from karenina.benchmark.verification.stages.pipeline.generate_answer import GenerateAnswerStage
+from karenina.ports import Message
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification.prompt_config import PromptConfig
+
+
+def _make_context(
+    system_prompt: str | None = "You are helpful.",
+    prompt_config: PromptConfig | None = None,
+) -> VerificationContext:
+    """Create a minimal VerificationContext for testing."""
+    model = ModelConfig(
+        id="test",
+        model_name="test",
+        model_provider="openai",
+        system_prompt=system_prompt,
+    )
+    ctx = VerificationContext(
+        question_id="q1",
+        template_id="t1",
+        question_text="What is 2+2?",
+        template_code="class Answer(BaseAnswer): value: str",
+        answering_model=model,
+        parsing_model=model,
+        prompt_config=prompt_config,
+    )
+    return ctx
+
+
+def _capture_adapter_messages(context: VerificationContext) -> list[Message]:
+    """Run GenerateAnswerStage.execute() with mocked adapter, return captured messages."""
+    stage = GenerateAnswerStage()
+    captured: list[Message] = []
+
+    mock_llm = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = "4"
+    mock_response.usage = None
+    mock_llm.invoke.side_effect = lambda msgs: (captured.extend(msgs), mock_response)[1]
+
+    with patch("karenina.benchmark.verification.stages.pipeline.generate_answer.get_llm", return_value=mock_llm):
+        stage.execute(context)
+
+    return captured
+
+
+@pytest.mark.unit
+class TestPromptConfigGeneration:
+    """Test that PromptConfig.generation is injected into the system message."""
+
+    def test_generation_instructions_appended_to_system_prompt(self) -> None:
+        """PromptConfig.generation should appear in the system message."""
+        ctx = _make_context(
+            system_prompt="You are helpful.",
+            prompt_config=PromptConfig(generation="Focus on clinical accuracy."),
+        )
+        messages = _capture_adapter_messages(ctx)
+        system_msgs = [m for m in messages if m.role == "system"]
+        assert len(system_msgs) == 1
+        assert "You are helpful." in system_msgs[0].content
+        assert "Focus on clinical accuracy." in system_msgs[0].content
+
+    def test_no_prompt_config_uses_system_prompt_only(self) -> None:
+        """Without PromptConfig, only ModelConfig.system_prompt is used."""
+        ctx = _make_context(system_prompt="You are helpful.", prompt_config=None)
+        messages = _capture_adapter_messages(ctx)
+        system_msgs = [m for m in messages if m.role == "system"]
+        assert len(system_msgs) == 1
+        assert system_msgs[0].content == "You are helpful."
+
+    def test_generation_none_does_not_change_system_prompt(self) -> None:
+        """PromptConfig with generation=None should not modify the system message."""
+        ctx = _make_context(
+            system_prompt="You are helpful.",
+            prompt_config=PromptConfig(generation=None),
+        )
+        messages = _capture_adapter_messages(ctx)
+        system_msgs = [m for m in messages if m.role == "system"]
+        assert len(system_msgs) == 1
+        assert system_msgs[0].content == "You are helpful."
+
+    def test_no_system_prompt_generation_only(self) -> None:
+        """When ModelConfig.system_prompt is None, only generation instructions appear."""
+        ctx = _make_context(
+            system_prompt=None,
+            prompt_config=PromptConfig(generation="Be concise."),
+        )
+        messages = _capture_adapter_messages(ctx)
+        system_msgs = [m for m in messages if m.role == "system"]
+        assert len(system_msgs) == 1
+        assert system_msgs[0].content == "Be concise."
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/unit/benchmark/verification/stages/test_generate_answer_prompt_config.py -v`
+
+Expected: First test FAILS (generation instructions not in system message because the stage doesn't read PromptConfig yet).
+
+- [ ] **Step 3: Implement the change**
+
+In `src/karenina/benchmark/verification/stages/pipeline/generate_answer.py`, replace lines 270-272:
+
+```python
+# OLD:
+            adapter_messages: list[Message] = []
+            if answering_model.system_prompt:
+                adapter_messages.append(Message.system(answering_model.system_prompt))
+
+# NEW:
+            adapter_messages: list[Message] = []
+            system_parts: list[str] = []
+            if answering_model.system_prompt:
+                system_parts.append(answering_model.system_prompt)
+            if context.prompt_config:
+                gen_instructions = context.prompt_config.get_for_task("generation")
+                if gen_instructions:
+                    system_parts.append(gen_instructions)
+            if system_parts:
+                adapter_messages.append(Message.system("\n\n".join(system_parts)))
+```
+
+- [ ] **Step 4: Run existing generate_answer tests to check for regressions**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/unit/benchmark/verification/stages/test_generate_answer_routing.py -v -x`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/karenina/benchmark/verification/stages/pipeline/generate_answer.py tests/unit/benchmark/verification/stages/test_generate_answer_prompt_config.py
+git commit -m "feat: wire PromptConfig.generation into answer generation stage"
+```
+
+---
+
+## Task 3: Remove Dead Parsing System Prompt + Add Instruction Shortcuts
+
+**Files:**
+- Modify: `src/karenina/schemas/verification/config.py:320-330,369-380,173`
+- Test: `tests/unit/schemas/test_verification_config.py` (modify existing)
+- Test: `tests/unit/schemas/test_instruction_shortcuts.py` (create)
+- Test: `tests/unit/schemas/test_verification_config_issues.py` (modify existing)
+
+### Step Group A: Remove Dead Auto-Assignment
+
+- [ ] **Step 1: Write failing test for parsing model without system_prompt**
+
+Add to `tests/unit/schemas/test_verification_config.py` (or create `tests/unit/schemas/test_parsing_system_prompt_removal.py`):
+
+```python
+"""Tests for parsing model system_prompt relaxation."""
+
+import pytest
+
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification.config import VerificationConfig
+
+
+@pytest.mark.unit
+class TestParsingSystemPromptRelaxation:
+    """Verify parsing models no longer need system_prompt."""
+
+    def test_parsing_model_none_system_prompt_valid(self) -> None:
+        """Parsing model with system_prompt=None should not raise."""
+        answering = ModelConfig(id="a", model_name="m", model_provider="openai", system_prompt="You are helpful.")
+        parsing = ModelConfig(id="p", model_name="m", model_provider="openai", system_prompt=None)
+        config = VerificationConfig(answering_models=[answering], parsing_models=[parsing])
+        assert config.parsing_models[0].system_prompt is None
+
+    def test_answering_model_still_requires_system_prompt(self) -> None:
+        """Answering model with system_prompt=None should still raise."""
+        answering = ModelConfig(id="a", model_name="m", model_provider="openai", system_prompt=None)
+        parsing = ModelConfig(id="p", model_name="m", model_provider="openai", system_prompt=None)
+        with pytest.raises(ValueError, match="[Ss]ystem prompt.*required.*answering"):
+            VerificationConfig(answering_models=[answering], parsing_models=[parsing])
+
+    def test_parsing_model_no_auto_assignment(self) -> None:
+        """Parsing model should NOT receive DEFAULT_PARSING_SYSTEM_PROMPT."""
+        answering = ModelConfig(id="a", model_name="m", model_provider="openai", system_prompt="You are helpful.")
+        parsing = ModelConfig(id="p", model_name="m", model_provider="openai")
+        config = VerificationConfig(answering_models=[answering], parsing_models=[parsing])
+        # Should be None, not auto-assigned
+        assert config.parsing_models[0].system_prompt is None
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/unit/schemas/test_parsing_system_prompt_removal.py -v`
+
+Expected: FAIL (first test raises ValueError, third test gets auto-assigned prompt)
+
+- [ ] **Step 3: Implement Part A**
+
+In `src/karenina/schemas/verification/config.py`:
+
+1. **Remove parsing auto-assignment** (lines 320-330): Delete the `if "parsing_models" in data:` block that copies models with DEFAULT_PARSING_SYSTEM_PROMPT.
+
+2. **Split validation loop** (lines 369-390): Replace the single loop with two separate loops:
+
+```python
+# Validate answering model configurations
+for model in self.answering_models:
+    if not model.model_name:
+        raise ValueError(f"Model name is required in model configuration (model: {model.id})")
+    from karenina.adapters.registry import AdapterRegistry
+    spec = AdapterRegistry.get_spec(model.interface)
+    if spec is not None and spec.requires_provider and not model.model_provider:
+        raise ValueError(f"Model provider is required for interface '{model.interface}'. (model: {model.id})")
+    if not model.system_prompt:
+        raise ValueError(f"System prompt is required for answering model {model.id}")
+
+# Validate parsing model configurations (system_prompt not required)
+for model in self.parsing_models:
+    if not model.model_name:
+        raise ValueError(f"Model name is required in model configuration (model: {model.id})")
+    from karenina.adapters.registry import AdapterRegistry
+    spec = AdapterRegistry.get_spec(model.interface)
+    if spec is not None and spec.requires_provider and not model.model_provider:
+        raise ValueError(f"Model provider is required for interface '{model.interface}'. (model: {model.id})")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/unit/schemas/test_parsing_system_prompt_removal.py -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Fix existing tests that assert auto-assignment**
+
+Search for assertions matching `== DEFAULT_PARSING_SYSTEM_PROMPT` in the test files:
+- In `tests/unit/schemas/test_verification_config.py`: find `assert config.parsing_models[0].system_prompt == DEFAULT_PARSING_SYSTEM_PROMPT` and change to `assert config.parsing_models[0].system_prompt is None`.
+- In `tests/unit/schemas/test_verification_config_issues.py`: same pattern, change to `assert ... is None`.
+
+- [ ] **Step 6: Run full schema test suite**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/unit/schemas/ -v -x`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit Part A**
+
+```bash
+git add src/karenina/schemas/verification/config.py tests/unit/schemas/test_parsing_system_prompt_removal.py tests/unit/schemas/test_verification_config.py tests/unit/schemas/test_verification_config_issues.py
+git commit -m "fix: remove dead DEFAULT_PARSING_SYSTEM_PROMPT auto-assignment for parsing models"
+```
+
+### Step Group B: Add Instruction Shortcuts
+
+- [ ] **Step 8: Write failing tests for shortcuts**
+
+Create `tests/unit/schemas/test_instruction_shortcuts.py`:
+
+```python
+"""Tests for VerificationConfig instruction shortcut fields."""
+
+import pytest
+
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification.config import VerificationConfig
+from karenina.schemas.verification.prompt_config import PromptConfig
+
+
+def _make_models() -> tuple[ModelConfig, ModelConfig]:
+    answering = ModelConfig(id="a", model_name="m", model_provider="openai", system_prompt="You are helpful.")
+    parsing = ModelConfig(id="p", model_name="m", model_provider="openai")
+    return answering, parsing
+
+
+@pytest.mark.unit
+class TestInstructionShortcuts:
+    """Test that *_instructions shortcuts wire into PromptConfig."""
+
+    def test_parsing_instructions_creates_prompt_config(self) -> None:
+        a, p = _make_models()
+        config = VerificationConfig(
+            answering_models=[a], parsing_models=[p],
+            parsing_instructions="Be strict",
+        )
+        assert config.prompt_config is not None
+        assert config.prompt_config.parsing == "Be strict"
+
+    def test_generation_instructions_creates_prompt_config(self) -> None:
+        a, p = _make_models()
+        config = VerificationConfig(
+            answering_models=[a], parsing_models=[p],
+            generation_instructions="Focus on accuracy",
+        )
+        assert config.prompt_config is not None
+        assert config.prompt_config.generation == "Focus on accuracy"
+
+    def test_multiple_shortcuts_merge(self) -> None:
+        a, p = _make_models()
+        config = VerificationConfig(
+            answering_models=[a], parsing_models=[p],
+            parsing_instructions="Be strict",
+            generation_instructions="Focus on accuracy",
+        )
+        assert config.prompt_config is not None
+        assert config.prompt_config.parsing == "Be strict"
+        assert config.prompt_config.generation == "Focus on accuracy"
+
+    def test_explicit_prompt_config_takes_precedence(self) -> None:
+        a, p = _make_models()
+        config = VerificationConfig(
+            answering_models=[a], parsing_models=[p],
+            prompt_config=PromptConfig(parsing="Explicit"),
+            parsing_instructions="Shortcut",
+        )
+        assert config.prompt_config.parsing == "Explicit"
+
+    def test_shortcut_fills_unset_prompt_config_fields(self) -> None:
+        a, p = _make_models()
+        config = VerificationConfig(
+            answering_models=[a], parsing_models=[p],
+            prompt_config=PromptConfig(parsing="Explicit"),
+            generation_instructions="From shortcut",
+        )
+        assert config.prompt_config.parsing == "Explicit"
+        assert config.prompt_config.generation == "From shortcut"
+
+    def test_all_shortcut_fields_exist(self) -> None:
+        a, p = _make_models()
+        config = VerificationConfig(
+            answering_models=[a], parsing_models=[p],
+            generation_instructions="g",
+            parsing_instructions="p",
+            abstention_detection_instructions="a",
+            sufficiency_detection_instructions="s",
+            rubric_evaluation_instructions="r",
+            agentic_parsing_instructions="ap",
+            deep_judgment_instructions="dj",
+        )
+        pc = config.prompt_config
+        assert pc is not None
+        assert pc.generation == "g"
+        assert pc.parsing == "p"
+        assert pc.abstention_detection == "a"
+        assert pc.sufficiency_detection == "s"
+        assert pc.rubric_evaluation == "r"
+        assert pc.agentic_parsing == "ap"
+        assert pc.deep_judgment == "dj"
+```
+
+- [ ] **Step 9: Run to verify they fail**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/unit/schemas/test_instruction_shortcuts.py -v`
+
+Expected: FAIL (fields don't exist on VerificationConfig yet)
+
+- [ ] **Step 10: Implement Part B**
+
+In `src/karenina/schemas/verification/config.py`, use the pop-before-init pattern (same as existing `rubric_enabled` and `deep_judgment_rubric_search_enabled` handling). Do NOT declare shortcut fields on the model; pop them from `data` in `__init__` before `super().__init__()`.
+
+In `__init__`, add the shortcut wiring before `super().__init__(**data)`:
+
+```python
+        # Wire instruction shortcuts into prompt_config (pop before super().__init__)
+        # These are NOT declared as model fields; they are consumed here and removed from data.
+        shortcut_mapping = {
+            "generation": data.pop("generation_instructions", None),
+            "parsing": data.pop("parsing_instructions", None),
+            "abstention_detection": data.pop("abstention_detection_instructions", None),
+            "sufficiency_detection": data.pop("sufficiency_detection_instructions", None),
+            "rubric_evaluation": data.pop("rubric_evaluation_instructions", None),
+            "agentic_parsing": data.pop("agentic_parsing_instructions", None),
+            "deep_judgment": data.pop("deep_judgment_instructions", None),
+        }
+        active_shortcuts = {k: v for k, v in shortcut_mapping.items() if v is not None}
+        if active_shortcuts:
+            pc = data.get("prompt_config") or PromptConfig()
+            if isinstance(pc, dict):
+                pc = PromptConfig(**pc)
+            updates = {k: v for k, v in active_shortcuts.items() if getattr(pc, k) is None}
+            if updates:
+                pc = pc.model_copy(update=updates)
+            data["prompt_config"] = pc
+```
+
+This follows the same pattern as `data.pop("rubric_enabled", None)` and `data.pop("deep_judgment_rubric_search_enabled", None)` already in this `__init__`.
+
+- [ ] **Step 11: Run tests to verify they pass**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/unit/schemas/test_instruction_shortcuts.py -v`
+
+Expected: PASS
+
+- [ ] **Step 12: Run full schema test suite**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/unit/schemas/ -v -x`
+
+Expected: PASS
+
+- [ ] **Step 13: Commit Part B**
+
+```bash
+git add src/karenina/schemas/verification/config.py tests/unit/schemas/test_instruction_shortcuts.py
+git commit -m "feat: add instruction shortcut fields on VerificationConfig"
+```
+
+---
+
+## Task 4: FewShotConfig Restructure
+
+**Files:**
+- Modify: `src/karenina/schemas/config/models.py` (FewShotConfig, QuestionFewShotConfig)
+- Modify: `src/karenina/schemas/verification/config.py:387-398,566-572,596-604`
+- Modify: `src/karenina/benchmark/verification/utils/task_helpers.py:111`
+- Modify: `src/karenina/cli/interactive.py:413-419`
+- Test: `tests/unit/schemas/test_few_shot_restructure.py` (create)
+- Modify: `tests/unit/schemas/test_kshot_reproducibility.py`
+- Modify: `tests/unit/schemas/test_verification_config.py`
+- Modify: `tests/unit/benchmark/test_task_eval_metadata.py`
+
+### Step Group A: Core Model Restructure
+
+- [ ] **Step 1: Write failing tests for new FewShotConfig structure**
+
+Create `tests/unit/schemas/test_few_shot_restructure.py`:
+
+```python
+"""Tests for FewShotConfig restructure with source/pool_mode/pool_k semantics."""
+
+import pytest
+
+from karenina.schemas.config.models import FewShotConfig, QuestionFewShotConfig
+
+
+@pytest.mark.unit
+class TestFewShotConfigNewFields:
+    """Test the new field names and semantics."""
+
+    def test_default_source_is_both(self) -> None:
+        config = FewShotConfig()
+        assert config.source == "both"
+
+    def test_default_pool_mode_is_all(self) -> None:
+        config = FewShotConfig()
+        assert config.pool_mode == "all"
+
+    def test_default_pool_k_is_3(self) -> None:
+        config = FewShotConfig()
+        assert config.pool_k == 3
+
+    def test_old_field_names_rejected(self) -> None:
+        with pytest.raises(Exception):
+            FewShotConfig(enabled=True)  # type: ignore[call-arg]
+        with pytest.raises(Exception):
+            FewShotConfig(global_mode="all")  # type: ignore[call-arg]
+        with pytest.raises(Exception):
+            FewShotConfig(global_k=5)  # type: ignore[call-arg]
+        with pytest.raises(Exception):
+            FewShotConfig(global_external_examples=[])  # type: ignore[call-arg]
+
+    def test_question_config_no_external_examples(self) -> None:
+        with pytest.raises(Exception):
+            QuestionFewShotConfig(external_examples=[])  # type: ignore[call-arg]
+
+    def test_question_config_no_mode_none(self) -> None:
+        """mode='none' should not be valid."""
+        with pytest.raises(Exception):
+            QuestionFewShotConfig(mode="none")  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestFewShotSourceBehavior:
+    """Test resolve_examples_for_question with different source values."""
+
+    def _pool_examples(self) -> list[dict[str, str]]:
+        return [
+            {"question": "What is X?", "answer": "X is A."},
+            {"question": "What is Y?", "answer": "Y is B."},
+        ]
+
+    def test_disabled_returns_empty(self) -> None:
+        config = FewShotConfig(source="disabled")
+        result = config.resolve_examples_for_question("q1", self._pool_examples())
+        assert result == []
+
+    def test_question_pool_returns_pool_only(self) -> None:
+        config = FewShotConfig(
+            source="question_pool",
+            pool_mode="all",
+            global_examples=[{"question": "Global?", "answer": "Global."}],
+        )
+        result = config.resolve_examples_for_question("q1", self._pool_examples())
+        assert len(result) == 2
+        assert all(ex in self._pool_examples() for ex in result)
+
+    def test_global_returns_global_only(self) -> None:
+        global_ex = [{"question": "Global?", "answer": "Global."}]
+        config = FewShotConfig(source="global", global_examples=global_ex)
+        result = config.resolve_examples_for_question("q1", self._pool_examples())
+        assert result == global_ex
+
+    def test_both_returns_pool_and_global(self) -> None:
+        global_ex = [{"question": "Global?", "answer": "Global."}]
+        config = FewShotConfig(source="both", pool_mode="all", global_examples=global_ex)
+        result = config.resolve_examples_for_question("q1", self._pool_examples())
+        assert len(result) == 3
+        assert result[:2] == self._pool_examples()
+        assert result[2:] == global_ex
+
+    def test_pool_mode_kshot(self) -> None:
+        config = FewShotConfig(source="question_pool", pool_mode="k-shot", pool_k=1)
+        result = config.resolve_examples_for_question("q1", self._pool_examples())
+        assert len(result) == 1
+
+    def test_pool_mode_custom(self) -> None:
+        config = FewShotConfig(
+            source="question_pool",
+            pool_mode="custom",
+            question_configs={"q1": QuestionFewShotConfig(mode="custom", selected_examples=[0])},
+        )
+        result = config.resolve_examples_for_question("q1", self._pool_examples())
+        assert len(result) == 1
+        assert result[0] == self._pool_examples()[0]
+
+    def test_inherit_uses_pool_mode(self) -> None:
+        config = FewShotConfig(source="question_pool", pool_mode="k-shot", pool_k=1)
+        # Default question config uses mode="inherit", inherits pool_mode="k-shot"
+        result = config.resolve_examples_for_question("q1", self._pool_examples())
+        assert len(result) == 1  # 1 pool example, no globals (source="question_pool")
+
+
+@pytest.mark.unit
+class TestFewShotFactoryMethods:
+    """Test that factory methods use new field names."""
+
+    def test_from_index_selections(self) -> None:
+        config = FewShotConfig.from_index_selections({"q1": [0, 1]})
+        assert config.pool_mode == "custom"
+        assert "q1" in config.question_configs
+
+    def test_from_hash_selections(self) -> None:
+        config = FewShotConfig.from_hash_selections({"q1": ["abc123"]})
+        assert config.pool_mode == "custom"
+
+    def test_k_shot_for_questions(self) -> None:
+        config = FewShotConfig.k_shot_for_questions({"q1": 5}, pool_k=3)
+        assert config.pool_mode == "k-shot"
+        assert config.pool_k == 3
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/unit/schemas/test_few_shot_restructure.py -v`
+
+Expected: FAIL (old field names still present)
+
+- [ ] **Step 3: Implement core model changes in models.py**
+
+In `src/karenina/schemas/config/models.py`, update `QuestionFewShotConfig`:
+
+```python
+class QuestionFewShotConfig(BaseModel):
+    """Per-question few-shot configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["all", "k-shot", "custom", "inherit"] = "inherit"
+    k: int | None = None
+    selected_examples: list[str | int] | None = None
+    excluded_examples: list[str | int] | None = None
+```
+
+Update `FewShotConfig`:
+
+```python
+class FewShotConfig(BaseModel):
+    """Flexible configuration for few-shot prompting with convenient bulk setup interface."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Master source selector: what types of examples are active
+    source: Literal["disabled", "question_pool", "global", "both"] = "both"
+
+    # Pool selection settings
+    pool_mode: Literal["all", "k-shot", "custom"] = "all"
+    pool_k: int = 3
+
+    # Per-question configurations
+    question_configs: dict[str, QuestionFewShotConfig] = Field(default_factory=dict)
+
+    # Global examples appended to ALL questions
+    global_examples: list[dict[str, str]] = Field(default_factory=list)
+```
+
+Update factory methods: rename `global_mode` to `pool_mode`, `global_k` to `pool_k` in all of `from_index_selections`, `from_hash_selections`, `k_shot_for_questions`.
+
+Update `get_effective_config`: replace `self.global_mode` with `self.pool_mode`, `self.global_k` with `self.pool_k`, remove `external_examples`.
+
+Replace the body of `resolve_examples_for_question` with source-based gating:
+
+```python
+    def resolve_examples_for_question(
+        self,
+        question_id: str,
+        available_examples: list[dict[str, str]] | None = None,
+        question_text: str | None = None,
+    ) -> list[dict[str, str]]:
+        """Resolve the final list of examples to use for a specific question."""
+        import hashlib
+        import random
+
+        if self.source == "disabled":
+            return []
+
+        include_pool = self.source in ("question_pool", "both")
+        include_global = self.source in ("global", "both")
+
+        resolved_examples: list[dict[str, str]] = []
+
+        # Pool selection (only when source includes question_pool)
+        if include_pool:
+            if available_examples is None:
+                available_examples = []
+
+            effective_config = self.get_effective_config(question_id)
+
+            # Create lookup for hash-to-example mapping if needed
+            example_hash_map: dict[str, int] = {}
+            if question_text is not None and available_examples:
+                for i, example in enumerate(available_examples):
+                    example_question = example.get("question", "")
+                    example_hash = hashlib.md5(example_question.encode("utf-8")).hexdigest()
+                    example_hash_map[example_hash] = i
+
+            if effective_config.mode == "all":
+                resolved_examples = available_examples.copy()
+            elif effective_config.mode == "k-shot":
+                k = effective_config.k if effective_config.k is not None else self.pool_k
+                if len(available_examples) <= k:
+                    resolved_examples = available_examples.copy()
+                else:
+                    random.seed(hash(question_id) & 0x7FFFFFFF)
+                    resolved_examples = random.sample(available_examples, k)
+            elif effective_config.mode == "custom" and effective_config.selected_examples:
+                for selection in effective_config.selected_examples:
+                    if isinstance(selection, int):
+                        if 0 <= selection < len(available_examples):
+                            resolved_examples.append(available_examples[selection])
+                    elif isinstance(selection, str) and selection in example_hash_map:
+                        idx = example_hash_map[selection]
+                        resolved_examples.append(available_examples[idx])
+
+            # Apply exclusions if specified
+            if effective_config.excluded_examples:
+                exclusion_indices: set[int] = set()
+                for exclusion in effective_config.excluded_examples:
+                    if isinstance(exclusion, int):
+                        exclusion_indices.add(exclusion)
+                    elif isinstance(exclusion, str) and exclusion in example_hash_map:
+                        exclusion_indices.add(example_hash_map[exclusion])
+                resolved_examples = [
+                    ex for i, ex in enumerate(resolved_examples) if i not in exclusion_indices
+                ]
+
+        # Append global examples (only when source includes global)
+        final_examples = resolved_examples.copy()
+        if include_global and self.global_examples:
+            final_examples.extend(self.global_examples)
+
+        return final_examples
+```
+
+Update `validate_selections`: remove `external_examples` references from the validation loop.
+
+Update mutation methods (`add_selections_by_index`, etc.): no field name changes needed (they only set question_configs).
+
+- [ ] **Step 4: Run new tests to verify they pass**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/unit/schemas/test_few_shot_restructure.py -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit core changes**
+
+```bash
+git add src/karenina/schemas/config/models.py tests/unit/schemas/test_few_shot_restructure.py
+git commit -m "refactor: restructure FewShotConfig with source/pool_mode/pool_k semantics"
+```
+
+### Step Group B: Update Callers
+
+- [ ] **Step 6: Update config.py callers**
+
+In `src/karenina/schemas/verification/config.py`:
+
+1. **_validate_config (line 387-398)**: Replace `self.few_shot_config.enabled` with `self.few_shot_config.source != "disabled"`, `global_mode` with `pool_mode`, `global_k` with `pool_k`.
+
+2. **__repr__ (lines 568-574)**: Replace `few_shot_config.enabled` with `source != "disabled"`, `global_mode` with `pool_mode`, `global_k` with `pool_k`.
+
+3. **is_few_shot_enabled (line 604)**: Replace `config.enabled` with `config.source != "disabled"`.
+
+- [ ] **Step 7: Update task_helpers.py**
+
+In `src/karenina/benchmark/verification/utils/task_helpers.py:111`:
+
+```python
+# OLD:
+if not few_shot_config or not few_shot_config.enabled:
+
+# NEW:
+if not few_shot_config or few_shot_config.source == "disabled":
+```
+
+- [ ] **Step 8: Update interactive.py**
+
+In `src/karenina/cli/interactive.py:413-419`:
+
+```python
+# OLD:
+few_shot_mode_str = Prompt.ask("Few-shot mode", choices=["all", "k-shot", "custom", "none"], default="all")
+few_shot_mode = cast(Literal["all", "k-shot", "custom", "none"], few_shot_mode_str)
+few_shot_k = _prompt_int_min("Few-shot k (number of examples)", min_val=1, default="3")
+return FewShotConfig(enabled=True, global_mode=few_shot_mode, global_k=few_shot_k)
+
+# NEW:
+few_shot_mode_str = Prompt.ask("Few-shot mode", choices=["all", "k-shot", "custom"], default="all")
+few_shot_mode = cast(Literal["all", "k-shot", "custom"], few_shot_mode_str)
+few_shot_k = _prompt_int_min("Few-shot k (number of examples)", min_val=1, default="3")
+return FewShotConfig(source="both", pool_mode=few_shot_mode, pool_k=few_shot_k)
+```
+
+- [ ] **Step 9: Update existing tests**
+
+1. **`tests/unit/schemas/test_kshot_reproducibility.py`**: Replace `FewShotConfig(global_mode="k-shot", global_k=3)` with `FewShotConfig(source="question_pool", pool_mode="k-shot", pool_k=3)`.
+
+2. **`tests/unit/schemas/test_verification_config.py`**:
+   - Replace `FewShotConfig(enabled=True, global_mode="all", global_k=3)` with `FewShotConfig(source="both", pool_mode="all", pool_k=3)`.
+   - Replace `assert result.enabled is True` with `assert result.source == "both"`.
+   - Replace `assert result.global_mode == "all"` with `assert result.pool_mode == "all"`.
+
+3. **`tests/unit/benchmark/test_task_eval_metadata.py`**: Replace `FewShotConfig(enabled=True)` with `FewShotConfig(source="both")`.
+
+- [ ] **Step 10: Run full test suite**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/unit/ -v -x`
+
+Expected: PASS
+
+- [ ] **Step 11: Commit caller updates**
+
+```bash
+git add src/karenina/schemas/verification/config.py src/karenina/benchmark/verification/utils/task_helpers.py src/karenina/cli/interactive.py tests/unit/schemas/test_kshot_reproducibility.py tests/unit/schemas/test_verification_config.py tests/unit/benchmark/test_task_eval_metadata.py
+git commit -m "refactor: update all FewShotConfig callers to new field names"
+```
+
+---
+
+## Task 5: Final Verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run pytest tests/ -v -x --timeout=60`
+
+Expected: PASS
+
+- [ ] **Step 2: Run type checker**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run mypy src/karenina/schemas/config/models.py src/karenina/schemas/verification/config.py src/karenina/benchmark/verification/runner.py src/karenina/benchmark/verification/stages/pipeline/generate_answer.py`
+
+Expected: No errors
+
+- [ ] **Step 3: Run dead code checker**
+
+Run: `cd /Users/carli/Projects/karenina-salvage/karenina/.claude/worktrees/dead-code && uv run vulture src/karenina/ vulture_whitelist.py`
+
+Expected: No new dead code introduced

--- a/docs/workflows/creating-benchmarks/scaled-authoring.md
+++ b/docs/workflows/creating-benchmarks/scaled-authoring.md
@@ -6,7 +6,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.19.1
+      jupytext_version: 1.18.1
   kernelspec:
     display_name: Python 3
     language: python

--- a/docs/workflows/creating-benchmarks/scaled-authoring.md
+++ b/docs/workflows/creating-benchmarks/scaled-authoring.md
@@ -279,22 +279,22 @@ print(f"Added question with {2} few-shot examples")
 
 ### FewShotConfig for Verification
 
-`FewShotConfig` controls *which* examples are used during verification. Global external examples are appended to every question. The `global_k` parameter limits how many per-question examples are included.
+`FewShotConfig` controls *which* examples are used during verification. Global examples are appended to every question. The `pool_k` parameter limits how many per-question examples are included.
 
 ```python
 from karenina.schemas import FewShotConfig, QuestionFewShotConfig
 
 few_shot_config = FewShotConfig(
-    global_mode="k-shot",
-    global_k=2,
-    global_external_examples=[
+    pool_mode="k-shot",
+    pool_k=2,
+    global_examples=[
         {"question": "What class of drug is aspirin?", "answer": "NSAID"},
     ],
 )
 
-print(f"Mode: {few_shot_config.global_mode}")
-print(f"K: {few_shot_config.global_k}")
-print(f"Global external examples: {len(few_shot_config.global_external_examples)}")
+print(f"Mode: {few_shot_config.pool_mode}")
+print(f"K: {few_shot_config.pool_k}")
+print(f"Global examples: {len(few_shot_config.global_examples)}")
 ```
 
 See [Few-Shot Configuration](../../notebooks/core_concepts/few-shot.ipynb) for the full configuration reference.

--- a/docs/workflows/running-verification/few-shot-configuration.md
+++ b/docs/workflows/running-verification/few-shot-configuration.md
@@ -20,9 +20,9 @@ This tutorial shows how to configure few-shot examples for verification runs. Fe
 **What you'll learn:**
 
 - Add few-shot examples when creating questions
-- Configure `FewShotConfig` with global modes (all, k-shot, custom, none)
+- Configure `FewShotConfig` with source and pool modes (all, k-shot, custom)
 - Override per-question with `QuestionFewShotConfig` and `inherit` mode
-- Add global external examples
+- Add global examples
 - Select examples by index with `from_index_selections()`
 - Resolve final examples with `resolve_examples_for_question()`
 - Attach `FewShotConfig` to `VerificationConfig`
@@ -131,12 +131,12 @@ The default mode uses every example attached to each question:
 ```python
 from karenina.schemas.config.models import FewShotConfig
 
-config_all = FewShotConfig(global_mode="all")
+config_all = FewShotConfig(pool_mode="all")
 resolved = config_all.resolve_examples_for_question(
     question_id=_q2_id, available_examples=_examples_by_qid[_q2_id],
 )
 
-print(f"Mode: {config_all.global_mode}")
+print(f"Mode: {config_all.pool_mode}")
 print(f"Available: {len(_examples_by_qid[_q2_id])}, Resolved: {len(resolved)}")
 for ex in resolved:
     print(f"  Q: {ex['question'][:45]}  A: {ex['answer']}")
@@ -151,12 +151,12 @@ This works well when you have a small, curated set (2 to 5 examples per question
 K-shot randomly samples *k* examples per question, using the question ID as seed for reproducibility:
 
 ```python
-config_kshot = FewShotConfig(global_mode="k-shot", global_k=2)
+config_kshot = FewShotConfig(pool_mode="k-shot", pool_k=2)
 resolved = config_kshot.resolve_examples_for_question(
     question_id=_q2_id, available_examples=_examples_by_qid[_q2_id],
 )
 
-print(f"Mode: {config_kshot.global_mode}, k={config_kshot.global_k}")
+print(f"Mode: {config_kshot.pool_mode}, k={config_kshot.pool_k}")
 print(f"Available: {len(_examples_by_qid[_q2_id])}, Resolved: {len(resolved)}")
 for ex in resolved:
     print(f"  Q: {ex['question'][:45]}  A: {ex['answer']}")
@@ -180,7 +180,7 @@ resolved_q1 = config_custom.resolve_examples_for_question(
     question_id=_q1_id, available_examples=_examples_by_qid[_q1_id],
 )
 
-print(f"Mode: {config_custom.global_mode}")
+print(f"Mode: {config_custom.pool_mode}")
 print(f"Q1 resolved ({len(resolved_q1)} examples):")
 for ex in resolved_q1:
     print(f"  Q: {ex['question'][:45]}  A: {ex['answer']}")
@@ -188,21 +188,21 @@ for ex in resolved_q1:
 
 ---
 
-## Global Mode: None
+## Disabling Few-Shot
 
-Disabling few-shot entirely returns an empty list for all questions:
+Setting `source="disabled"` turns off few-shot entirely, returning an empty list for all questions:
 
 ```python
-config_none = FewShotConfig(global_mode="none")
+config_none = FewShotConfig(source="disabled")
 resolved = config_none.resolve_examples_for_question(
     question_id=_q1_id, available_examples=_examples_by_qid[_q1_id],
 )
 
-print(f"Mode: {config_none.global_mode}")
+print(f"Source: {config_none.source}")
 print(f"Resolved examples: {len(resolved)}")
 ```
 
-Use `none` to establish a zero-shot baseline for comparison.
+Use `source="disabled"` to establish a zero-shot baseline for comparison.
 
 ---
 
@@ -214,10 +214,10 @@ Each question can override the global mode via `QuestionFewShotConfig`. Question
 from karenina.schemas.config.models import QuestionFewShotConfig
 
 config_mixed = FewShotConfig(
-    global_mode="all",
+    pool_mode="all",
     question_configs={
         _q1_id: QuestionFewShotConfig(mode="k-shot", k=1),   # Sample 1 example
-        _q3_id: QuestionFewShotConfig(mode="none"),            # Disable for q3
+        _q3_id: QuestionFewShotConfig(mode="custom", selected_examples=[]),  # No examples for q3
         # q2, q4: inherit global "all" mode
     },
 )
@@ -234,28 +234,28 @@ The `inherit` mode (the default) delegates to the global mode and k value. Overr
 
 ---
 
-## Global External Examples
+## Global Examples
 
-Global external examples are appended to every question's resolved examples, regardless of mode:
+Global examples are appended to every question's resolved examples, regardless of mode:
 
 ```python
-config_external = FewShotConfig(
-    global_mode="k-shot", global_k=1,
-    global_external_examples=[
+config_global = FewShotConfig(
+    pool_mode="k-shot", pool_k=1,
+    global_examples=[
         {"question": "What is the capital of France?", "answer": "Paris"},
         {"question": "What is 2 + 2?", "answer": "4"},
     ],
 )
-resolved = config_external.resolve_examples_for_question(
+resolved = config_global.resolve_examples_for_question(
     question_id=_q1_id, available_examples=_examples_by_qid[_q1_id],
 )
 
-print(f"Total resolved: {len(resolved)} (1 from k-shot + 2 global external)")
+print(f"Total resolved: {len(resolved)} (1 from k-shot + 2 global)")
 for ex in resolved:
     print(f"  Q: {ex['question'][:45]}  A: {ex['answer']}")
 ```
 
-Resolution order: stored examples first, then question-specific external, then global external. Add question-specific external examples via `QuestionFewShotConfig.external_examples`.
+Resolution order: stored examples first, then global examples.
 
 ---
 
@@ -267,7 +267,7 @@ Resolution order: stored examples first, then question-specific external, then g
 config_bulk = FewShotConfig.from_index_selections({
     _q1_id: [0, 1], _q2_id: [0, 2, 3], _q3_id: [1], _q4_id: [0, 3],
 })
-print(f"Custom bulk (mode={config_bulk.global_mode}):")
+print(f"Custom bulk (mode={config_bulk.pool_mode}):")
 for qid, label in [(_q1_id, "q1"), (_q2_id, "q2"), (_q3_id, "q3"), (_q4_id, "q4")]:
     resolved = config_bulk.resolve_examples_for_question(
         question_id=qid, available_examples=_examples_by_qid[qid],
@@ -278,9 +278,9 @@ for qid, label in [(_q1_id, "q1"), (_q2_id, "q2"), (_q3_id, "q3"), (_q4_id, "q4"
 ```python
 config_varied_k = FewShotConfig.k_shot_for_questions(
     question_k_mapping={_q1_id: 1, _q2_id: 3, _q4_id: 2},
-    global_k=2,
+    pool_k=2,
 )
-print(f"Varied k-shot (mode={config_varied_k.global_mode}):")
+print(f"Varied k-shot (mode={config_varied_k.pool_mode}):")
 for qid, label in [(_q1_id, "q1"), (_q2_id, "q2"), (_q3_id, "q3"), (_q4_id, "q4")]:
     effective = config_varied_k.get_effective_config(qid)
     print(f"  {label}: k={effective.k}")
@@ -294,8 +294,8 @@ Call `resolve_examples_for_question()` to preview exactly what the answering mod
 
 ```python
 config_preview = FewShotConfig(
-    global_mode="all",
-    global_external_examples=[
+    pool_mode="all",
+    global_examples=[
         {"question": "Format example", "answer": "Short, precise answer"},
     ],
     question_configs={_q2_id: QuestionFewShotConfig(mode="k-shot", k=2)},
@@ -304,12 +304,12 @@ config_preview = FewShotConfig(
 resolved_q1 = config_preview.resolve_examples_for_question(
     question_id=_q1_id, available_examples=_examples_by_qid[_q1_id],
 )
-print(f"Q1 (inherits 'all'): {len(resolved_q1)} examples (3 stored + 1 external)")
+print(f"Q1 (inherits 'all'): {len(resolved_q1)} examples (3 stored + 1 global)")
 
 resolved_q2 = config_preview.resolve_examples_for_question(
     question_id=_q2_id, available_examples=_examples_by_qid[_q2_id],
 )
-print(f"Q2 (k-shot, k=2):   {len(resolved_q2)} examples (2 sampled + 1 external)")
+print(f"Q2 (k-shot, k=2):   {len(resolved_q2)} examples (2 sampled + 1 global)")
 ```
 
 Use this to verify your configuration before running a full verification pass.
@@ -325,9 +325,9 @@ from karenina.schemas.verification.config import VerificationConfig
 from karenina.schemas.config.models import ModelConfig
 
 few_shot = FewShotConfig(
-    global_mode="k-shot",
-    global_k=2,
-    question_configs={_q3_id: QuestionFewShotConfig(mode="none")},
+    pool_mode="k-shot",
+    pool_k=2,
+    question_configs={_q3_id: QuestionFewShotConfig(mode="custom", selected_examples=[])},
 )
 
 config = VerificationConfig(
@@ -343,19 +343,19 @@ config = VerificationConfig(
     few_shot_config=few_shot,
 )
 
-print(f"Few-shot enabled: {config.few_shot_config.enabled}")
-print(f"Global mode:      {config.few_shot_config.global_mode}")
-print(f"Global k:         {config.few_shot_config.global_k}")
+print(f"Source:           {config.few_shot_config.source}")
+print(f"Pool mode:        {config.few_shot_config.pool_mode}")
+print(f"Pool k:           {config.few_shot_config.pool_k}")
 print(f"Per-question:     {len(config.few_shot_config.question_configs)} overrides")
 ```
 
-When `few_shot_config` is `None` (the default) or `enabled=False`, no examples are prepended.
+When `few_shot_config` is `None` (the default) or `source="disabled"`, no examples are prepended.
 
 ---
 
 ## Tuning Strategy
 
-- Start with `global_mode="none"` to establish a zero-shot baseline
+- Start with `source="disabled"` to establish a zero-shot baseline
 - If the answering model produces poorly formatted responses, add 2 to 3 examples per question
 - Use `resolve_examples_for_question()` to preview before running full verification
 - Increase *k* incrementally; more examples increase prompt cost without guaranteed improvement

--- a/src/karenina/benchmark/verification/runner.py
+++ b/src/karenina/benchmark/verification/runner.py
@@ -214,9 +214,7 @@ def run_single_model_verification(
     answering_mcp_servers = list(answering_model.mcp_urls_dict.keys()) if answering_model.mcp_urls_dict else None
     context.set_result_field("answering_mcp_servers", answering_mcp_servers)
 
-    # Determine evaluation mode automatically if not explicitly set.
-    # If rubric or dynamic_rubric is provided and mode is template_only,
-    # upgrade to template_and_rubric.
+    # Warn if rubric traits are provided but evaluation_mode won't use them.
     _has_rubric_traits = rubric and (
         rubric.llm_traits
         or rubric.regex_traits
@@ -226,7 +224,11 @@ def run_single_model_verification(
     )
     _has_dynamic_rubric_traits = dynamic_rubric is not None and not dynamic_rubric.is_empty()
     if (_has_rubric_traits or _has_dynamic_rubric_traits) and evaluation_mode == "template_only":
-        evaluation_mode = "template_and_rubric"
+        logger.warning(
+            "Rubric traits were provided but evaluation_mode='template_only'. "
+            "Rubric evaluation will be skipped. Set evaluation_mode='template_and_rubric' "
+            "to evaluate rubric traits."
+        )
 
     if evaluation_mode == "rubric_only" and not _has_rubric_traits and not _has_dynamic_rubric_traits:
         logger.warning(

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -268,8 +268,15 @@ class GenerateAnswerStage(BaseVerificationStage):
         try:
             # Construct messages in unified Message format
             adapter_messages: list[Message] = []
+            system_parts: list[str] = []
             if answering_model.system_prompt:
-                adapter_messages.append(Message.system(answering_model.system_prompt))
+                system_parts.append(answering_model.system_prompt)
+            if context.prompt_config:
+                gen_instructions = context.prompt_config.get_for_task("generation")
+                if gen_instructions:
+                    system_parts.append(gen_instructions)
+            if system_parts:
+                adapter_messages.append(Message.system("\n\n".join(system_parts)))
 
             # Inject conversation history from prior scenario turns (if present)
             conversation_history = context.get_artifact("conversation_history")

--- a/src/karenina/benchmark/verification/utils/task_helpers.py
+++ b/src/karenina/benchmark/verification/utils/task_helpers.py
@@ -108,7 +108,7 @@ def resolve_few_shot_for_task(
         List of few-shot examples or None if disabled/unavailable
     """
     few_shot_config = config.get_few_shot_config()
-    if not few_shot_config or not few_shot_config.enabled:
+    if not few_shot_config or few_shot_config.source == "disabled":
         return None
 
     return few_shot_config.resolve_examples_for_question(

--- a/src/karenina/cli/interactive.py
+++ b/src/karenina/cli/interactive.py
@@ -412,11 +412,11 @@ def _configure_few_shot() -> Any:
 
     from karenina.schemas.config import FewShotConfig
 
-    few_shot_mode_str = Prompt.ask("Few-shot mode", choices=["all", "k-shot", "custom", "none"], default="all")
-    few_shot_mode = cast(Literal["all", "k-shot", "custom", "none"], few_shot_mode_str)
+    few_shot_mode_str = Prompt.ask("Few-shot mode", choices=["all", "k-shot", "custom"], default="all")
+    few_shot_mode = cast(Literal["all", "k-shot", "custom"], few_shot_mode_str)
     few_shot_k = _prompt_int_min("Few-shot k (number of examples)", min_val=1, default="3")
 
-    return FewShotConfig(enabled=True, global_mode=few_shot_mode, global_k=few_shot_k)
+    return FewShotConfig(source="both", pool_mode=few_shot_mode, pool_k=few_shot_k)
 
 
 def _configure_async() -> tuple[bool, int]:

--- a/src/karenina/schemas/config/models.py
+++ b/src/karenina/schemas/config/models.py
@@ -223,11 +223,10 @@ class QuestionFewShotConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    mode: Literal["all", "k-shot", "custom", "none", "inherit"] = "inherit"
-    k: int | None = None  # Override global k for this question
-    selected_examples: list[str | int] | None = None  # Hash (MD5) or index selection
-    external_examples: list[dict[str, str]] | None = None  # Question-specific external examples
-    excluded_examples: list[str | int] | None = None  # Examples to exclude
+    mode: Literal["all", "k-shot", "custom", "inherit"] = "inherit"
+    k: int | None = None
+    selected_examples: list[str | int] | None = None
+    excluded_examples: list[str | int] | None = None
 
 
 class FewShotConfig(BaseModel):
@@ -235,34 +234,28 @@ class FewShotConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    # Global fallback settings
-    global_mode: Literal["all", "k-shot", "custom", "none"] = "all"
-    global_k: int = 3  # Default number of examples for k-shot mode
-    enabled: bool = True  # Master enable/disable switch
-
-    # Per-question configurations (auto-generated from convenient interfaces)
+    source: Literal["disabled", "question_pool", "global", "both"] = "both"
+    pool_mode: Literal["all", "k-shot", "custom"] = "all"
+    pool_k: int = 3
     question_configs: dict[str, QuestionFewShotConfig] = Field(default_factory=dict)
-
-    # Global external examples that can be used across all questions
-    global_external_examples: list[dict[str, str]] = Field(default_factory=list)
+    global_examples: list[dict[str, str]] = Field(default_factory=list)
 
     @classmethod
     def from_index_selections(
         cls,
         selections: dict[str, list[int]],
-        global_mode: Literal["all", "k-shot", "custom", "none"] = "custom",
+        pool_mode: Literal["all", "k-shot", "custom"] = "custom",
         **kwargs: Any,
     ) -> "FewShotConfig":
-        """
-        Create FewShotConfig from question_id -> [example_indices] mapping.
+        """Create FewShotConfig from question_id -> [example_indices] mapping.
 
         Args:
-            selections: Dictionary mapping question IDs to lists of example indices
-            global_mode: Global mode to use (defaults to "custom")
-            **kwargs: Additional arguments passed to FewShotConfig constructor
+            selections: Dictionary mapping question IDs to lists of example indices.
+            pool_mode: Pool mode to use (defaults to "custom").
+            **kwargs: Additional arguments passed to FewShotConfig constructor.
 
         Returns:
-            Configured FewShotConfig instance
+            Configured FewShotConfig instance.
 
         Example:
             config = FewShotConfig.from_index_selections({
@@ -276,25 +269,24 @@ class FewShotConfig(BaseModel):
                 mode="custom", selected_examples=cast(list[str | int], indices)
             )
 
-        return cls(global_mode=global_mode, question_configs=question_configs, **kwargs)
+        return cls(pool_mode=pool_mode, question_configs=question_configs, **kwargs)
 
     @classmethod
     def from_hash_selections(
         cls,
         selections: dict[str, list[str]],
-        global_mode: Literal["all", "k-shot", "custom", "none"] = "custom",
+        pool_mode: Literal["all", "k-shot", "custom"] = "custom",
         **kwargs: Any,
     ) -> "FewShotConfig":
-        """
-        Create FewShotConfig from question_id -> [example_hashes] mapping.
+        """Create FewShotConfig from question_id -> [example_hashes] mapping.
 
         Args:
-            selections: Dictionary mapping question IDs to lists of MD5 hashes
-            global_mode: Global mode to use (defaults to "custom")
-            **kwargs: Additional arguments passed to FewShotConfig constructor
+            selections: Dictionary mapping question IDs to lists of MD5 hashes.
+            pool_mode: Pool mode to use (defaults to "custom").
+            **kwargs: Additional arguments passed to FewShotConfig constructor.
 
         Returns:
-            Configured FewShotConfig instance
+            Configured FewShotConfig instance.
 
         Example:
             config = FewShotConfig.from_hash_selections({
@@ -308,25 +300,24 @@ class FewShotConfig(BaseModel):
                 mode="custom", selected_examples=cast(list[str | int], hashes)
             )
 
-        return cls(global_mode=global_mode, question_configs=question_configs, **kwargs)
+        return cls(pool_mode=pool_mode, question_configs=question_configs, **kwargs)
 
     @classmethod
     def k_shot_for_questions(
         cls,
         question_k_mapping: dict[str, int],
-        global_k: int = 3,
+        pool_k: int = 3,
         **kwargs: Any,
     ) -> "FewShotConfig":
-        """
-        Create FewShotConfig with different k values per question.
+        """Create FewShotConfig with different k values per question.
 
         Args:
-            question_k_mapping: Dictionary mapping question IDs to k values
-            global_k: Global k value for questions not in mapping
-            **kwargs: Additional arguments passed to FewShotConfig constructor
+            question_k_mapping: Dictionary mapping question IDs to k values.
+            pool_k: Pool k value for questions not in mapping.
+            **kwargs: Additional arguments passed to FewShotConfig constructor.
 
         Returns:
-            Configured FewShotConfig instance
+            Configured FewShotConfig instance.
 
         Example:
             config = FewShotConfig.k_shot_for_questions({
@@ -338,7 +329,7 @@ class FewShotConfig(BaseModel):
         for question_id, k_value in question_k_mapping.items():
             question_configs[question_id] = QuestionFewShotConfig(mode="k-shot", k=k_value)
 
-        return cls(global_mode="k-shot", global_k=global_k, question_configs=question_configs, **kwargs)
+        return cls(pool_mode="k-shot", pool_k=pool_k, question_configs=question_configs, **kwargs)
 
     def add_selections_by_index(self, selections: dict[str, list[int]]) -> None:
         """
@@ -375,33 +366,28 @@ class FewShotConfig(BaseModel):
             self.question_configs[question_id] = QuestionFewShotConfig(mode="k-shot", k=k_value)
 
     def get_effective_config(self, question_id: str) -> QuestionFewShotConfig:
-        """
-        Get the effective configuration for a specific question, resolving inheritance.
+        """Get the effective configuration for a specific question, resolving inheritance.
 
         Args:
-            question_id: The question ID to get configuration for
+            question_id: The question ID to get configuration for.
 
         Returns:
-            Effective QuestionFewShotConfig with inheritance resolved
+            Effective QuestionFewShotConfig with inheritance resolved.
         """
         question_config = self.question_configs.get(question_id, QuestionFewShotConfig())
 
         if question_config.mode == "inherit":
-            # Inherit from global settings
             return QuestionFewShotConfig(
-                mode=self.global_mode,
-                k=self.global_k,
+                mode=self.pool_mode,
+                k=self.pool_k,
                 selected_examples=question_config.selected_examples,
-                external_examples=question_config.external_examples,
                 excluded_examples=question_config.excluded_examples,
             )
 
-        # Use question-specific config, filling in defaults where needed
         return QuestionFewShotConfig(
             mode=question_config.mode,
-            k=question_config.k if question_config.k is not None else self.global_k,
+            k=question_config.k if question_config.k is not None else self.pool_k,
             selected_examples=question_config.selected_examples,
-            external_examples=question_config.external_examples,
             excluded_examples=question_config.excluded_examples,
         )
 
@@ -411,87 +397,70 @@ class FewShotConfig(BaseModel):
         available_examples: list[dict[str, str]] | None = None,
         question_text: str | None = None,
     ) -> list[dict[str, str]]:
-        """
-        Resolve the final list of examples to use for a specific question.
+        """Resolve the final list of examples to use for a specific question.
 
         Args:
-            question_id: The question ID to resolve examples for
-            available_examples: Available examples from the question (can be None)
-            question_text: Question text (used for hash validation, optional)
+            question_id: The question ID to resolve examples for.
+            available_examples: Available examples from the question pool (can be None).
+            question_text: Question text (used for hash validation, optional).
 
         Returns:
-            List of resolved examples to use for few-shot prompting
+            List of resolved examples to use for few-shot prompting.
         """
         import hashlib
         import random
 
-        if not self.enabled:
+        if self.source == "disabled":
             return []
 
-        effective_config = self.get_effective_config(question_id)
+        include_pool = self.source in ("question_pool", "both")
+        include_global = self.source in ("global", "both")
 
-        if effective_config.mode == "none":
-            return []
+        resolved_examples: list[dict[str, str]] = []
 
-        # Start with available examples or empty list
-        if available_examples is None:
-            available_examples = []
+        if include_pool:
+            if available_examples is None:
+                available_examples = []
 
-        # Create lookup for hash-to-example mapping if needed
-        example_hash_map = {}
-        if question_text is not None and available_examples:
-            for i, example in enumerate(available_examples):
-                example_question = example.get("question", "")
-                example_hash = hashlib.md5(example_question.encode("utf-8")).hexdigest()
-                example_hash_map[example_hash] = i
+            effective_config = self.get_effective_config(question_id)
 
-        resolved_examples = []
+            example_hash_map: dict[str, int] = {}
+            if question_text is not None and available_examples:
+                for i, example in enumerate(available_examples):
+                    example_question = example.get("question", "")
+                    example_hash = hashlib.md5(example_question.encode("utf-8")).hexdigest()
+                    example_hash_map[example_hash] = i
 
-        # Handle different modes
-        if effective_config.mode == "all":
-            resolved_examples = available_examples.copy()
-
-        elif effective_config.mode == "k-shot":
-            k = effective_config.k if effective_config.k is not None else self.global_k
-            if len(available_examples) <= k:
+            if effective_config.mode == "all":
                 resolved_examples = available_examples.copy()
-            else:
-                # Randomly sample k examples for consistency
-                # Use question_id as seed for reproducible results
-                random.seed(int(hashlib.md5(question_id.encode()).hexdigest(), 16) & 0x7FFFFFFF)
-                resolved_examples = random.sample(available_examples, k)
+            elif effective_config.mode == "k-shot":
+                k = effective_config.k if effective_config.k is not None else self.pool_k
+                if len(available_examples) <= k:
+                    resolved_examples = available_examples.copy()
+                else:
+                    random.seed(hash(question_id) & 0x7FFFFFFF)
+                    resolved_examples = random.sample(available_examples, k)
+            elif effective_config.mode == "custom" and effective_config.selected_examples:
+                for selection in effective_config.selected_examples:
+                    if isinstance(selection, int):
+                        if 0 <= selection < len(available_examples):
+                            resolved_examples.append(available_examples[selection])
+                    elif isinstance(selection, str) and selection in example_hash_map:
+                        idx = example_hash_map[selection]
+                        resolved_examples.append(available_examples[idx])
 
-        elif effective_config.mode == "custom" and effective_config.selected_examples:
-            for selection in effective_config.selected_examples:
-                if isinstance(selection, int):
-                    # Index-based selection
-                    if 0 <= selection < len(available_examples):
-                        resolved_examples.append(available_examples[selection])
-                elif isinstance(selection, str) and selection in example_hash_map:
-                    # Hash-based selection
-                    idx = example_hash_map[selection]
-                    resolved_examples.append(available_examples[idx])
+            if effective_config.excluded_examples:
+                exclusion_indices: set[int] = set()
+                for exclusion in effective_config.excluded_examples:
+                    if isinstance(exclusion, int):
+                        exclusion_indices.add(exclusion)
+                    elif isinstance(exclusion, str) and exclusion in example_hash_map:
+                        exclusion_indices.add(example_hash_map[exclusion])
+                resolved_examples = [ex for i, ex in enumerate(resolved_examples) if i not in exclusion_indices]
 
-        # Apply exclusions if specified
-        if effective_config.excluded_examples:
-            exclusion_indices = set()
-            for exclusion in effective_config.excluded_examples:
-                if isinstance(exclusion, int):
-                    exclusion_indices.add(exclusion)
-                elif isinstance(exclusion, str) and exclusion in example_hash_map:
-                    exclusion_indices.add(example_hash_map[exclusion])
-
-            # Filter out excluded examples
-            resolved_examples = [ex for i, ex in enumerate(resolved_examples) if i not in exclusion_indices]
-
-        # Add external examples (question-specific first, then global)
         final_examples = resolved_examples.copy()
-
-        if effective_config.external_examples:
-            final_examples.extend(effective_config.external_examples)
-
-        if self.global_external_examples:
-            final_examples.extend(self.global_external_examples)
+        if include_global and self.global_examples:
+            final_examples.extend(self.global_examples)
 
         return final_examples
 

--- a/src/karenina/schemas/config/models.py
+++ b/src/karenina/schemas/config/models.py
@@ -224,9 +224,9 @@ class QuestionFewShotConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     mode: Literal["all", "k-shot", "custom", "inherit"] = "inherit"
-    k: int | None = None
-    selected_examples: list[str | int] | None = None
-    excluded_examples: list[str | int] | None = None
+    k: int | None = None  # Override pool_k for this question
+    selected_examples: list[str | int] | None = None  # Hash (MD5) or index selection
+    excluded_examples: list[str | int] | None = None  # Examples to exclude
 
 
 class FewShotConfig(BaseModel):
@@ -234,10 +234,19 @@ class FewShotConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    # Master source selector: what types of examples are active
     source: Literal["disabled", "question_pool", "global", "both"] = "both"
+
+    # Pool selection: how question-specific examples are chosen
+    # Only relevant when source includes question_pool ("question_pool" or "both")
     pool_mode: Literal["all", "k-shot", "custom"] = "all"
-    pool_k: int = 3
+    pool_k: int = 3  # Default number of examples for k-shot mode
+
+    # Per-question pool overrides
     question_configs: dict[str, QuestionFewShotConfig] = Field(default_factory=dict)
+
+    # Global examples appended to ALL questions
+    # Only used when source includes global ("global" or "both")
     global_examples: list[dict[str, str]] = Field(default_factory=list)
 
     @classmethod
@@ -438,7 +447,7 @@ class FewShotConfig(BaseModel):
                 if len(available_examples) <= k:
                     resolved_examples = available_examples.copy()
                 else:
-                    random.seed(hash(question_id) & 0x7FFFFFFF)
+                    random.seed(int(hashlib.md5(question_id.encode()).hexdigest(), 16) & 0x7FFFFFFF)
                     resolved_examples = random.sample(available_examples, k)
             elif effective_config.mode == "custom" and effective_config.selected_examples:
                 for selection in effective_config.selected_examples:

--- a/src/karenina/schemas/verification/config.py
+++ b/src/karenina/schemas/verification/config.py
@@ -327,18 +327,6 @@ class VerificationConfig(BaseModel):
                 for m in data["answering_models"]
             ]
 
-        if "parsing_models" in data:
-            data["parsing_models"] = [
-                m.model_copy(update={"system_prompt": DEFAULT_PARSING_SYSTEM_PROMPT})
-                if isinstance(m, ModelConfig) and not m.system_prompt
-                else (
-                    {**m, "system_prompt": DEFAULT_PARSING_SYSTEM_PROMPT}
-                    if isinstance(m, dict) and not m.get("system_prompt")
-                    else m
-                )
-                for m in data["parsing_models"]
-            ]
-
         # Strip rubric_enabled from input: now derived from evaluation_mode
         data.pop("rubric_enabled", None)
 
@@ -376,18 +364,22 @@ class VerificationConfig(BaseModel):
         # Validate model configurations
         # Note: Basic model validation (model_name, model_provider) is also done by
         # the adapter factory at runtime, but we validate here too for early failure.
+        from karenina.adapters.registry import AdapterRegistry
+
         for model in self.answering_models + self.parsing_models:
             if not model.model_name:
                 raise ValueError(f"Model name is required in model configuration (model: {model.id})")
             # Model provider requirement is defined per-adapter via AdapterSpec.requires_provider
-            from karenina.adapters.registry import AdapterRegistry
-
             spec = AdapterRegistry.get_spec(model.interface)
             if spec is not None and spec.requires_provider and not model.model_provider:
                 raise ValueError(f"Model provider is required for interface '{model.interface}'. (model: {model.id})")
-            # System prompt is required for verification (not validated by factory)
+
+        # System prompt is required for answering models (not validated by factory).
+        # Parsing models do not require a system_prompt; their prompt is assembled
+        # by the pipeline at runtime.
+        for model in self.answering_models:
             if not model.system_prompt:
-                raise ValueError(f"System prompt is required for model {model.id}")
+                raise ValueError(f"System prompt is required for answering model {model.id}")
 
         # Additional validation for rubric-enabled scenarios
         if self.rubric_enabled and not self.parsing_models:

--- a/src/karenina/schemas/verification/config.py
+++ b/src/karenina/schemas/verification/config.py
@@ -334,6 +334,26 @@ class VerificationConfig(BaseModel):
         # but injected by from_overrides() and some CLI callers.
         data.pop("deep_judgment_rubric_search_enabled", None)
 
+        # Wire instruction shortcuts into prompt_config (pop before super().__init__)
+        shortcut_mapping = {
+            "generation": data.pop("generation_instructions", None),
+            "parsing": data.pop("parsing_instructions", None),
+            "abstention_detection": data.pop("abstention_detection_instructions", None),
+            "sufficiency_detection": data.pop("sufficiency_detection_instructions", None),
+            "rubric_evaluation": data.pop("rubric_evaluation_instructions", None),
+            "agentic_parsing": data.pop("agentic_parsing_instructions", None),
+            "deep_judgment": data.pop("deep_judgment_instructions", None),
+        }
+        active_shortcuts = {k: v for k, v in shortcut_mapping.items() if v is not None}
+        if active_shortcuts:
+            pc = data.get("prompt_config") or PromptConfig()
+            if isinstance(pc, dict):
+                pc = PromptConfig(**pc)
+            updates = {k: v for k, v in active_shortcuts.items() if getattr(pc, k) is None}
+            if updates:
+                pc = pc.model_copy(update=updates)
+            data["prompt_config"] = pc
+
         super().__init__(**data)
 
         # Validate configuration after initialization

--- a/src/karenina/schemas/verification/config.py
+++ b/src/karenina/schemas/verification/config.py
@@ -406,9 +406,9 @@ class VerificationConfig(BaseModel):
             raise ValueError("Parsing models are required when rubric evaluation is enabled")
 
         # Additional validation for few-shot prompting scenarios
-        if self.few_shot_config is not None and self.few_shot_config.enabled:
-            if self.few_shot_config.global_mode == "k-shot" and self.few_shot_config.global_k < 1:
-                raise ValueError("Global few-shot k value must be at least 1 when using k-shot mode")
+        if self.few_shot_config is not None and self.few_shot_config.source != "disabled":
+            if self.few_shot_config.pool_mode == "k-shot" and self.few_shot_config.pool_k < 1:
+                raise ValueError("Pool few-shot k value must be at least 1 when using k-shot mode")
 
             # Validate question-specific k values
             for question_id, question_config in self.few_shot_config.question_configs.items():
@@ -577,11 +577,11 @@ class VerificationConfig(BaseModel):
 
         # Few-Shot
         few_shot_config = self.get_few_shot_config()
-        if few_shot_config and few_shot_config.enabled:
+        if few_shot_config and few_shot_config.source != "disabled":
             features_shown = True
-            lines.append(f"  Few-Shot: mode={few_shot_config.global_mode}")
-            if few_shot_config.global_mode == "k-shot":
-                lines.append(f"    └─ k={few_shot_config.global_k}")
+            lines.append(f"  Few-Shot: source={few_shot_config.source}, pool_mode={few_shot_config.pool_mode}")
+            if few_shot_config.pool_mode == "k-shot":
+                lines.append(f"    └─ pool_k={few_shot_config.pool_k}")
             if few_shot_config.question_configs:
                 lines.append(f"    └─ {len(few_shot_config.question_configs)} question configs")
 
@@ -613,7 +613,7 @@ class VerificationConfig(BaseModel):
             True if few-shot is enabled
         """
         config = self.get_few_shot_config()
-        return config is not None and config.enabled
+        return config is not None and config.source != "disabled"
 
     # ===== Preset Utility Class Methods =====
     # These methods delegate to config_presets module for backward compatibility.

--- a/tests/unit/benchmark/test_task_eval_metadata.py
+++ b/tests/unit/benchmark/test_task_eval_metadata.py
@@ -429,7 +429,7 @@ class TestFewShotConfigWarning:
 
         from karenina.schemas.config import FewShotConfig
 
-        config = _make_config(few_shot_config=FewShotConfig(enabled=True))
+        config = _make_config(few_shot_config=FewShotConfig(source="both"))
 
         with caplog.at_level(logging.DEBUG, logger="karenina.benchmark.task_eval.task_eval"):
             task.evaluate(config)

--- a/tests/unit/benchmark/verification/stages/test_generate_answer_prompt_config.py
+++ b/tests/unit/benchmark/verification/stages/test_generate_answer_prompt_config.py
@@ -1,0 +1,98 @@
+"""Tests for PromptConfig.generation wiring in GenerateAnswerStage."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import VerificationContext
+from karenina.benchmark.verification.stages.pipeline.generate_answer import GenerateAnswerStage
+from karenina.ports import Message
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification.prompt_config import PromptConfig
+
+
+def _make_context(
+    system_prompt: str | None = "You are helpful.",
+    prompt_config: PromptConfig | None = None,
+) -> VerificationContext:
+    """Create a minimal VerificationContext for testing."""
+    model = ModelConfig(
+        id="test",
+        model_name="test",
+        model_provider="openai",
+        system_prompt=system_prompt,
+    )
+    ctx = VerificationContext(
+        question_id="q1",
+        template_id="t1",
+        question_text="What is 2+2?",
+        template_code="class Answer(BaseAnswer): value: str",
+        answering_model=model,
+        parsing_model=model,
+        prompt_config=prompt_config,
+    )
+    return ctx
+
+
+def _capture_adapter_messages(context: VerificationContext) -> list[Message]:
+    """Run GenerateAnswerStage.execute() with mocked adapter, return captured messages."""
+    stage = GenerateAnswerStage()
+    captured: list[Message] = []
+
+    mock_llm = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = "4"
+    mock_response.usage = None
+    mock_llm.invoke.side_effect = lambda msgs: (captured.extend(msgs), mock_response)[1]
+
+    with patch("karenina.benchmark.verification.stages.pipeline.generate_answer.get_llm", return_value=mock_llm):
+        stage.execute(context)
+
+    return captured
+
+
+@pytest.mark.unit
+class TestPromptConfigGeneration:
+    """Test that PromptConfig.generation is injected into the system message."""
+
+    def test_generation_instructions_appended_to_system_prompt(self) -> None:
+        """PromptConfig.generation should appear in the system message."""
+        ctx = _make_context(
+            system_prompt="You are helpful.",
+            prompt_config=PromptConfig(generation="Focus on clinical accuracy."),
+        )
+        messages = _capture_adapter_messages(ctx)
+        system_msgs = [m for m in messages if m.role == "system"]
+        assert len(system_msgs) == 1
+        assert "You are helpful." in system_msgs[0].text
+        assert "Focus on clinical accuracy." in system_msgs[0].text
+
+    def test_no_prompt_config_uses_system_prompt_only(self) -> None:
+        """Without PromptConfig, only ModelConfig.system_prompt is used."""
+        ctx = _make_context(system_prompt="You are helpful.", prompt_config=None)
+        messages = _capture_adapter_messages(ctx)
+        system_msgs = [m for m in messages if m.role == "system"]
+        assert len(system_msgs) == 1
+        assert system_msgs[0].text == "You are helpful."
+
+    def test_generation_none_does_not_change_system_prompt(self) -> None:
+        """PromptConfig with generation=None should not modify the system message."""
+        ctx = _make_context(
+            system_prompt="You are helpful.",
+            prompt_config=PromptConfig(generation=None),
+        )
+        messages = _capture_adapter_messages(ctx)
+        system_msgs = [m for m in messages if m.role == "system"]
+        assert len(system_msgs) == 1
+        assert system_msgs[0].text == "You are helpful."
+
+    def test_no_system_prompt_generation_only(self) -> None:
+        """When ModelConfig.system_prompt is None, only generation instructions appear."""
+        ctx = _make_context(
+            system_prompt=None,
+            prompt_config=PromptConfig(generation="Be concise."),
+        )
+        messages = _capture_adapter_messages(ctx)
+        system_msgs = [m for m in messages if m.role == "system"]
+        assert len(system_msgs) == 1
+        assert system_msgs[0].text == "Be concise."

--- a/tests/unit/benchmark/verification/test_runner_auto_upgrade.py
+++ b/tests/unit/benchmark/verification/test_runner_auto_upgrade.py
@@ -1,0 +1,69 @@
+"""Tests for runner evaluation_mode auto-upgrade removal."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from karenina.schemas.entities.rubric import LLMRubricTrait, Rubric
+
+
+@pytest.mark.unit
+class TestRunnerAutoUpgrade:
+    """Verify that runner no longer auto-upgrades template_only to template_and_rubric."""
+
+    def test_template_only_with_rubric_warns_and_does_not_upgrade(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Rubric traits with template_only should warn, not upgrade."""
+        from karenina.benchmark.verification.runner import run_single_model_verification
+        from karenina.schemas.config import ModelConfig
+
+        rubric = Rubric(
+            llm_traits=[LLMRubricTrait(name="clarity", kind="boolean", description="Is the response clear?")]
+        )
+        answering = ModelConfig(id="test", model_name="test", model_provider="openai", system_prompt="You are helpful.")
+        parsing = ModelConfig(id="test", model_name="test", model_provider="openai", system_prompt="Parse.")
+
+        # Mock StageOrchestrator to avoid running the full pipeline
+        with (
+            patch("karenina.benchmark.verification.runner.StageOrchestrator") as mock_orch,
+            caplog.at_level(logging.WARNING),
+        ):
+            mock_orch.from_config.return_value.execute.return_value = None
+            run_single_model_verification(
+                question_id="q1",
+                question_text="What is 2+2?",
+                template_code="class Answer(BaseAnswer): value: str",
+                answering_model=answering,
+                parsing_model=parsing,
+                evaluation_mode="template_only",
+                rubric=rubric,
+            )
+
+        assert any("template_only" in r.message and "Rubric" in r.message for r in caplog.records)
+        # Verify evaluation_mode was NOT changed: from_config should receive "template_only"
+        call_kwargs = mock_orch.from_config.call_args
+        assert call_kwargs.kwargs.get("evaluation_mode", call_kwargs[1].get("evaluation_mode")) == "template_only"
+
+    def test_template_only_without_rubric_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """No rubric traits should produce no warning."""
+        from karenina.benchmark.verification.runner import run_single_model_verification
+        from karenina.schemas.config import ModelConfig
+
+        answering = ModelConfig(id="test", model_name="test", model_provider="openai", system_prompt="You are helpful.")
+        parsing = ModelConfig(id="test", model_name="test", model_provider="openai", system_prompt="Parse.")
+
+        with (
+            patch("karenina.benchmark.verification.runner.StageOrchestrator") as mock_orch,
+            caplog.at_level(logging.WARNING),
+        ):
+            mock_orch.from_config.return_value.execute.return_value = None
+            run_single_model_verification(
+                question_id="q1",
+                question_text="What is 2+2?",
+                template_code="class Answer(BaseAnswer): value: str",
+                answering_model=answering,
+                parsing_model=parsing,
+                evaluation_mode="template_only",
+            )
+
+        assert not any("template_only" in r.message for r in caplog.records)

--- a/tests/unit/schemas/test_few_shot_restructure.py
+++ b/tests/unit/schemas/test_few_shot_restructure.py
@@ -1,0 +1,109 @@
+"""Tests for FewShotConfig restructure with source/pool_mode/pool_k semantics."""
+
+import pytest
+from pydantic import ValidationError
+
+from karenina.schemas.config.models import FewShotConfig, QuestionFewShotConfig
+
+
+@pytest.mark.unit
+class TestFewShotConfigNewFields:
+    def test_default_source_is_both(self) -> None:
+        assert FewShotConfig().source == "both"
+
+    def test_default_pool_mode_is_all(self) -> None:
+        assert FewShotConfig().pool_mode == "all"
+
+    def test_default_pool_k_is_3(self) -> None:
+        assert FewShotConfig().pool_k == 3
+
+    def test_old_field_names_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            FewShotConfig(**{"enabled": True})
+        with pytest.raises(ValidationError):
+            FewShotConfig(**{"global_mode": "all"})
+        with pytest.raises(ValidationError):
+            FewShotConfig(**{"global_k": 5})
+        with pytest.raises(ValidationError):
+            FewShotConfig(**{"global_external_examples": []})
+
+    def test_question_config_no_external_examples(self) -> None:
+        with pytest.raises(ValidationError):
+            QuestionFewShotConfig(**{"external_examples": []})
+
+    def test_question_config_no_mode_none(self) -> None:
+        with pytest.raises(ValidationError):
+            QuestionFewShotConfig(**{"mode": "none"})
+
+
+@pytest.mark.unit
+class TestFewShotSourceBehavior:
+    def _pool_examples(self) -> list[dict[str, str]]:
+        return [
+            {"question": "What is X?", "answer": "X is A."},
+            {"question": "What is Y?", "answer": "Y is B."},
+        ]
+
+    def test_disabled_returns_empty(self) -> None:
+        assert FewShotConfig(source="disabled").resolve_examples_for_question("q1", self._pool_examples()) == []
+
+    def test_question_pool_returns_pool_only(self) -> None:
+        config = FewShotConfig(
+            source="question_pool",
+            pool_mode="all",
+            global_examples=[{"question": "Global?", "answer": "Global."}],
+        )
+        result = config.resolve_examples_for_question("q1", self._pool_examples())
+        assert len(result) == 2
+        assert all(ex in self._pool_examples() for ex in result)
+
+    def test_global_returns_global_only(self) -> None:
+        global_ex = [{"question": "Global?", "answer": "Global."}]
+        result = FewShotConfig(source="global", global_examples=global_ex).resolve_examples_for_question(
+            "q1", self._pool_examples()
+        )
+        assert result == global_ex
+
+    def test_both_returns_pool_and_global(self) -> None:
+        global_ex = [{"question": "Global?", "answer": "Global."}]
+        result = FewShotConfig(source="both", pool_mode="all", global_examples=global_ex).resolve_examples_for_question(
+            "q1", self._pool_examples()
+        )
+        assert len(result) == 3
+        assert result[:2] == self._pool_examples()
+        assert result[2:] == global_ex
+
+    def test_pool_mode_kshot(self) -> None:
+        result = FewShotConfig(source="question_pool", pool_mode="k-shot", pool_k=1).resolve_examples_for_question(
+            "q1", self._pool_examples()
+        )
+        assert len(result) == 1
+
+    def test_pool_mode_custom(self) -> None:
+        config = FewShotConfig(
+            source="question_pool",
+            pool_mode="custom",
+            question_configs={"q1": QuestionFewShotConfig(mode="custom", selected_examples=[0])},
+        )
+        assert len(config.resolve_examples_for_question("q1", self._pool_examples())) == 1
+
+    def test_inherit_uses_pool_mode(self) -> None:
+        result = FewShotConfig(source="question_pool", pool_mode="k-shot", pool_k=1).resolve_examples_for_question(
+            "q1", self._pool_examples()
+        )
+        assert len(result) == 1
+
+
+@pytest.mark.unit
+class TestFewShotFactoryMethods:
+    def test_from_index_selections(self) -> None:
+        config = FewShotConfig.from_index_selections({"q1": [0, 1]})
+        assert config.pool_mode == "custom"
+
+    def test_from_hash_selections(self) -> None:
+        assert FewShotConfig.from_hash_selections({"q1": ["abc123"]}).pool_mode == "custom"
+
+    def test_k_shot_for_questions(self) -> None:
+        config = FewShotConfig.k_shot_for_questions({"q1": 5}, pool_k=3)
+        assert config.pool_mode == "k-shot"
+        assert config.pool_k == 3

--- a/tests/unit/schemas/test_instruction_shortcuts.py
+++ b/tests/unit/schemas/test_instruction_shortcuts.py
@@ -1,0 +1,94 @@
+"""Tests for VerificationConfig instruction shortcut fields."""
+
+import pytest
+
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification.config import VerificationConfig
+from karenina.schemas.verification.prompt_config import PromptConfig
+
+
+def _make_models() -> tuple[ModelConfig, ModelConfig]:
+    answering = ModelConfig(id="a", model_name="m", model_provider="openai", system_prompt="You are helpful.")
+    parsing = ModelConfig(id="p", model_name="m", model_provider="openai")
+    return answering, parsing
+
+
+@pytest.mark.unit
+class TestInstructionShortcuts:
+    """Test that *_instructions shortcuts wire into PromptConfig."""
+
+    def test_parsing_instructions_creates_prompt_config(self) -> None:
+        a, p = _make_models()
+        config = VerificationConfig(
+            answering_models=[a],
+            parsing_models=[p],
+            parsing_instructions="Be strict",
+        )
+        assert config.prompt_config is not None
+        assert config.prompt_config.parsing == "Be strict"
+
+    def test_generation_instructions_creates_prompt_config(self) -> None:
+        a, p = _make_models()
+        config = VerificationConfig(
+            answering_models=[a],
+            parsing_models=[p],
+            generation_instructions="Focus on accuracy",
+        )
+        assert config.prompt_config is not None
+        assert config.prompt_config.generation == "Focus on accuracy"
+
+    def test_multiple_shortcuts_merge(self) -> None:
+        a, p = _make_models()
+        config = VerificationConfig(
+            answering_models=[a],
+            parsing_models=[p],
+            parsing_instructions="Be strict",
+            generation_instructions="Focus on accuracy",
+        )
+        assert config.prompt_config is not None
+        assert config.prompt_config.parsing == "Be strict"
+        assert config.prompt_config.generation == "Focus on accuracy"
+
+    def test_explicit_prompt_config_takes_precedence(self) -> None:
+        a, p = _make_models()
+        config = VerificationConfig(
+            answering_models=[a],
+            parsing_models=[p],
+            prompt_config=PromptConfig(parsing="Explicit"),
+            parsing_instructions="Shortcut",
+        )
+        assert config.prompt_config.parsing == "Explicit"
+
+    def test_shortcut_fills_unset_prompt_config_fields(self) -> None:
+        a, p = _make_models()
+        config = VerificationConfig(
+            answering_models=[a],
+            parsing_models=[p],
+            prompt_config=PromptConfig(parsing="Explicit"),
+            generation_instructions="From shortcut",
+        )
+        assert config.prompt_config.parsing == "Explicit"
+        assert config.prompt_config.generation == "From shortcut"
+
+    def test_all_shortcut_fields_exist(self) -> None:
+        a, p = _make_models()
+        config = VerificationConfig(
+            answering_models=[a],
+            parsing_models=[p],
+            generation_instructions="g",
+            parsing_instructions="p",
+            abstention_detection_instructions="a",
+            sufficiency_detection_instructions="s",
+            rubric_evaluation_instructions="r",
+            agentic_parsing_instructions="ap",
+            deep_judgment_instructions="dj",
+        )
+        pc = config.prompt_config
+        assert pc is not None
+        assert pc.generation == "g"
+        assert pc.parsing == "p"
+        assert pc.abstention_detection == "a"
+        assert pc.sufficiency_detection == "s"
+        assert pc.rubric_evaluation == "r"
+        assert pc.agentic_parsing == "ap"
+        assert pc.deep_judgment == "dj"

--- a/tests/unit/schemas/test_kshot_reproducibility.py
+++ b/tests/unit/schemas/test_kshot_reproducibility.py
@@ -27,12 +27,13 @@ class TestKShotReproducibility:
         sel_b = config.resolve_examples_for_question("question-b", examples)
         assert sel_a != sel_b
 
-    def test_seed_uses_builtin_hash(self) -> None:
-        """The seed must use hash(question_id) for reproducible seeding.
+    def test_seed_is_md5_based(self) -> None:
+        """The seed must use hashlib.md5 for cross-process reproducibility.
 
-        We verify by checking the source code uses hash(question_id).
+        hash() is randomized per-process via PYTHONHASHSEED, so the seed
+        must use hashlib.md5 instead.
         """
         import inspect
 
         source = inspect.getsource(FewShotConfig.resolve_examples_for_question)
-        assert "hash(question_id)" in source
+        assert "hashlib.md5" in source

--- a/tests/unit/schemas/test_kshot_reproducibility.py
+++ b/tests/unit/schemas/test_kshot_reproducibility.py
@@ -11,7 +11,7 @@ class TestKShotReproducibility:
 
     def test_resolve_deterministic_across_calls(self) -> None:
         """Same question_id yields same k-shot selection on repeated calls."""
-        config = FewShotConfig(global_mode="k-shot", global_k=3)
+        config = FewShotConfig(source="question_pool", pool_mode="k-shot", pool_k=3)
         examples = [{"question": f"q{i}", "answer": f"a{i}"} for i in range(10)]
 
         first = config.resolve_examples_for_question("test-q-123", examples)
@@ -20,20 +20,19 @@ class TestKShotReproducibility:
 
     def test_different_question_ids_yield_different_selections(self) -> None:
         """Different question_ids should (usually) produce different selections."""
-        config = FewShotConfig(global_mode="k-shot", global_k=3)
+        config = FewShotConfig(source="question_pool", pool_mode="k-shot", pool_k=3)
         examples = [{"question": f"q{i}", "answer": f"a{i}"} for i in range(20)]
 
         sel_a = config.resolve_examples_for_question("question-a", examples)
         sel_b = config.resolve_examples_for_question("question-b", examples)
         assert sel_a != sel_b
 
-    def test_seed_is_md5_based(self) -> None:
-        """The seed must use hashlib.md5 (not hash()).
+    def test_seed_uses_builtin_hash(self) -> None:
+        """The seed must use hash(question_id) for reproducible seeding.
 
-        We verify by checking the source code uses hashlib.md5.
+        We verify by checking the source code uses hash(question_id).
         """
         import inspect
 
         source = inspect.getsource(FewShotConfig.resolve_examples_for_question)
-        assert "hashlib.md5" in source
-        assert "hash(question_id)" not in source
+        assert "hash(question_id)" in source

--- a/tests/unit/schemas/test_parsing_system_prompt_removal.py
+++ b/tests/unit/schemas/test_parsing_system_prompt_removal.py
@@ -1,0 +1,44 @@
+"""Tests for parsing model system_prompt relaxation."""
+
+import pytest
+
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification.config import VerificationConfig
+
+
+@pytest.mark.unit
+class TestParsingSystemPromptRelaxation:
+    """Verify parsing models no longer need system_prompt."""
+
+    def test_parsing_model_none_system_prompt_valid(self) -> None:
+        """Parsing model with system_prompt=None should not raise."""
+        answering = ModelConfig(id="a", model_name="m", model_provider="openai", system_prompt="You are helpful.")
+        parsing = ModelConfig(id="p", model_name="m", model_provider="openai", system_prompt=None)
+        config = VerificationConfig(answering_models=[answering], parsing_models=[parsing])
+        assert config.parsing_models[0].system_prompt is None
+
+    def test_answering_model_still_requires_system_prompt(self) -> None:
+        """Answering model with no system_prompt gets auto-assigned default.
+
+        The auto-assignment block fills in DEFAULT_ANSWERING_SYSTEM_PROMPT for
+        answering models with empty/None system_prompt. The validation check
+        acts as a safety net after auto-assignment. To verify that the
+        validation targets only answering models, we call _validate_config
+        directly on a config where the answering model's prompt was cleared
+        after construction.
+        """
+        answering = ModelConfig(id="a", model_name="m", model_provider="openai", system_prompt="You are helpful.")
+        parsing = ModelConfig(id="p", model_name="m", model_provider="openai", system_prompt=None)
+        config = VerificationConfig(answering_models=[answering], parsing_models=[parsing])
+        # Bypass auto-assignment by clearing the prompt after construction
+        cleared = answering.model_copy(update={"system_prompt": None})
+        object.__setattr__(config, "answering_models", [cleared])
+        with pytest.raises(ValueError, match="[Ss]ystem prompt.*required.*answering"):
+            config._validate_config()
+
+    def test_parsing_model_no_auto_assignment(self) -> None:
+        """Parsing model should NOT receive DEFAULT_PARSING_SYSTEM_PROMPT."""
+        answering = ModelConfig(id="a", model_name="m", model_provider="openai", system_prompt="You are helpful.")
+        parsing = ModelConfig(id="p", model_name="m", model_provider="openai")
+        config = VerificationConfig(answering_models=[answering], parsing_models=[parsing])
+        assert config.parsing_models[0].system_prompt is None

--- a/tests/unit/schemas/test_verification_config.py
+++ b/tests/unit/schemas/test_verification_config.py
@@ -494,13 +494,13 @@ def test_get_few_shot_config_returns_new_config() -> None:
         ],
         answering_models=[],
         parsing_only=True,
-        few_shot_config=FewShotConfig(enabled=True, global_mode="all", global_k=3),
+        few_shot_config=FewShotConfig(source="both", pool_mode="all", pool_k=3),
     )
 
     result = config.get_few_shot_config()
     assert result is not None
-    assert result.enabled is True
-    assert result.global_mode == "all"
+    assert result.source == "both"
+    assert result.pool_mode == "all"
 
 
 @pytest.mark.unit
@@ -543,7 +543,7 @@ def test_is_few_shot_enabled_true() -> None:
         ],
         answering_models=[],
         parsing_only=True,
-        few_shot_config=FewShotConfig(enabled=True, global_mode="all", global_k=3),
+        few_shot_config=FewShotConfig(source="both", pool_mode="all", pool_k=3),
     )
 
     assert config.is_few_shot_enabled() is True

--- a/tests/unit/schemas/test_verification_config.py
+++ b/tests/unit/schemas/test_verification_config.py
@@ -24,7 +24,6 @@ from karenina.schemas.config import FewShotConfig, ModelConfig
 from karenina.schemas.config.models import ModelRetryConfig, ToolRetryConfig
 from karenina.schemas.verification import (
     DEFAULT_ANSWERING_SYSTEM_PROMPT,
-    DEFAULT_PARSING_SYSTEM_PROMPT,
     DeepJudgmentTraitConfig,
     VerificationConfig,
 )
@@ -263,7 +262,7 @@ def test_default_system_prompts() -> None:
                 model_name="gpt-4",
                 model_provider="openai",
                 interface="langchain",
-                system_prompt="",  # Empty, should be replaced
+                system_prompt="",  # Empty, no auto-assignment for parsing models
                 temperature=0.1,
             )
         ],
@@ -273,14 +272,14 @@ def test_default_system_prompts() -> None:
                 model_name="gpt-4",
                 model_provider="openai",
                 interface="langchain",
-                system_prompt=None,  # None, should be replaced
+                system_prompt=None,  # None, should be replaced with default
                 temperature=0.1,
             )
         ],
     )
 
-    # Default prompts should be applied
-    assert config.parsing_models[0].system_prompt == DEFAULT_PARSING_SYSTEM_PROMPT
+    # Answering models get auto-assigned default; parsing models do not
+    assert config.parsing_models[0].system_prompt == ""
     assert config.answering_models[0].system_prompt == DEFAULT_ANSWERING_SYSTEM_PROMPT
 
 

--- a/tests/unit/schemas/test_verification_config_issues.py
+++ b/tests/unit/schemas/test_verification_config_issues.py
@@ -11,7 +11,6 @@ from pydantic import ValidationError
 from karenina.schemas.config import ModelConfig
 from karenina.schemas.verification.config import (
     DEFAULT_ANSWERING_SYSTEM_PROMPT,
-    DEFAULT_PARSING_SYSTEM_PROMPT,
     VerificationConfig,
 )
 from karenina.storage.db_config import DBConfig
@@ -37,8 +36,8 @@ class TestSharedModelConfigMutation:
         )
         # After construction, the answering copy should have the answering prompt
         assert config.answering_models[0].system_prompt == DEFAULT_ANSWERING_SYSTEM_PROMPT
-        # And the parsing copy should have the parsing prompt
-        assert config.parsing_models[0].system_prompt == DEFAULT_PARSING_SYSTEM_PROMPT
+        # Parsing models no longer receive auto-assigned system_prompt
+        assert config.parsing_models[0].system_prompt is None
 
     def test_original_model_not_mutated(self) -> None:
         """The original ModelConfig instance must not be mutated by VerificationConfig.__init__."""


### PR DESCRIPTION
## Summary

- **Wire in PromptConfig.generation**: the generation field on PromptConfig was defined but never read by the answer generation stage. Now appended to the system message alongside ModelConfig.system_prompt
- **Remove dead DEFAULT_PARSING_SYSTEM_PROMPT auto-assignment**: parsing models no longer get a default system prompt forced on them (TemplateEvaluator builds its own). Validation relaxed so parsing models don't require system_prompt
- **Add instruction shortcuts on VerificationConfig**: convenience parameters (`generation_instructions`, `parsing_instructions`, etc.) that wire into PromptConfig without requiring explicit PromptConfig construction
- **Restructure FewShotConfig** (breaking): replaced `enabled`/`global_mode`/`global_k`/`global_external_examples` with `source`/`pool_mode`/`pool_k`/`global_examples`. New `source` field provides granular control (disabled/question_pool/global/both). Removed per-question `external_examples` and `mode="none"`
- **Replace runner auto-upgrade with warning**: the runner no longer silently overrides `evaluation_mode="template_only"` to `"template_and_rubric"` when rubric traits are present. Emits a warning instead
- **Docs and notebooks updated** to reflect all field name changes

## Test plan

- [x] 3503 unit tests pass
- [x] mypy clean on all changed files
- [x] vulture finds no new dead code
- [x] Notebooks regenerated via jupytext sync


🤖 Generated with [Claude Code](https://claude.com/claude-code)