### PR TITLE
feat(verification): streaming support and partial recovery on LLM/agent timeout

### DIFF
--- a/src/karenina/adapters/claude_agent_sdk/agent.py
+++ b/src/karenina/adapters/claude_agent_sdk/agent.py
@@ -19,7 +19,6 @@ Key differences from LangChain:
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -446,6 +445,11 @@ class ClaudeSDKAgentAdapter:
     ) -> AgentResult:
         """Synchronous wrapper for arun().
 
+        Always uses a dedicated thread with asyncio.run() to give the
+        Claude Agent SDK a fresh event loop, avoiding cancel scope
+        conflicts with BlockingPortal. See _run_in_fresh_loop in
+        the llm module for the full rationale.
+
         Args:
             messages: Initial conversation messages.
             tools: Optional list of Tool definitions.
@@ -460,29 +464,17 @@ class ClaudeSDKAgentAdapter:
             AgentTimeoutError: If execution exceeds the timeout.
             AgentResponseError: If the response is malformed or invalid.
         """
-        from karenina.benchmark.verification.executor import get_async_portal
+        from .llm import _run_in_fresh_loop
 
-        portal = get_async_portal()
-
-        if portal is not None:
-            return portal.call(self.arun, messages, tools, mcp_servers, config)
-
-        # No portal - check if we're in an async context
-        try:
-            asyncio.get_running_loop()
-            # We're in an async context - use ThreadPoolExecutor
-
-            def run_in_thread() -> AgentResult:
-                return asyncio.run(self.arun(messages, tools, mcp_servers, config))
-
-            timeout = config.timeout if config and config.timeout else 600
-            with concurrent.futures.ThreadPoolExecutor() as executor:
-                future = executor.submit(run_in_thread)
-                return future.result(timeout=timeout)
-
-        except RuntimeError:
-            # No event loop running, safe to use asyncio.run
-            return asyncio.run(self.arun(messages, tools, mcp_servers, config))
+        timeout = config.timeout if config and config.timeout else 600
+        return _run_in_fresh_loop(
+            self.arun,
+            messages,
+            tools,
+            mcp_servers,
+            config,
+            timeout=timeout,
+        )
 
     async def aclose(self) -> None:
         """Close underlying resources.

--- a/src/karenina/adapters/claude_agent_sdk/llm.py
+++ b/src/karenina/adapters/claude_agent_sdk/llm.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
@@ -25,6 +27,7 @@ from pydantic import BaseModel
 from karenina.adapters._parallel_base import with_llm_semaphore
 from karenina.ports import LLMPort, LLMResponse, Message, ParseError
 from karenina.ports.capabilities import PortCapabilities
+from karenina.ports.llm import StreamingLLMResponse
 
 from .messages import ClaudeSDKMessageConverter
 from .usage import extract_sdk_usage
@@ -154,11 +157,12 @@ class ClaudeSDKLLMAdapter:
         """Declare what prompt features this adapter supports.
 
         Returns:
-            PortCapabilities with system prompt support and structured output support.
+            PortCapabilities with system prompt, structured output, and streaming support.
         """
         return PortCapabilities(
             supports_system_prompt=True,
             supports_structured_output=True,
+            supports_streaming=True,
         )
 
     async def ainvoke(self, messages: list[Message]) -> LLMResponse:
@@ -310,13 +314,115 @@ class ClaudeSDKLLMAdapter:
             _max_turns=max_turns,
         )
 
-    def astream(self, messages: list[Message]) -> Any:  # noqa: ARG002
-        """Not supported: claude_agent_sdk adapter does not support streaming."""
-        raise NotImplementedError("claude_agent_sdk adapter does not support streaming")
+    @asynccontextmanager
+    async def astream(self, messages: list[Message]) -> AsyncIterator[StreamingLLMResponse]:  # noqa: ANN201
+        """Stream LLM response via Claude Agent SDK.
 
-    def stream_invoke(self, messages: list[Message], timeout: float | None = None) -> LLMResponse:  # noqa: ARG002
-        """Not supported: claude_agent_sdk adapter does not support streaming."""
-        raise NotImplementedError("claude_agent_sdk adapter does not support streaming")
+        Uses query() with include_partial_messages=True to receive
+        AssistantMessage objects as the response is built. Text deltas
+        are computed by tracking previously seen content.
+
+        Args:
+            messages: List of unified Message objects.
+
+        Yields:
+            StreamingLLMResponse that can be iterated for text chunks.
+        """
+        from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, query
+
+        prompt_string = self._converter.to_prompt_string(messages)
+        system_prompt = self._converter.extract_system_prompt(messages)
+
+        options = self._build_options(system_prompt)
+        options.include_partial_messages = True
+
+        response = StreamingLLMResponse()
+
+        async def _chunk_generator() -> AsyncIterator[str]:  # noqa: ANN202
+            """Yield text deltas from SDK partial AssistantMessages."""
+            emitted_length = 0
+            async for message in query(prompt=prompt_string, options=options):
+                if isinstance(message, AssistantMessage):
+                    # Extract full text from content blocks
+                    full_text = "".join(
+                        block.text for block in getattr(message, "content", []) if isinstance(block, TextBlock)
+                    )
+                    # Yield only the new portion
+                    if len(full_text) > emitted_length:
+                        delta = full_text[emitted_length:]
+                        emitted_length = len(full_text)
+                        yield delta
+                elif isinstance(message, ResultMessage):
+                    # Final message carries usage data
+                    response.usage = extract_sdk_usage(message, model=self._config.model_name)
+
+        response._set_chunk_source(_chunk_generator())
+        yield response
+        response.is_complete = True
+
+    async def _astream_with_timeout(self, messages: list[Message], timeout: float | None) -> LLMResponse:
+        """Stream with wall-clock timeout, returning accumulated content.
+
+        Args:
+            messages: List of unified Message objects.
+            timeout: Wall-clock timeout in seconds. None means no timeout.
+
+        Returns:
+            LLMResponse with accumulated content and is_partial flag.
+        """
+        is_partial = False
+        async with self.astream(messages) as sr:
+            try:
+                async with asyncio.timeout(timeout):
+                    async for _chunk in sr:
+                        pass
+            except TimeoutError:
+                is_partial = True
+                logger.warning(
+                    "Streaming timeout after %ss: captured %d chars of partial response",
+                    timeout,
+                    len(sr.accumulated_content),
+                )
+
+        return LLMResponse(
+            content=sr.accumulated_content,
+            usage=sr.usage,
+            raw=None,
+            is_partial=is_partial,
+            usage_unavailable=is_partial,
+        )
+
+    @with_llm_semaphore
+    def stream_invoke(self, messages: list[Message], timeout: float | None = None) -> LLMResponse:
+        """Stream with wall-clock timeout synchronously.
+
+        Args:
+            messages: List of unified Message objects.
+            timeout: Wall-clock timeout in seconds. None means no timeout.
+
+        Returns:
+            LLMResponse with accumulated content. is_partial is True if
+            the stream was interrupted by timeout.
+        """
+        from karenina.benchmark.verification.executor import get_async_portal
+
+        portal = get_async_portal()
+
+        if portal is not None:
+            return portal.call(self._astream_with_timeout, messages, timeout)
+
+        try:
+            asyncio.get_running_loop()
+
+            def run_in_thread() -> LLMResponse:
+                return asyncio.run(self._astream_with_timeout(messages, timeout))
+
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future = executor.submit(run_in_thread)
+                return future.result(timeout=(timeout or 300) + 30)
+
+        except RuntimeError:
+            return asyncio.run(self._astream_with_timeout(messages, timeout))
 
     async def aclose(self) -> None:
         """Close underlying resources.

--- a/src/karenina/adapters/claude_agent_sdk/llm.py
+++ b/src/karenina/adapters/claude_agent_sdk/llm.py
@@ -20,7 +20,7 @@ import concurrent.futures
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from pydantic import BaseModel
 
@@ -35,9 +35,57 @@ from .usage import extract_sdk_usage
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
     from claude_agent_sdk import ClaudeAgentOptions, ResultMessage
 
     from karenina.schemas.config import ModelConfig
+
+_T = TypeVar("_T")
+
+
+def _run_in_fresh_loop(
+    coro_func: Callable[..., Coroutine[Any, Any, _T]],
+    *args: Any,
+    timeout: float = 300,
+) -> _T:
+    """Run an async function in a dedicated thread with a fresh event loop.
+
+    The Claude Agent SDK (query(), ClaudeSDKClient) uses anyio cancel scopes
+    internally. When run via BlockingPortal.call(), those cancel scopes conflict
+    with the portal's own cancel scope hierarchy, producing:
+
+        RuntimeError: Attempted to exit a cancel scope that isn't the
+        current task's current cancel scope
+
+    This helper always spawns a new thread with asyncio.run(), giving the SDK
+    a completely isolated event loop and task context. This avoids the cancel
+    scope mismatch regardless of whether a BlockingPortal is active.
+
+    Other adapters (claude_tool, langchain) do not need this because their
+    underlying async calls (httpx, LangChain ainvoke) do not create anyio
+    cancel scopes.
+
+    Args:
+        coro_func: Async function to call.
+        *args: Positional arguments forwarded to coro_func.
+        timeout: Thread-level timeout in seconds (default: 300).
+
+    Returns:
+        The return value of the coroutine.
+
+    Raises:
+        concurrent.futures.TimeoutError: If the thread does not finish
+            within the timeout.
+        Exception: Any exception raised by the coroutine is re-raised.
+    """
+
+    def _target() -> _T:
+        return asyncio.run(coro_func(*args))
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future: concurrent.futures.Future[_T] = executor.submit(_target)
+        return future.result(timeout=timeout)
 
 
 class ClaudeSDKLLMAdapter:
@@ -229,8 +277,9 @@ class ClaudeSDKLLMAdapter:
         """Invoke the LLM synchronously.
 
         This is a convenience wrapper around ainvoke() for sync code.
-        Uses the shared async portal if available, otherwise falls back
-        to asyncio.run() with proper event loop handling.
+        Always uses a dedicated thread with asyncio.run() to give the
+        Claude Agent SDK a fresh event loop, avoiding cancel scope
+        conflicts with BlockingPortal.
 
         Args:
             messages: List of unified Message objects.
@@ -241,30 +290,7 @@ class ClaudeSDKLLMAdapter:
         Raises:
             PortError: If the invocation fails.
         """
-        from karenina.benchmark.verification.executor import get_async_portal
-
-        portal = get_async_portal()
-
-        if portal is not None:
-            # Use the shared BlockingPortal for proper event loop management
-            return portal.call(self.ainvoke, messages)
-
-        # No portal available - check if we're already in an async context
-        try:
-            asyncio.get_running_loop()
-            # We're in an async context - use ThreadPoolExecutor to avoid
-            # nested event loop issues
-
-            def run_in_thread() -> LLMResponse:
-                return asyncio.run(self.ainvoke(messages))
-
-            with concurrent.futures.ThreadPoolExecutor() as executor:
-                future = executor.submit(run_in_thread)
-                return future.result(timeout=300)  # 5 minute timeout
-
-        except RuntimeError:
-            # No event loop running, safe to use asyncio.run
-            return asyncio.run(self.ainvoke(messages))
+        return _run_in_fresh_loop(self.ainvoke, messages, timeout=300)
 
     def with_structured_output(
         self,
@@ -396,6 +422,10 @@ class ClaudeSDKLLMAdapter:
     def stream_invoke(self, messages: list[Message], timeout: float | None = None) -> LLMResponse:
         """Stream with wall-clock timeout synchronously.
 
+        Always uses a dedicated thread with asyncio.run() to give the
+        Claude Agent SDK a fresh event loop, avoiding cancel scope
+        conflicts with BlockingPortal.
+
         Args:
             messages: List of unified Message objects.
             timeout: Wall-clock timeout in seconds. None means no timeout.
@@ -404,25 +434,12 @@ class ClaudeSDKLLMAdapter:
             LLMResponse with accumulated content. is_partial is True if
             the stream was interrupted by timeout.
         """
-        from karenina.benchmark.verification.executor import get_async_portal
-
-        portal = get_async_portal()
-
-        if portal is not None:
-            return portal.call(self._astream_with_timeout, messages, timeout)
-
-        try:
-            asyncio.get_running_loop()
-
-            def run_in_thread() -> LLMResponse:
-                return asyncio.run(self._astream_with_timeout(messages, timeout))
-
-            with concurrent.futures.ThreadPoolExecutor() as executor:
-                future = executor.submit(run_in_thread)
-                return future.result(timeout=(timeout or 300) + 30)
-
-        except RuntimeError:
-            return asyncio.run(self._astream_with_timeout(messages, timeout))
+        return _run_in_fresh_loop(
+            self._astream_with_timeout,
+            messages,
+            timeout,
+            timeout=(timeout or 300) + 30,
+        )
 
     async def aclose(self) -> None:
         """Close underlying resources.

--- a/src/karenina/adapters/claude_agent_sdk/llm.py
+++ b/src/karenina/adapters/claude_agent_sdk/llm.py
@@ -310,6 +310,14 @@ class ClaudeSDKLLMAdapter:
             _max_turns=max_turns,
         )
 
+    def astream(self, messages: list[Message]) -> Any:  # noqa: ARG002
+        """Not supported: claude_agent_sdk adapter does not support streaming."""
+        raise NotImplementedError("claude_agent_sdk adapter does not support streaming")
+
+    def stream_invoke(self, messages: list[Message], timeout: float | None = None) -> LLMResponse:  # noqa: ARG002
+        """Not supported: claude_agent_sdk adapter does not support streaming."""
+        raise NotImplementedError("claude_agent_sdk adapter does not support streaming")
+
     async def aclose(self) -> None:
         """Close underlying resources.
 

--- a/src/karenina/adapters/claude_agent_sdk/parser.py
+++ b/src/karenina/adapters/claude_agent_sdk/parser.py
@@ -1,17 +1,19 @@
 """Claude Agent SDK Parser adapter implementing the ParserPort interface.
 
-This module provides the ClaudeSDKParserAdapter class that implements the ParserPort
-interface using the Claude Agent SDK's query() function with structured output.
+This module provides the ClaudeSDKParserAdapter that uses direct API calls
+for structured output parsing, bypassing the Agent SDK's subprocess transport.
 
-IMPORTANT: This is NOT just JSON parsing. It invokes an LLM to interpret
-natural language responses and extract structured data according to a schema.
+The adapter detects the endpoint type from the model configuration:
 
-Key differences from LangChain:
-- Uses query() with output_format={'type': 'json_schema', 'schema': ...}
-- SDK's structured_output is already a Python dict, NOT a JSON string
-- Use schema.model_validate(result.structured_output) NOT json.loads()
-- SDK needs max_turns>=2 for internal structured output validation
-- System prompt passed via ClaudeAgentOptions.system_prompt (same as LLM adapter)
+- **Anthropic API** (no custom base URL): Uses ``anthropic.AsyncAnthropic``
+  with ``output_config`` for native constrained decoding.
+- **Custom endpoint** (vLLM, sglang): Uses ``openai.AsyncOpenAI`` with
+  ``response_format`` on the OpenAI-compatible endpoint (auto-derived from
+  the same host). Logs a warning on first use.
+
+This hybrid approach gives guaranteed schema enforcement on both endpoint
+types while keeping the Agent SDK's subprocess transport for agent and LLM
+operations (where it works correctly).
 """
 
 from __future__ import annotations
@@ -21,15 +23,15 @@ import concurrent.futures
 import json
 import logging
 from typing import TYPE_CHECKING, Any, TypeVar
+from urllib.parse import urlparse
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
-from karenina.ports import Message, ParseError, ParsePortResult, ParserPort
+from karenina.ports import Message, ParseError, ParsePortResult, ParserPort, UsageMetadata
 from karenina.ports.capabilities import PortCapabilities
+from karenina.utils.json_extraction import extract_json_from_response
 
 if TYPE_CHECKING:
-    from claude_agent_sdk import ClaudeAgentOptions, ResultMessage
-
     from karenina.schemas.config import ModelConfig
 
 logger = logging.getLogger(__name__)
@@ -37,21 +39,59 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=BaseModel)
 
 
+def _enforce_no_additional_properties(schema: dict[str, Any]) -> dict[str, Any]:
+    """Recursively set ``additionalProperties: false`` on all object types.
+
+    Anthropic's ``output_config`` requires this; Pydantic's
+    ``model_json_schema()`` omits it (defaulting to true per JSON Schema spec).
+
+    Args:
+        schema: A JSON schema dict (mutated in place and returned).
+
+    Returns:
+        The same schema dict with ``additionalProperties`` set on all objects.
+    """
+    if schema.get("type") == "object":
+        schema["additionalProperties"] = False
+
+    # Walk nested schemas: properties, items, $defs, allOf/anyOf/oneOf
+    for prop in schema.get("properties", {}).values():
+        _enforce_no_additional_properties(prop)
+    if "items" in schema and isinstance(schema["items"], dict):
+        _enforce_no_additional_properties(schema["items"])
+    for defn in schema.get("$defs", {}).values():
+        _enforce_no_additional_properties(defn)
+    for keyword in ("allOf", "anyOf", "oneOf"):
+        for sub in schema.get(keyword, []):
+            if isinstance(sub, dict):
+                _enforce_no_additional_properties(sub)
+
+    return schema
+
+
+def _derive_openai_base_url(anthropic_base_url: str) -> str:
+    """Derive an OpenAI-compatible base URL from an Anthropic base URL.
+
+    Both vLLM and sglang expose OpenAI and Anthropic endpoints on the same
+    host and port. This strips any path from the Anthropic URL and appends
+    ``/v1`` for the OpenAI endpoint.
+
+    Args:
+        anthropic_base_url: The custom Anthropic endpoint URL.
+
+    Returns:
+        OpenAI-compatible base URL (e.g. ``http://host:8000/v1``).
+    """
+    parsed = urlparse(anthropic_base_url)
+    return f"{parsed.scheme}://{parsed.netloc}/v1"
+
+
 class ClaudeSDKParserAdapter:
-    """Parser adapter using Claude Agent SDK's structured output capabilities.
+    """Parser adapter using direct API calls for structured output.
 
-    This adapter implements the ParserPort Protocol and provides LLM-based
-    structured output parsing. It invokes an LLM (the "judge" model) to
-    interpret natural language responses and extract structured data.
-
-    The parsing flow:
-    1. Build a prompt with the response text and instruction to extract data
-    2. Invoke the SDK's query() with output_format set to the JSON schema
-    3. The SDK constrains the LLM to output valid JSON matching the schema
-    4. Validate the result using Pydantic and return the model instance
-
-    IMPORTANT: Unlike LangChain, the SDK's structured_output is already a
-    Python dict. No json.loads() is needed - use model_validate() directly.
+    Bypasses the Agent SDK subprocess (which hangs on custom endpoints with
+    ``--json-schema``) by calling the API directly. Uses constrained decoding
+    for schema enforcement on both Anthropic API and custom endpoints.
 
     Example:
         >>> from karenina.schemas.config import ModelConfig
@@ -68,74 +108,69 @@ class ClaudeSDKParserAdapter:
         ...     interface="claude_agent_sdk"
         ... )
         >>> parser = ClaudeSDKParserAdapter(config)
-        >>> trace = "Based on my analysis, BCL2 is an anti-apoptotic gene..."
-        >>> answer = await parser.aparse_to_pydantic(trace, Answer)
-        >>> print(answer.gene_name)
-        'BCL2'
+        >>> answer = await parser.aparse_to_pydantic(messages, Answer)
     """
 
-    # Default max_turns for structured output (minimum needed for SDK validation)
-    DEFAULT_STRUCTURED_MAX_TURNS = 2
-
-    def __init__(self, model_config: ModelConfig, *, max_turns: int | None = None) -> None:
+    def __init__(self, model_config: ModelConfig) -> None:
         """Initialize the Claude SDK parser adapter.
 
         Args:
             model_config: Configuration specifying model, provider, and interface.
-            max_turns: Maximum turns for SDK structured output validation.
-                Default is 2 (minimum needed for structured output).
         """
         self._config = model_config
-        self._max_turns = max_turns if max_turns is not None else self.DEFAULT_STRUCTURED_MAX_TURNS
+        self._is_custom_endpoint = bool(model_config.anthropic_base_url)
+        self._anthropic_client: Any | None = None
+        self._openai_client: Any | None = None
+        self._warned_custom_endpoint = False
 
     @property
     def capabilities(self) -> PortCapabilities:
         """Declare what prompt features this parser adapter supports.
-
-        Claude Agent SDK supports native structured output via output_format
-        and system prompts via ClaudeAgentOptions.system_prompt.
 
         Returns:
             PortCapabilities with system prompt and structured output support.
         """
         return PortCapabilities(supports_system_prompt=True, supports_structured_output=True)
 
-    def _build_options(self, schema: type[BaseModel], system_prompt: str) -> ClaudeAgentOptions:
-        """Build ClaudeAgentOptions for structured output parsing.
+    def _get_anthropic_client(self) -> Any:
+        """Get or create the async Anthropic client (for Anthropic API)."""
+        if self._anthropic_client is None:
+            import anthropic
 
-        Args:
-            schema: The Pydantic schema to use for structured output.
-            system_prompt: System prompt text extracted from messages.
+            kwargs: dict[str, Any] = {}
+            if self._config.anthropic_api_key:
+                kwargs["api_key"] = self._config.anthropic_api_key.get_secret_value()
+            if self._config.request_timeout is not None:
+                kwargs["timeout"] = self._config.request_timeout
+            self._anthropic_client = anthropic.AsyncAnthropic(**kwargs)
+        return self._anthropic_client
 
-        Returns:
-            Configured ClaudeAgentOptions with output_format and system_prompt set.
-        """
-        from claude_agent_sdk import ClaudeAgentOptions
+    def _get_openai_client(self) -> Any:
+        """Get or create the async OpenAI client (for custom endpoints)."""
+        if self._openai_client is None:
+            from openai import AsyncOpenAI
 
-        # Generate JSON schema from the Pydantic model
-        json_schema = schema.model_json_schema()
+            base_url = _derive_openai_base_url(self._config.anthropic_base_url)  # type: ignore[arg-type]
+            api_key = self._config.anthropic_api_key.get_secret_value() if self._config.anthropic_api_key else "EMPTY"
+            kwargs: dict[str, Any] = {
+                "api_key": api_key,
+                "base_url": base_url,
+            }
+            if self._config.request_timeout is not None:
+                kwargs["timeout"] = self._config.request_timeout
+            self._openai_client = AsyncOpenAI(**kwargs)
 
-        options_kwargs: dict[str, Any] = {
-            # Use bypassPermissions for batch/automated calls
-            "permission_mode": "bypassPermissions",
-            # No tools needed for parsing
-            "allowed_tools": [],
-            # Set structured output format
-            "output_format": {
-                "type": "json_schema",
-                "schema": json_schema,
-            },
-            # SDK needs internal turns for structured output validation
-            "max_turns": self._max_turns,
-            # System prompt from pre-assembled messages
-            "system_prompt": system_prompt,
-        }
-
-        # Add model specification if provided
-        if self._config.model_name:
-            options_kwargs["model"] = self._config.model_name
-
-        return ClaudeAgentOptions(**options_kwargs)
+            if not self._warned_custom_endpoint:
+                logger.warning(
+                    "Custom Anthropic endpoint detected (%s). "
+                    "Parsing will use the OpenAI-compatible endpoint (%s) "
+                    "for schema enforcement via response_format. "
+                    "This is compatible with vLLM and sglang.",
+                    self._config.anthropic_base_url,
+                    base_url,
+                )
+                self._warned_custom_endpoint = True
+        return self._openai_client
 
     @staticmethod
     def _extract_from_messages(messages: list[Message]) -> tuple[str, str]:
@@ -156,85 +191,178 @@ class ClaudeSDKParserAdapter:
                 user_parts.append(msg.text)
         return system_text, "\n\n".join(user_parts)
 
+    async def _parse_via_anthropic(
+        self,
+        system_text: str,
+        user_text: str,
+        schema: type[T],
+    ) -> ParsePortResult[T]:
+        """Parse via Anthropic API with output_config (constrained decoding).
+
+        Args:
+            system_text: System prompt text.
+            user_text: User prompt text.
+            schema: Pydantic model class for the expected structure.
+
+        Returns:
+            ParsePortResult with the validated model instance.
+        """
+        client = self._get_anthropic_client()
+        json_schema = _enforce_no_additional_properties(schema.model_json_schema())
+
+        kwargs: dict[str, Any] = {
+            "model": self._config.model_name,
+            "max_tokens": self._config.max_tokens or 4096,
+            "messages": [{"role": "user", "content": user_text}],
+            "output_config": {
+                "format": {"type": "json_schema", "schema": json_schema},
+            },
+        }
+        if system_text:
+            kwargs["system"] = system_text
+        if self._config.temperature is not None:
+            kwargs["temperature"] = self._config.temperature
+
+        try:
+            response = await client.messages.create(**kwargs)
+        except Exception as e:
+            raise ParseError(f"Anthropic API call failed during parsing: {e}") from e
+
+        text_parts = [b.text for b in response.content if hasattr(b, "text")]
+        raw_text = "\n".join(text_parts)
+
+        usage = UsageMetadata(
+            input_tokens=response.usage.input_tokens,
+            output_tokens=response.usage.output_tokens,
+            total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+            cache_read_tokens=getattr(response.usage, "cache_read_input_tokens", None),
+            cache_creation_tokens=getattr(response.usage, "cache_creation_input_tokens", None),
+            model=getattr(response, "model", None) or self._config.model_name,
+        )
+
+        return self._validate_json_response(raw_text, schema, usage)
+
+    async def _parse_via_openai(
+        self,
+        system_text: str,
+        user_text: str,
+        schema: type[T],
+    ) -> ParsePortResult[T]:
+        """Parse via OpenAI-compatible endpoint with response_format (constrained decoding).
+
+        Args:
+            system_text: System prompt text.
+            user_text: User prompt text.
+            schema: Pydantic model class for the expected structure.
+
+        Returns:
+            ParsePortResult with the validated model instance.
+        """
+        client = self._get_openai_client()
+        json_schema = _enforce_no_additional_properties(schema.model_json_schema())
+
+        messages: list[dict[str, str]] = []
+        if system_text:
+            messages.append({"role": "system", "content": system_text})
+        messages.append({"role": "user", "content": user_text})
+
+        kwargs: dict[str, Any] = {
+            "model": self._config.model_name,
+            "max_tokens": self._config.max_tokens or 4096,
+            "messages": messages,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": schema.__name__,
+                    "schema": json_schema,
+                    "strict": True,
+                },
+            },
+        }
+        if self._config.temperature is not None:
+            kwargs["temperature"] = self._config.temperature
+
+        try:
+            response = await client.chat.completions.create(**kwargs)
+        except Exception as e:
+            raise ParseError(f"OpenAI API call failed during parsing: {e}") from e
+
+        raw_text = response.choices[0].message.content or ""
+
+        usage = UsageMetadata(
+            input_tokens=getattr(response.usage, "prompt_tokens", 0),
+            output_tokens=getattr(response.usage, "completion_tokens", 0),
+            total_tokens=getattr(response.usage, "total_tokens", 0),
+            model=getattr(response, "model", None) or self._config.model_name,
+        )
+
+        return self._validate_json_response(raw_text, schema, usage)
+
+    def _validate_json_response(
+        self,
+        raw_text: str,
+        schema: type[T],
+        usage: UsageMetadata,
+    ) -> ParsePortResult[T]:
+        """Extract JSON from response text and validate against the schema.
+
+        Tries direct ``json.loads`` first (expected when constrained decoding
+        is active), then falls back to ``extract_json_from_response`` for
+        responses wrapped in code fences or mixed with reasoning text.
+
+        Args:
+            raw_text: Raw text from the API response.
+            schema: Pydantic model class to validate against.
+            usage: Pre-built usage metadata.
+
+        Returns:
+            ParsePortResult with the validated model instance.
+        """
+        if not raw_text.strip():
+            raise ParseError("Empty response from API during parsing")
+
+        try:
+            data = json.loads(raw_text.strip())
+        except json.JSONDecodeError:
+            try:
+                json_str = extract_json_from_response(raw_text)
+                data = json.loads(json_str)
+            except (ValueError, json.JSONDecodeError) as e:
+                raise ParseError(f"Failed to extract JSON from response: {e}. Raw text: {raw_text[:300]}") from e
+
+        try:
+            return ParsePortResult(parsed=schema.model_validate(data), usage=usage)
+        except ValidationError as e:
+            raise ParseError(
+                f"Schema validation failed for {schema.__name__}: {e}. Extracted data: {json.dumps(data)[:300]}"
+            ) from e
+
     async def aparse_to_pydantic(self, messages: list[Message], schema: type[T]) -> ParsePortResult[T]:
-        """Parse using pre-assembled prompt messages into a structured Pydantic model.
+        """Parse pre-assembled prompt messages into a structured Pydantic model.
+
+        Routes to the Anthropic API (with ``output_config``) or the
+        OpenAI-compatible endpoint (with ``response_format``) based on
+        whether a custom base URL is configured.
 
         Args:
             messages: Pre-assembled prompt messages (system + user).
             schema: A Pydantic model class defining the expected structure.
-                    Field descriptions guide the LLM on what to extract.
 
         Returns:
             ParsePortResult containing the parsed model and usage metadata.
 
         Raises:
-            ParseError: If the LLM fails to extract valid structured data.
-            PortError: If the underlying LLM invocation fails.
+            ParseError: If the LLM fails to produce valid structured data.
         """
-        from claude_agent_sdk import ResultMessage, query
-        from pydantic import ValidationError
-
-        # Extract system and user text from pre-assembled messages
         system_text, user_text = self._extract_from_messages(messages)
 
-        # Build prompt and options
-        prompt = user_text
-        options = self._build_options(schema, system_text)
-
-        # Execute query and collect result
-        result: ResultMessage | None = None
-
-        try:
-            async for message in query(prompt=prompt, options=options):
-                if isinstance(message, ResultMessage):
-                    result = message
-                    # Don't break - let iteration complete naturally per SDK best practices
-
-        except Exception as e:
-            raise ParseError(f"SDK query failed during parsing: {e}") from e
-
-        if result is None:
-            raise ParseError("No ResultMessage received from SDK")
-
-        # Extract usage from ResultMessage using shared utility
-        from karenina.adapters.claude_agent_sdk.usage import extract_sdk_usage
-
-        usage = extract_sdk_usage(result, model=self._config.model_name)
-
-        # Check for structured output failure
-        # SDK returns subtype='error_max_structured_output_retries' on validation failure
-        if result.subtype and "error" in result.subtype.lower():
-            error_msg = f"Structured output extraction failed: {result.subtype}"
-            if result.result:
-                error_msg += f" - {result.result}"
-            raise ParseError(error_msg)
-
-        # Extract structured output
-        # IMPORTANT: SDK's structured_output is already a Python dict, NOT JSON string
-        if result.structured_output is None:
-            # Fallback: try to parse result.result as JSON if no structured output
-            if result.result:
-                try:
-                    data = json.loads(result.result)
-                    return ParsePortResult(parsed=schema.model_validate(data), usage=usage)
-                except (json.JSONDecodeError, ValidationError) as e:
-                    logger.debug(f"Fallback JSON parsing failed: {e}")
-
-            raise ParseError(
-                f"No structured output in SDK response. "
-                f"Subtype: {result.subtype}, Result: {result.result[:100] if result.result else 'None'}"
-            )
-
-        # Validate and return the structured output
-        try:
-            return ParsePortResult(parsed=schema.model_validate(result.structured_output), usage=usage)
-        except ValidationError as e:
-            raise ParseError(f"Structured output validation failed: {e}. Raw output: {result.structured_output}") from e
+        if self._is_custom_endpoint:
+            return await self._parse_via_openai(system_text, user_text, schema)
+        return await self._parse_via_anthropic(system_text, user_text, schema)
 
     def parse_to_pydantic(self, messages: list[Message], schema: type[T]) -> ParsePortResult[T]:
         """Parse using pre-assembled prompt messages (sync).
 
-        This is a convenience wrapper around aparse_to_pydantic() for sync code.
         Uses the shared async portal if available, otherwise falls back to
         asyncio.run() with proper event loop handling.
 
@@ -246,8 +374,7 @@ class ClaudeSDKParserAdapter:
             ParsePortResult containing the parsed model and usage metadata.
 
         Raises:
-            ParseError: If the LLM fails to extract valid structured data.
-            PortError: If the underlying LLM invocation fails.
+            ParseError: If parsing fails.
         """
         from karenina.benchmark.verification.executor import get_async_portal
 
@@ -256,7 +383,6 @@ class ClaudeSDKParserAdapter:
         if portal is not None:
             return portal.call(self.aparse_to_pydantic, messages, schema)
 
-        # No portal available - check if we're already in an async context
         try:
             asyncio.get_running_loop()
 
@@ -265,29 +391,23 @@ class ClaudeSDKParserAdapter:
 
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 future = executor.submit(run_in_thread)
-                return future.result(timeout=300)  # 5 minute timeout
+                return future.result(timeout=300)
 
         except RuntimeError:
-            # No event loop running, safe to use asyncio.run
             return asyncio.run(self.aparse_to_pydantic(messages, schema))
 
     async def aclose(self) -> None:
-        """Close underlying resources.
-
-        The Claude SDK parser adapter uses query() which doesn't hold persistent
-        connections, so this is a no-op. Provided for interface consistency
-        with other adapters that do require cleanup.
-        """
-        pass
+        """Close underlying HTTP clients."""
+        if self._anthropic_client is not None:
+            await self._anthropic_client.close()
+            self._anthropic_client = None
+        if self._openai_client is not None:
+            await self._openai_client.close()
+            self._openai_client = None
 
 
 # Verify protocol compliance at import time
 def _verify_protocol_compliance() -> None:
     """Verify ClaudeSDKParserAdapter implements ParserPort protocol."""
-    # This is a static check - if this fails, it means the adapter
-    # doesn't properly implement the protocol
     adapter_instance: ParserPort = None  # type: ignore[assignment]
-
-    # The following would fail mypy if the protocol wasn't properly implemented
-    # We don't actually run this, it's just for static analysis
-    _ = adapter_instance  # Suppress unused warning
+    _ = adapter_instance

--- a/src/karenina/adapters/claude_agent_sdk/prompts/parsing.py
+++ b/src/karenina/adapters/claude_agent_sdk/prompts/parsing.py
@@ -1,24 +1,56 @@
-"""Parsing instruction for Claude Agent SDK adapter."""
+"""Parsing instruction for Claude Agent SDK adapter.
+
+The Claude Agent SDK parser uses a direct API call (not the SDK subprocess)
+for structured output extraction. The JSON schema and extraction rules are
+included in the prompt to guide the model, complementing the API-level
+schema enforcement (output_config on Anthropic, response_format on vLLM/sglang).
+"""
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from typing import Any
 
 from karenina.ports.adapter_instruction import AdapterInstructionRegistry
 
-SYSTEM_ADDITION = "If uncertain, use your best interpretation based on the text."
+SYSTEM_ADDITION = """\
+# Extraction Rules
 
-USER_ADDITION = ""
+- Extract only what's actually stated; do not infer or add information not present.
+- Use null for information not present (if the field allows null).
+- Match field names and types exactly as defined in the JSON schema.
+- If a field expects a string, return a single string, not a list.
+- If a field expects a boolean, return true or false, not a string or number.
+- If uncertain, use your best interpretation based on the text.
+
+# Output Format
+
+Return ONLY a valid JSON object. Do not wrap it in markdown fences, code blocks, or any surrounding text."""
+
+USER_ADDITION = """\
+**JSON SCHEMA (your response MUST conform to this):**
+```json
+{schema_json}
+```
+
+**CRITICAL:**
+- Every field name must match the schema exactly.
+- Every required field must be present.
+- Return ONLY the raw JSON object, no explanation, no markdown fences."""
 
 
 @dataclass
 class _ClaudeSDKParsingInstruction:
-    """Append best-interpretation directive for Claude Agent SDK parsing.
+    """Append extraction and format directives for Claude Agent SDK parsing.
 
-    The Claude Agent SDK uses native structured output via output_format,
-    so no format/schema sections are needed. Only a best-interpretation
-    directive is appended.
+    When targeting the Anthropic API, schema enforcement is handled by
+    output_config (constrained decoding). When targeting custom endpoints
+    (vLLM, sglang), enforcement uses the OpenAI response_format. In both
+    cases, the prompt-level schema instructions serve as a reinforcing signal.
     """
+
+    json_schema: dict[str, Any] | None = None
 
     @property
     def system_addition(self) -> str:
@@ -26,11 +58,16 @@ class _ClaudeSDKParsingInstruction:
 
     @property
     def user_addition(self) -> str:
-        return USER_ADDITION
+        if self.json_schema is None:
+            return ""
+        schema_json = json.dumps(self.json_schema, indent=2)
+        return USER_ADDITION.format(schema_json=schema_json)
 
 
-def _claude_sdk_parsing_instruction_factory(**kwargs: object) -> _ClaudeSDKParsingInstruction:  # noqa: ARG001
-    return _ClaudeSDKParsingInstruction()
+def _claude_sdk_parsing_instruction_factory(**kwargs: object) -> _ClaudeSDKParsingInstruction:
+    return _ClaudeSDKParsingInstruction(
+        json_schema=kwargs.get("json_schema"),  # type: ignore[arg-type]
+    )
 
 
 AdapterInstructionRegistry.register("claude_agent_sdk", "parsing", _claude_sdk_parsing_instruction_factory)

--- a/src/karenina/adapters/claude_tool/agent.py
+++ b/src/karenina/adapters/claude_tool/agent.py
@@ -401,18 +401,32 @@ class ClaudeToolAgentAdapter:
                     break
 
         # Execute with optional timeout
+        timeout_reached = False
         if config.timeout:
-            await asyncio.wait_for(execute_loop(), timeout=config.timeout)
+            try:
+                await asyncio.wait_for(execute_loop(), timeout=config.timeout)
+            except TimeoutError:
+                timeout_reached = True
+                logger.warning(
+                    "Agent timed out after %ss (%d turns, %d trace messages accumulated)",
+                    config.timeout,
+                    turns,
+                    len(trace_messages),
+                )
         else:
             await execute_loop()
 
         if not trace_messages:
+            if timeout_reached:
+                raise AgentTimeoutError(f"Agent execution timed out after {config.timeout}s with no messages")
             raise AgentResponseError("No messages received from tool_runner")
 
         # Build outputs
         raw_trace = claude_tool_messages_to_raw_trace(trace_messages)
         if limit_reached:
             raw_trace += "\n\n[Note: Turn limit reached - partial response shown]"
+        if timeout_reached:
+            raw_trace += "\n\n[Note: Agent timed out - partial response shown]"
 
         final_response = self._extract_final_response(trace_messages)
 
@@ -430,8 +444,9 @@ class ClaudeToolAgentAdapter:
             usage=total_usage,
             turns=turns,
             limit_reached=limit_reached,
-            session_id=None,  # tool_runner doesn't provide session IDs
+            session_id=None,
             actual_model=actual_model,
+            timeout_reached=timeout_reached,
         )
 
     def run(

--- a/src/karenina/adapters/claude_tool/llm.py
+++ b/src/karenina/adapters/claude_tool/llm.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 
 from pydantic import BaseModel
@@ -22,6 +24,7 @@ from pydantic import BaseModel
 from karenina.adapters._parallel_base import with_llm_semaphore
 from karenina.ports import AdapterUnavailableError, LLMPort, LLMResponse, Message, ParseError
 from karenina.ports.capabilities import PortCapabilities
+from karenina.ports.llm import StreamingLLMResponse
 from karenina.schemas.config import ModelConfig
 from karenina.utils.messages import append_error_feedback
 
@@ -129,11 +132,12 @@ class ClaudeToolLLMAdapter:
         """Declare what prompt features this adapter supports.
 
         Returns:
-            PortCapabilities with system prompt support and structured output support.
+            PortCapabilities with system prompt, structured output, and streaming support.
         """
         return PortCapabilities(
             supports_system_prompt=True,
             supports_structured_output=True,
+            supports_streaming=True,
         )
 
     async def ainvoke(self, messages: list[Message]) -> LLMResponse:
@@ -157,31 +161,7 @@ class ClaudeToolLLMAdapter:
     async def _ainvoke_text(self, messages: list[Message]) -> LLMResponse:
         """Invoke LLM for regular text output."""
         client = self._get_async_client()
-
-        # Convert messages
-        anthropic_messages = convert_to_anthropic(messages)
-        system_prompt = extract_system_prompt(messages)
-
-        # Build kwargs
-        if not self._config.model_name:
-            raise AdapterUnavailableError("model_name is required in ModelConfig", reason="missing_model_name")
-
-        kwargs: dict[str, Any] = {
-            "model": self._config.model_name,
-            "max_tokens": self._config.max_tokens,
-            "messages": anthropic_messages,
-        }
-
-        # Add system with caching if present
-        if system_prompt:
-            cached_system = build_system_with_cache(system_prompt)
-            if cached_system:
-                kwargs["system"] = cached_system
-
-        # Add temperature if specified
-        if self._config.temperature is not None:
-            kwargs["temperature"] = self._config.temperature
-
+        kwargs = self._build_invoke_kwargs(messages)
         response = await client.messages.create(**kwargs)
 
         # Extract text content
@@ -309,6 +289,130 @@ class ClaudeToolLLMAdapter:
 
         except RuntimeError:
             return asyncio.run(self.ainvoke(messages))
+
+    def _build_invoke_kwargs(self, messages: list[Message]) -> dict[str, Any]:
+        """Build kwargs for messages.create / messages.stream.
+
+        Shared between _ainvoke_text and astream to avoid duplication.
+        """
+        anthropic_messages = convert_to_anthropic(messages)
+        system_prompt = extract_system_prompt(messages)
+
+        if not self._config.model_name:
+            raise AdapterUnavailableError("model_name is required in ModelConfig", reason="missing_model_name")
+
+        kwargs: dict[str, Any] = {
+            "model": self._config.model_name,
+            "max_tokens": self._config.max_tokens,
+            "messages": anthropic_messages,
+        }
+
+        if system_prompt:
+            cached_system = build_system_with_cache(system_prompt)
+            if cached_system:
+                kwargs["system"] = cached_system
+
+        if self._config.temperature is not None:
+            kwargs["temperature"] = self._config.temperature
+
+        return kwargs
+
+    @asynccontextmanager
+    async def astream(self, messages: list[Message]) -> AsyncIterator[StreamingLLMResponse]:  # noqa: ANN201
+        """Stream LLM response, accumulating tokens as they arrive.
+
+        Uses Anthropic SDK's ``client.messages.stream()`` for native streaming.
+        On timeout, the StreamingLLMResponse contains whatever content
+        was received before the interruption.
+
+        Args:
+            messages: List of unified Message objects.
+
+        Yields:
+            StreamingLLMResponse that can be iterated for text chunks.
+        """
+        client = self._get_async_client()
+        kwargs = self._build_invoke_kwargs(messages)
+        response = StreamingLLMResponse()
+
+        async with client.messages.stream(**kwargs) as stream:
+            response._set_chunk_source(stream.text_stream)
+            try:
+                yield response
+            finally:
+                # Best-effort usage extraction from the stream's final message
+                try:
+                    final_message = await stream.get_final_message()
+                    response.usage = extract_usage_from_response(final_message, model=self._config.model_name)
+                except Exception:
+                    logger.warning("Could not extract usage from stream", exc_info=True)
+        response.is_complete = True
+
+    async def _astream_with_timeout(self, messages: list[Message], timeout: float | None) -> LLMResponse:
+        """Stream with wall-clock timeout, returning accumulated content.
+
+        Args:
+            messages: List of unified Message objects.
+            timeout: Wall-clock timeout in seconds. None means no timeout.
+
+        Returns:
+            LLMResponse with accumulated content and is_partial flag.
+        """
+        is_partial = False
+        async with self.astream(messages) as sr:
+            try:
+                async with asyncio.timeout(timeout):
+                    async for _chunk in sr:
+                        pass
+            except TimeoutError:
+                is_partial = True
+                logger.warning(
+                    "Streaming timeout after %ss: captured %d chars of partial response",
+                    timeout,
+                    len(sr.accumulated_content),
+                )
+
+        return LLMResponse(
+            content=sr.accumulated_content,
+            usage=sr.usage,
+            raw=None,
+            is_partial=is_partial,
+        )
+
+    @with_llm_semaphore
+    def stream_invoke(self, messages: list[Message], timeout: float | None = None) -> LLMResponse:
+        """Stream with wall-clock timeout, returning accumulated content synchronously.
+
+        Uses streaming internally so that partial content can be captured on
+        timeout. Returns the same LLMResponse type as invoke().
+
+        Args:
+            messages: List of unified Message objects.
+            timeout: Wall-clock timeout in seconds. None means no timeout.
+
+        Returns:
+            LLMResponse with accumulated content. ``is_partial`` is True if
+            the stream was interrupted by timeout.
+        """
+        from karenina.benchmark.verification.executor import get_async_portal
+
+        portal = get_async_portal()
+
+        if portal is not None:
+            return portal.call(self._astream_with_timeout, messages, timeout)
+
+        try:
+            asyncio.get_running_loop()
+
+            def run_in_thread() -> LLMResponse:
+                return asyncio.run(self._astream_with_timeout(messages, timeout))
+
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future = executor.submit(run_in_thread)
+                return future.result(timeout=(timeout or 300) + 30)
+
+        except RuntimeError:
+            return asyncio.run(self._astream_with_timeout(messages, timeout))
 
     def with_structured_output(
         self, schema: type[BaseModel], *, max_retries: int | None = None

--- a/src/karenina/adapters/claude_tool/llm.py
+++ b/src/karenina/adapters/claude_tool/llm.py
@@ -377,6 +377,7 @@ class ClaudeToolLLMAdapter:
             usage=sr.usage,
             raw=None,
             is_partial=is_partial,
+            usage_unavailable=is_partial,
         )
 
     @with_llm_semaphore

--- a/src/karenina/adapters/langchain/agent.py
+++ b/src/karenina/adapters/langchain/agent.py
@@ -18,7 +18,6 @@ from karenina.ports import (
     AgentExecutionError,
     AgentPort,
     AgentResult,
-    AgentTimeoutError,
     MCPHttpServerConfig,
     MCPServerConfig,
     Message,
@@ -308,7 +307,6 @@ class LangChainAgentAdapter:
 
         Raises:
             AgentExecutionError: If the agent fails during execution.
-            AgentTimeoutError: If execution exceeds the timeout.
         """
         from karenina.adapters.langchain.trace import (
             extract_final_ai_message_from_response,
@@ -340,6 +338,7 @@ class LangChainAgentAdapter:
 
         # Prepare agent invocation
         recursion_limit_reached = False
+        timeout_reached = False
         agent_response: dict[str, Any] = {"messages": []}
 
         # Use session-based thread_id for checkpointing
@@ -400,10 +399,12 @@ class LangChainAgentAdapter:
                                 try:
                                     agent_response = await asyncio.wait_for(coro, timeout=config.timeout)
                                 except TimeoutError as e:
-                                    deferred_error = AgentTimeoutError(
-                                        f"Agent execution timed out after {config.timeout}s"
+                                    logger.warning(
+                                        "Agent timed out after %ss, attempting partial state recovery",
+                                        config.timeout,
                                     )
-                                    deferred_error.__cause__ = e
+                                    timeout_reached = True
+                                    agent_response = extract_partial_agent_state(agent, lc_messages, e, agent_config)
                             else:
                                 agent_response = await coro
                         except Exception as e:
@@ -429,8 +430,12 @@ class LangChainAgentAdapter:
                             try:
                                 agent_response = await asyncio.wait_for(coro, timeout=config.timeout)
                             except TimeoutError as e:
-                                deferred_error = AgentTimeoutError(f"Agent execution timed out after {config.timeout}s")
-                                deferred_error.__cause__ = e
+                                logger.warning(
+                                    "Agent timed out after %ss, attempting partial state recovery",
+                                    config.timeout,
+                                )
+                                timeout_reached = True
+                                agent_response = extract_partial_agent_state(agent, lc_messages, e, agent_config)
                         else:
                             agent_response = await coro
                     except Exception as e:
@@ -459,6 +464,8 @@ class LangChainAgentAdapter:
         raw_trace = harmonize_agent_response(agent_response)
         if recursion_limit_reached:
             raw_trace += "\n\n[Note: Recursion limit reached - partial response shown]"
+        if timeout_reached:
+            raw_trace += "\n\n[Note: Agent timed out - partial response shown]"
 
         # Build trace_messages (new structured format)
         # Exclude user messages — the trace should only contain assistant and
@@ -493,6 +500,7 @@ class LangChainAgentAdapter:
             limit_reached=recursion_limit_reached,
             session_id=thread_id,
             actual_model=self._config.model_name,
+            timeout_reached=timeout_reached,
         )
 
     def run(
@@ -515,7 +523,6 @@ class LangChainAgentAdapter:
 
         Raises:
             AgentExecutionError: If the agent fails during execution.
-            AgentTimeoutError: If execution exceeds the timeout.
         """
         from karenina.benchmark.verification.executor import get_async_portal
 

--- a/src/karenina/adapters/langchain/llm.py
+++ b/src/karenina/adapters/langchain/llm.py
@@ -300,6 +300,7 @@ class LangChainLLMAdapter:
             usage=sr.usage,
             raw=None,
             is_partial=is_partial,
+            usage_unavailable=is_partial,
         )
 
     @with_llm_semaphore

--- a/src/karenina/adapters/langchain/llm.py
+++ b/src/karenina/adapters/langchain/llm.py
@@ -23,6 +23,8 @@ import asyncio
 import concurrent.futures
 import json
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ValidationError
@@ -30,6 +32,7 @@ from pydantic import BaseModel, ValidationError
 from karenina.adapters._parallel_base import with_llm_semaphore
 from karenina.ports import LLMPort, LLMResponse, Message, ParseError
 from karenina.ports.capabilities import PortCapabilities
+from karenina.ports.llm import StreamingLLMResponse
 from karenina.utils.errors import is_retryable_error
 from karenina.utils.json_extraction import extract_json_from_response
 from karenina.utils.messages import append_error_feedback
@@ -37,7 +40,7 @@ from karenina.utils.retry import TRANSIENT_RETRY
 
 from .messages import LangChainMessageConverter
 from .prompts import FORMAT_INSTRUCTIONS
-from .usage import extract_langchain_usage, extract_usage_from_response
+from .usage import extract_langchain_usage, extract_usage_from_chunk, extract_usage_from_response
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +129,12 @@ class LangChainLLMAdapter:
             kwargs["temperature"] = self._config.temperature
 
         if self._config.request_timeout is not None:
-            kwargs["request_timeout"] = self._config.request_timeout
+            # LangChain's ChatAnthropic uses 'default_request_timeout', not 'request_timeout'.
+            # Other providers (OpenAI, Google) accept 'request_timeout' as-is.
+            if self._config.model_provider == "anthropic":
+                kwargs["default_request_timeout"] = self._config.request_timeout
+            else:
+                kwargs["request_timeout"] = self._config.request_timeout
 
         if self._config.extra_kwargs:
             kwargs.update(self._config.extra_kwargs)
@@ -155,11 +163,12 @@ class LangChainLLMAdapter:
         """Declare what prompt features this adapter supports.
 
         Returns:
-            PortCapabilities with system prompt support and structured output support.
+            PortCapabilities with system prompt, structured output, and streaming support.
         """
         return PortCapabilities(
             supports_system_prompt=True,
             supports_structured_output=True,
+            supports_streaming=True,
         )
 
     async def ainvoke(self, messages: list[Message]) -> LLMResponse:
@@ -231,6 +240,102 @@ class LangChainLLMAdapter:
         except RuntimeError:
             # No event loop running, safe to use asyncio.run
             return asyncio.run(self.ainvoke(messages))
+
+    @asynccontextmanager
+    async def astream(self, messages: list[Message]) -> AsyncIterator[StreamingLLMResponse]:  # noqa: ANN201
+        """Stream LLM response, accumulating tokens as they arrive.
+
+        Uses LangChain's cross-provider ``.astream()`` method which yields
+        ``AIMessageChunk`` objects uniformly across providers.
+
+        Args:
+            messages: List of unified Message objects.
+
+        Yields:
+            StreamingLLMResponse that can be iterated for text chunks.
+        """
+        lc_messages = self._converter.to_provider(messages)
+        response = StreamingLLMResponse()
+
+        async def _chunk_generator() -> AsyncIterator[str]:  # noqa: ANN202
+            """Yield text chunks from LangChain's astream, extracting usage from final chunk."""
+            async for chunk in self._model.astream(lc_messages):
+                text = chunk.content if isinstance(chunk.content, str) else ""
+                if text:
+                    yield text
+                # Usage metadata typically arrives on the final chunk
+                if hasattr(chunk, "usage_metadata") and chunk.usage_metadata:
+                    response.usage = extract_usage_from_chunk(chunk, model_name=self._config.model_name)
+
+        response._set_chunk_source(_chunk_generator())
+        yield response
+        response.is_complete = True
+
+    async def _astream_with_timeout(self, messages: list[Message], timeout: float | None) -> LLMResponse:
+        """Stream with wall-clock timeout, returning accumulated content.
+
+        Args:
+            messages: List of unified Message objects.
+            timeout: Wall-clock timeout in seconds. None means no timeout.
+
+        Returns:
+            LLMResponse with accumulated content and is_partial flag.
+        """
+        is_partial = False
+        async with self.astream(messages) as sr:
+            try:
+                async with asyncio.timeout(timeout):
+                    async for _chunk in sr:
+                        pass
+            except TimeoutError:
+                is_partial = True
+                logger.warning(
+                    "Streaming timeout after %ss: captured %d chars of partial response",
+                    timeout,
+                    len(sr.accumulated_content),
+                )
+
+        return LLMResponse(
+            content=sr.accumulated_content,
+            usage=sr.usage,
+            raw=None,
+            is_partial=is_partial,
+        )
+
+    @with_llm_semaphore
+    def stream_invoke(self, messages: list[Message], timeout: float | None = None) -> LLMResponse:
+        """Stream with wall-clock timeout, returning accumulated content synchronously.
+
+        Uses streaming internally so that partial content can be captured on
+        timeout. Returns the same LLMResponse type as invoke().
+
+        Args:
+            messages: List of unified Message objects.
+            timeout: Wall-clock timeout in seconds. None means no timeout.
+
+        Returns:
+            LLMResponse with accumulated content. ``is_partial`` is True if
+            the stream was interrupted by timeout.
+        """
+        from karenina.benchmark.verification.executor import get_async_portal
+
+        portal = get_async_portal()
+
+        if portal is not None:
+            return portal.call(self._astream_with_timeout, messages, timeout)
+
+        try:
+            asyncio.get_running_loop()
+
+            def run_in_thread() -> LLMResponse:
+                return asyncio.run(self._astream_with_timeout(messages, timeout))
+
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future = executor.submit(run_in_thread)
+                return future.result(timeout=(timeout or 300) + 30)
+
+        except RuntimeError:
+            return asyncio.run(self._astream_with_timeout(messages, timeout))
 
     def with_structured_output(self, schema: type[BaseModel], *, max_retries: int | None = None) -> LangChainLLMAdapter:
         """Return a new adapter configured for structured output.

--- a/src/karenina/adapters/langchain/usage.py
+++ b/src/karenina/adapters/langchain/usage.py
@@ -214,6 +214,35 @@ def extract_usage_cumulative(
     )
 
 
+def extract_usage_from_chunk(chunk: Any, *, model_name: str | None = None) -> UsageMetadata:
+    """Extract usage metadata from a LangChain AIMessageChunk.
+
+    During streaming, usage metadata typically arrives on the final chunk
+    via the ``usage_metadata`` attribute.
+
+    Args:
+        chunk: LangChain AIMessageChunk with optional usage_metadata.
+        model_name: Optional model name to include in metadata.
+
+    Returns:
+        UsageMetadata with extracted token counts.
+    """
+    meta: dict[str, Any] = {}
+    if hasattr(chunk, "usage_metadata") and chunk.usage_metadata:
+        um = chunk.usage_metadata
+        meta = (
+            um
+            if isinstance(um, dict)
+            else {
+                "input_tokens": getattr(um, "input_tokens", 0),
+                "output_tokens": getattr(um, "output_tokens", 0),
+                "cache_read_input_tokens": getattr(um, "cache_read_input_tokens", None),
+                "cache_creation_input_tokens": getattr(um, "cache_creation_input_tokens", None),
+            }
+        )
+    return _build_usage_metadata(meta, model_name)
+
+
 def _extract_from_response(response: Any) -> dict[str, Any]:
     """Extract usage dict from a response object.
 

--- a/src/karenina/adapters/langchain_deep_agents/initialization.py
+++ b/src/karenina/adapters/langchain_deep_agents/initialization.py
@@ -51,7 +51,10 @@ def create_chat_model(model_config: ModelConfig, **kwargs: Any) -> Any:
     if model_config.temperature is not None:
         model_kwargs["temperature"] = model_config.temperature
     if model_config.request_timeout is not None:
-        model_kwargs["request_timeout"] = model_config.request_timeout
+        if model_config.model_provider == "anthropic":
+            model_kwargs["default_request_timeout"] = model_config.request_timeout
+        else:
+            model_kwargs["request_timeout"] = model_config.request_timeout
 
     model_kwargs.update(kwargs)
 

--- a/src/karenina/adapters/langchain_deep_agents/llm.py
+++ b/src/karenina/adapters/langchain_deep_agents/llm.py
@@ -12,13 +12,17 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
 from karenina.adapters._parallel_base import with_llm_semaphore
+from karenina.adapters.langchain.usage import extract_usage_from_chunk
 from karenina.ports import LLMResponse, Message
 from karenina.ports.capabilities import PortCapabilities
+from karenina.ports.llm import StreamingLLMResponse
 from karenina.ports.usage import UsageMetadata
 
 from .initialization import create_chat_model
@@ -69,11 +73,12 @@ class DeepAgentsLLMAdapter:
         """Declare adapter capabilities.
 
         Returns:
-            PortCapabilities with system_prompt=True and structured_output=True.
+            PortCapabilities with system_prompt, structured_output, and streaming support.
         """
         return PortCapabilities(
             supports_system_prompt=True,
             supports_structured_output=True,
+            supports_streaming=True,
         )
 
     async def ainvoke(self, messages: list[Message]) -> LLMResponse:
@@ -197,13 +202,106 @@ class DeepAgentsLLMAdapter:
             _structured_schema=schema,
         )
 
-    def astream(self, messages: list[Message]) -> Any:  # noqa: ARG002
-        """Not supported: langchain_deep_agents adapter does not support streaming."""
-        raise NotImplementedError("langchain_deep_agents adapter does not support streaming")
+    @asynccontextmanager
+    async def astream(self, messages: list[Message]) -> AsyncIterator[StreamingLLMResponse]:  # noqa: ANN201
+        """Stream LLM response using LangChain's cross-provider astream.
 
-    def stream_invoke(self, messages: list[Message], timeout: float | None = None) -> LLMResponse:  # noqa: ARG002
-        """Not supported: langchain_deep_agents adapter does not support streaming."""
-        raise NotImplementedError("langchain_deep_agents adapter does not support streaming")
+        Args:
+            messages: List of unified Message objects.
+
+        Yields:
+            StreamingLLMResponse that can be iterated for text chunks.
+        """
+        from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+        lc_messages: list[Any] = []
+        for msg in messages:
+            text = msg.text or ""
+            if msg.role.value == "system":
+                lc_messages.append(SystemMessage(content=text))
+            elif msg.role.value == "user":
+                lc_messages.append(HumanMessage(content=text))
+            elif msg.role.value == "assistant":
+                lc_messages.append(AIMessage(content=text))
+
+        chat_model = create_chat_model(self._config)
+        response = StreamingLLMResponse()
+
+        async def _chunk_generator() -> AsyncIterator[str]:  # noqa: ANN202
+            """Yield text chunks from LangChain's astream, extracting usage from final chunk."""
+            async for chunk in chat_model.astream(lc_messages):
+                text = chunk.content if isinstance(chunk.content, str) else ""
+                if text:
+                    yield text
+                if hasattr(chunk, "usage_metadata") and chunk.usage_metadata:
+                    response.usage = extract_usage_from_chunk(chunk, model_name=self._config.model_name)
+
+        response._set_chunk_source(_chunk_generator())
+        yield response
+        response.is_complete = True
+
+    async def _astream_with_timeout(self, messages: list[Message], timeout: float | None) -> LLMResponse:
+        """Stream with wall-clock timeout, returning accumulated content.
+
+        Args:
+            messages: List of unified Message objects.
+            timeout: Wall-clock timeout in seconds. None means no timeout.
+
+        Returns:
+            LLMResponse with accumulated content and is_partial flag.
+        """
+        is_partial = False
+        async with self.astream(messages) as sr:
+            try:
+                async with asyncio.timeout(timeout):
+                    async for _chunk in sr:
+                        pass
+            except TimeoutError:
+                is_partial = True
+                logger.warning(
+                    "Streaming timeout after %ss: captured %d chars of partial response",
+                    timeout,
+                    len(sr.accumulated_content),
+                )
+
+        return LLMResponse(
+            content=sr.accumulated_content,
+            usage=sr.usage,
+            raw=None,
+            is_partial=is_partial,
+            usage_unavailable=is_partial,
+        )
+
+    @with_llm_semaphore
+    def stream_invoke(self, messages: list[Message], timeout: float | None = None) -> LLMResponse:
+        """Stream with wall-clock timeout synchronously.
+
+        Args:
+            messages: List of unified Message objects.
+            timeout: Wall-clock timeout in seconds. None means no timeout.
+
+        Returns:
+            LLMResponse with accumulated content. is_partial is True if timeout fired.
+        """
+        from karenina.benchmark.verification.executor import get_async_portal
+
+        portal = get_async_portal()
+
+        if portal is not None:
+            return portal.call(self._astream_with_timeout, messages, timeout)
+
+        try:
+            asyncio.get_running_loop()
+
+            def run_in_thread() -> LLMResponse:
+                return asyncio.run(self._astream_with_timeout(messages, timeout))
+
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future = executor.submit(run_in_thread)
+                return future.result(timeout=(timeout or 300) + 30)
+
+        except RuntimeError:
+            return asyncio.run(self._astream_with_timeout(messages, timeout))
 
     async def aclose(self) -> None:
         """Close underlying resources.

--- a/src/karenina/adapters/langchain_deep_agents/llm.py
+++ b/src/karenina/adapters/langchain_deep_agents/llm.py
@@ -197,6 +197,14 @@ class DeepAgentsLLMAdapter:
             _structured_schema=schema,
         )
 
+    def astream(self, messages: list[Message]) -> Any:  # noqa: ARG002
+        """Not supported: langchain_deep_agents adapter does not support streaming."""
+        raise NotImplementedError("langchain_deep_agents adapter does not support streaming")
+
+    def stream_invoke(self, messages: list[Message], timeout: float | None = None) -> LLMResponse:  # noqa: ARG002
+        """Not supported: langchain_deep_agents adapter does not support streaming."""
+        raise NotImplementedError("langchain_deep_agents adapter does not support streaming")
+
     async def aclose(self) -> None:
         """Close underlying resources.
 

--- a/src/karenina/adapters/manual/__init__.py
+++ b/src/karenina/adapters/manual/__init__.py
@@ -247,6 +247,14 @@ class ManualLLMAdapter:
         """Raises ManualInterfaceError - manual interface cannot invoke LLM."""
         raise ManualInterfaceError("llm.with_structured_output()")
 
+    def astream(self, messages: list[Message]) -> Any:  # noqa: ARG002
+        """Raises ManualInterfaceError - manual interface cannot stream."""
+        raise ManualInterfaceError("llm.astream()")
+
+    def stream_invoke(self, messages: list[Message], timeout: float | None = None) -> LLMResponse:  # noqa: ARG002
+        """Raises ManualInterfaceError - manual interface cannot stream."""
+        raise ManualInterfaceError("llm.stream_invoke()")
+
     async def aclose(self) -> None:
         """Close underlying resources (no-op for manual adapter)."""
 

--- a/src/karenina/benchmark/verification/scenario_executor.py
+++ b/src/karenina/benchmark/verification/scenario_executor.py
@@ -239,6 +239,8 @@ class ScenarioExecutor:
         # Thread-safe storage for results (indexed by original position)
         results_lock = threading.Lock()
         results_by_index: dict[int, ScenarioExecutionResult] = {}
+        # Partial progress for in-flight combos (turn tracking via callback)
+        partial_progress: dict[int, dict[str, Any]] = {}
 
         # Thread-safe error tracking
         failed_tasks: list[tuple[str, BaseException]] = []
@@ -277,6 +279,22 @@ class ScenarioExecutor:
 
                     try:
                         manager = ScenarioManager()
+
+                        def make_turn_callback(idx: int, scenario_name: str) -> Callable[..., None]:
+                            """Create a per-turn callback that tracks progress."""
+
+                            def _on_turn(**kwargs: Any) -> None:
+                                turn_num = kwargs.get("scenario_turn", 0)
+                                node_id = kwargs.get("scenario_node", "")
+                                with results_lock:
+                                    partial_progress[idx] = {
+                                        "scenario_id": scenario_name,
+                                        "turn": turn_num,
+                                        "node": node_id,
+                                    }
+
+                            return _on_turn
+
                         exec_result = manager.run(
                             scenario=scenario_def,
                             config=config,
@@ -285,6 +303,7 @@ class ScenarioExecutor:
                             run_name=run_name,
                             global_rubric=global_rubric,
                             answer_cache=answer_cache,
+                            progress_callback=make_turn_callback(original_index, scenario_def.name),
                         )
 
                         with results_lock:
@@ -339,12 +358,25 @@ class ScenarioExecutor:
         for idx in sorted(results_by_index.keys()):
             results.append(results_by_index[idx])
 
-        # Handle timeout: add a timeout error entry
         if not completed:
+            # Log partial progress for in-flight combos
+            in_flight_info: list[str] = []
+            for idx in range(total):
+                if idx not in results_by_index and idx in partial_progress:
+                    info = partial_progress[idx]
+                    in_flight_info.append(
+                        f"  combo {idx}: {info['scenario_id']} reached turn {info['turn']} at node {info['node']}"
+                    )
+
+            completed_count_final = len(results_by_index)
+            partial_count = len(in_flight_info)
             timeout_msg = (
                 f"Parallel scenario batch timed out after {self.config.timeout_seconds:.0f}s "
-                f"({len(results)} of {total} combos completed)"
+                f"({completed_count_final} completed, {partial_count} in-flight, "
+                f"{total - completed_count_final - partial_count} not started of {total} combos)"
             )
+            if in_flight_info:
+                timeout_msg += "\nIn-flight combo progress:\n" + "\n".join(in_flight_info)
             logger.error("%s", timeout_msg)
             failed_tasks.append((timeout_msg, TimeoutError(timeout_msg)))
 

--- a/src/karenina/benchmark/verification/stages/core/base.py
+++ b/src/karenina/benchmark/verification/stages/core/base.py
@@ -105,6 +105,9 @@ class ArtifactKeys:
     # Recursion Limit
     RECURSION_LIMIT_REACHED = "recursion_limit_reached"
 
+    # Streaming Timeout
+    RESPONSE_TIMEOUT_PARTIAL = "response_timeout_partial"
+
     # Trace Validation
     MCP_ENABLED = "mcp_enabled"
     TRACE_VALIDATION_FAILED = "trace_validation_failed"

--- a/src/karenina/benchmark/verification/stages/core/base.py
+++ b/src/karenina/benchmark/verification/stages/core/base.py
@@ -107,6 +107,7 @@ class ArtifactKeys:
 
     # Streaming Timeout
     RESPONSE_TIMEOUT_PARTIAL = "response_timeout_partial"
+    USAGE_UNAVAILABLE = "usage_unavailable"
 
     # Trace Validation
     MCP_ENABLED = "mcp_enabled"

--- a/src/karenina/benchmark/verification/stages/pipeline/abstention_check.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/abstention_check.py
@@ -68,6 +68,9 @@ class AbstentionCheckStage(BaseCheckStage):
         # Skip if recursion limit was reached (response is truncated/unreliable)
         if context.get_artifact(ArtifactKeys.RECURSION_LIMIT_REACHED, False):
             return False
+        # Skip if response was truncated by streaming timeout
+        if context.get_artifact(ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL, False):
+            return False
         return context.abstention_enabled
 
     def _should_trigger_override(self, detected: bool | None, check_performed: bool) -> bool:

--- a/src/karenina/benchmark/verification/stages/pipeline/agentic_parse_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/agentic_parse_template.py
@@ -73,6 +73,8 @@ class AgenticParseTemplateStage(BaseVerificationStage):
             return False
         if context.get_artifact(ArtifactKeys.RECURSION_LIMIT_REACHED, False):
             return False
+        if context.get_artifact(ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL, False):
+            return False
         if context.get_artifact(ArtifactKeys.TRACE_VALIDATION_FAILED, False):
             return False
         if context.get_artifact(ArtifactKeys.ABSTENTION_DETECTED, False):

--- a/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
@@ -235,6 +235,7 @@ class FinalizeResultStage(BaseVerificationStage):
             regex_overall_success=context.get_result_field(ArtifactKeys.REGEX_OVERALL_SUCCESS),
             regex_extraction_results=context.get_result_field(ArtifactKeys.REGEX_EXTRACTION_RESULTS),
             recursion_limit_reached=context.get_result_field(ArtifactKeys.RECURSION_LIMIT_REACHED, False),
+            response_timeout_partial=context.get_result_field(ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL, False),
             # Agentic parsing
             investigation_trace=context.get_result_field(ArtifactKeys.INVESTIGATION_TRACE),
             agentic_parsing_performed=context.get_result_field(ArtifactKeys.AGENTIC_PARSING_PERFORMED, False),

--- a/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
@@ -236,6 +236,7 @@ class FinalizeResultStage(BaseVerificationStage):
             regex_extraction_results=context.get_result_field(ArtifactKeys.REGEX_EXTRACTION_RESULTS),
             recursion_limit_reached=context.get_result_field(ArtifactKeys.RECURSION_LIMIT_REACHED, False),
             response_timeout_partial=context.get_result_field(ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL, False),
+            usage_unavailable=context.get_result_field(ArtifactKeys.USAGE_UNAVAILABLE, False),
             # Agentic parsing
             investigation_trace=context.get_result_field(ArtifactKeys.INVESTIGATION_TRACE),
             agentic_parsing_performed=context.get_result_field(ArtifactKeys.AGENTIC_PARSING_PERFORMED, False),

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -71,6 +71,7 @@ class GenerateAnswerStage(BaseVerificationStage):
             ArtifactKeys.RECURSION_LIMIT_REACHED,
             ArtifactKeys.ANSWERING_MODEL_STR,
             ArtifactKeys.ANSWERING_MCP_SERVERS,
+            ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL,
         ]
 
     def should_run(self, context: VerificationContext) -> bool:
@@ -359,11 +360,28 @@ class GenerateAnswerStage(BaseVerificationStage):
                 # LLMPort path: Use for simple LLM calls without tools
                 assert answering_llm is not None
 
-                # Invoke LLM directly
-                llm_response = answering_llm.invoke(adapter_messages)
+                # Use streaming when available to capture partial output on timeout
+                if answering_llm.capabilities.supports_streaming:
+                    llm_response = answering_llm.stream_invoke(
+                        adapter_messages,
+                        timeout=context.answering_model.request_timeout,
+                    )
+                else:
+                    llm_response = answering_llm.invoke(adapter_messages)
 
                 # Format response as trace (AI message only, question is not part of the trace)
                 raw_llm_response = f"--- AI Message ---\n{llm_response.content}"
+
+                # Mark partial response if streaming timed out
+                if llm_response.is_partial:
+                    if not llm_response.content:
+                        raise TimeoutError("LLM request timed out with no content received")
+                    self.set_artifact_and_result(context, "response_timeout_partial", True)
+                    logger.warning(
+                        "Question %s: response truncated by streaming timeout (%d chars captured)",
+                        context.question_id,
+                        len(llm_response.content),
+                    )
 
                 # Build trace_messages for the LLM path too
                 llm_trace_messages = [

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -383,6 +383,10 @@ class GenerateAnswerStage(BaseVerificationStage):
                         len(llm_response.content),
                     )
 
+                # Propagate usage_unavailable flag if present
+                if llm_response.usage_unavailable:
+                    self.set_artifact_and_result(context, ArtifactKeys.USAGE_UNAVAILABLE, True)
+
                 # Build trace_messages for the LLM path too
                 llm_trace_messages = [
                     Message.assistant(llm_response.content),

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -392,9 +392,9 @@ class GenerateAnswerStage(BaseVerificationStage):
 
                 # Mark partial response if streaming timed out
                 if llm_response.is_partial:
+                    self.set_artifact_and_result(context, "response_timeout_partial", True)
                     if not llm_response.content:
                         raise TimeoutError("LLM request timed out with no content received")
-                    self.set_artifact_and_result(context, "response_timeout_partial", True)
                     logger.warning(
                         "Question %s: response truncated by streaming timeout (%d chars captured)",
                         context.question_id,

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -324,6 +324,24 @@ class GenerateAnswerStage(BaseVerificationStage):
                 raw_llm_response = result.raw_trace
                 recursion_limit_reached = result.limit_reached
 
+                # Handle agent timeout with partial trace
+                if result.timeout_reached:
+                    if result.raw_trace:
+                        self.set_artifact_and_result(context, "response_timeout_partial", True)
+                        self.set_artifact_and_result(context, ArtifactKeys.USAGE_UNAVAILABLE, True)
+                        logger.warning(
+                            "Question %s: agent timed out with partial trace (%d chars, %d turns)",
+                            context.question_id,
+                            len(result.raw_trace),
+                            result.turns,
+                        )
+                    else:
+                        error_msg = "Agent timed out with no trace messages"
+                        context.mark_error(error_msg)
+                        context.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "")
+                        context.set_artifact(ArtifactKeys.RECURSION_LIMIT_REACHED, False)
+                        return
+
                 # Track usage metadata from adapter
                 if result.usage:
                     inner_usage: dict[str, int | float] = {

--- a/src/karenina/benchmark/verification/stages/pipeline/parse_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/parse_template.py
@@ -115,6 +115,9 @@ class ParseTemplateStage(BaseVerificationStage):
         # Skip parsing if recursion limit was reached (response is truncated/unreliable)
         if context.get_artifact(ArtifactKeys.RECURSION_LIMIT_REACHED, False):
             return False
+        # Skip parsing if response was truncated by streaming timeout
+        if context.get_artifact(ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL, False):
+            return False
         # Skip parsing if trace validation failed (trace doesn't end with AI message)
         if context.get_artifact(ArtifactKeys.TRACE_VALIDATION_FAILED, False):
             return False

--- a/src/karenina/benchmark/verification/stages/pipeline/sufficiency_check.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/sufficiency_check.py
@@ -72,6 +72,9 @@ class SufficiencyCheckStage(BaseCheckStage):
         # Skip if recursion limit was reached (response is truncated/unreliable)
         if context.get_artifact(ArtifactKeys.RECURSION_LIMIT_REACHED, False):
             return False
+        # Skip if response was truncated by streaming timeout
+        if context.get_artifact(ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL, False):
+            return False
         # Skip if trace validation failed (trace doesn't end with AI message)
         if context.get_artifact(ArtifactKeys.TRACE_VALIDATION_FAILED, False):
             return False

--- a/src/karenina/benchmark/verification/stages/pipeline/verify_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/verify_template.py
@@ -79,6 +79,9 @@ class VerifyTemplateStage(BaseVerificationStage):
         # Skip verification if recursion limit was reached (response is truncated/unreliable)
         if context.get_artifact(ArtifactKeys.RECURSION_LIMIT_REACHED, False):
             return False
+        # Skip verification if response was truncated by streaming timeout
+        if context.get_artifact(ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL, False):
+            return False
         # Skip verification if abstention was detected (model refused to answer)
         if context.get_artifact(ArtifactKeys.ABSTENTION_DETECTED, False):
             return False

--- a/src/karenina/ports/__init__.py
+++ b/src/karenina/ports/__init__.py
@@ -31,7 +31,7 @@ from karenina.ports.errors import (
     ParseError,
     PortError,
 )
-from karenina.ports.llm import LLMPort, LLMResponse
+from karenina.ports.llm import LLMPort, LLMResponse, StreamingLLMResponse
 from karenina.ports.messages import (
     Content,
     ContentType,
@@ -62,6 +62,7 @@ __all__ = [
     # LLM Port
     "LLMPort",
     "LLMResponse",
+    "StreamingLLMResponse",
     # Parser Port
     "ParsePortResult",
     "ParserPort",

--- a/src/karenina/ports/agent.py
+++ b/src/karenina/ports/agent.py
@@ -181,6 +181,9 @@ class AgentResult:
         actual_model: The actual model that generated the response, which may
             differ from the requested model due to fallback or routing. Extracted
             from SDK AssistantMessage.model field.
+        timeout_reached: True if the agent stopped due to a wall-clock timeout
+            rather than completing naturally. Partial trace may be available.
+            Distinct from limit_reached (turn/recursion limit vs wall-clock).
 
     Example:
         >>> result = AgentResult(
@@ -208,6 +211,7 @@ class AgentResult:
     limit_reached: bool
     session_id: str | None = None
     actual_model: str | None = None
+    timeout_reached: bool = False
 
 
 @runtime_checkable

--- a/src/karenina/ports/capabilities.py
+++ b/src/karenina/ports/capabilities.py
@@ -21,3 +21,4 @@ class PortCapabilities:
 
     supports_system_prompt: bool = True
     supports_structured_output: bool = False
+    supports_streaming: bool = False

--- a/src/karenina/ports/llm.py
+++ b/src/karenina/ports/llm.py
@@ -5,6 +5,8 @@ agent loops. Use this for simple text generation and structured output tasks.
 For multi-turn agent execution with tools/MCP, use AgentPort instead.
 """
 
+from collections.abc import AsyncIterator
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
@@ -23,6 +25,7 @@ class LLMResponse:
         content: The text content of the response.
         usage: Token usage and cost metadata.
         raw: Provider-specific raw response object for advanced use cases.
+        is_partial: Whether the response was truncated (e.g., due to streaming timeout).
 
     Example:
         >>> response = LLMResponse(
@@ -37,6 +40,41 @@ class LLMResponse:
     content: str
     usage: UsageMetadata
     raw: Any = None
+    is_partial: bool = False
+
+
+class StreamingLLMResponse:
+    """Accumulating response from a streaming LLM invocation.
+
+    Async-iterable: yields str chunks. Accumulates content internally.
+    On timeout or error, ``accumulated_content`` has whatever arrived.
+
+    Example:
+        >>> async with llm.astream(messages) as sr:
+        ...     async for chunk in sr:
+        ...         print(chunk, end="")
+        ...     print(f"\\nTotal: {len(sr.accumulated_content)} chars")
+    """
+
+    def __init__(self) -> None:
+        self.accumulated_content: str = ""
+        self.usage: UsageMetadata = UsageMetadata()
+        self.is_complete: bool = False
+        self._chunks: AsyncIterator[str] | None = None
+
+    def _set_chunk_source(self, chunks: AsyncIterator[str]) -> None:
+        """Set the async iterator that produces text chunks."""
+        self._chunks = chunks
+
+    def __aiter__(self) -> "StreamingLLMResponse":
+        return self
+
+    async def __anext__(self) -> str:
+        if self._chunks is None:
+            raise StopAsyncIteration
+        chunk = await self._chunks.__anext__()
+        self.accumulated_content += chunk
+        return chunk
 
 
 @runtime_checkable
@@ -130,6 +168,42 @@ class LLMPort(Protocol):
             >>> structured_llm = llm.with_structured_output(Answer)
         """
         ...
+
+    def astream(self, messages: list[Message]) -> AbstractAsyncContextManager[StreamingLLMResponse]:
+        """Open a streaming LLM connection.
+
+        Yields a StreamingLLMResponse that produces text chunks and accumulates
+        content. Check capabilities.supports_streaming before calling.
+
+        Args:
+            messages: List of messages forming the conversation.
+
+        Returns:
+            Async context manager yielding StreamingLLMResponse.
+
+        Raises:
+            NotImplementedError: If the adapter does not support streaming.
+        """
+        raise NotImplementedError
+
+    def stream_invoke(self, messages: list[Message], timeout: float | None = None) -> LLMResponse:
+        """Invoke the LLM with streaming and optional wall-clock timeout.
+
+        Sync wrapper that streams tokens and captures partial output on timeout.
+        Check capabilities.supports_streaming before calling.
+
+        Args:
+            messages: List of messages forming the conversation.
+            timeout: Wall-clock timeout in seconds. If exceeded, returns partial
+                content with is_partial=True.
+
+        Returns:
+            LLMResponse with content (possibly partial) and usage metadata.
+
+        Raises:
+            NotImplementedError: If the adapter does not support streaming.
+        """
+        raise NotImplementedError
 
     async def aclose(self) -> None:
         """Close underlying resources.

--- a/src/karenina/ports/llm.py
+++ b/src/karenina/ports/llm.py
@@ -26,6 +26,9 @@ class LLMResponse:
         usage: Token usage and cost metadata.
         raw: Provider-specific raw response object for advanced use cases.
         is_partial: Whether the response was truncated (e.g., due to streaming timeout).
+        usage_unavailable: Whether usage metadata could not be captured (e.g., streaming
+            timeout interrupted the final chunk that carries token counts). When True,
+            usage fields are zero but do not reflect actual consumption.
 
     Example:
         >>> response = LLMResponse(
@@ -41,6 +44,7 @@ class LLMResponse:
     usage: UsageMetadata
     raw: Any = None
     is_partial: bool = False
+    usage_unavailable: bool = False
 
 
 class StreamingLLMResponse:

--- a/src/karenina/schemas/scenario/state.py
+++ b/src/karenina/schemas/scenario/state.py
@@ -56,7 +56,7 @@ class ScenarioExecutionResult:
     """
 
     scenario_id: str
-    status: Literal["completed", "limit_reached", "error"]
+    status: Literal["completed", "limit_reached", "error", "timeout"]
     path: list[str]
     turn_count: int
     history: list[TurnRecord]

--- a/src/karenina/schemas/verification/result_components.py
+++ b/src/karenina/schemas/verification/result_components.py
@@ -137,6 +137,9 @@ class VerificationResultTemplate(BaseModel):
     # Recursion limit metadata
     recursion_limit_reached: bool = False  # Whether agent hit recursion limit
 
+    # Streaming timeout metadata
+    response_timeout_partial: bool = False  # Whether response was truncated due to streaming timeout
+
     # Agentic parsing
     investigation_trace: str | None = Field(
         default=None,

--- a/src/karenina/schemas/verification/result_components.py
+++ b/src/karenina/schemas/verification/result_components.py
@@ -139,6 +139,7 @@ class VerificationResultTemplate(BaseModel):
 
     # Streaming timeout metadata
     response_timeout_partial: bool = False  # Whether response was truncated due to streaming timeout
+    usage_unavailable: bool = False  # Whether usage metadata could not be captured (e.g., streaming timeout)
 
     # Agentic parsing
     investigation_trace: str | None = Field(

--- a/tests/e2e/test_mcp_agent.py
+++ b/tests/e2e/test_mcp_agent.py
@@ -38,18 +38,24 @@ def test_mcp_agent_middleware_signature() -> None:
 
     from karenina.adapters.langchain.mcp import create_mcp_client_and_tools
     from karenina.adapters.langchain.middleware import build_agent_middleware
-    from karenina.exceptions import McpTimeoutError
+    from karenina.exceptions import McpClientError, McpTimeoutError
     from karenina.schemas.config import AgentMiddlewareConfig
 
     # Create fixture-backed LLM client
     llm = FixtureBackedLLMClient(FIXTURE_DIR)
 
     # Connect to Open Targets MCP server to get tools
-    # (tools come from MCP server, LLM responses come from fixtures)
+    # (tools come from MCP server, LLM responses come from fixtures).
+    # We treat any MCP client error as a skip condition: this test depends
+    # on a live external service and underlying anyio task groups wrap
+    # network errors (ConnectionError, DNS failures, TLS handshake issues)
+    # in BaseExceptionGroup, which surfaces as McpClientError after the
+    # adapter's "except Exception" catches it. Skipping keeps the suite
+    # green when the external MCP endpoint is unavailable or flaky in CI.
     mcp_urls = {"opentargets": "https://mcp.platform.opentargets.org/mcp"}
     try:
         _, tools = create_mcp_client_and_tools(mcp_urls, None, None)
-    except (TimeoutError, ConnectionError, OSError, McpTimeoutError) as e:
+    except (TimeoutError, ConnectionError, OSError, McpTimeoutError, McpClientError) as e:
         pytest.skip(f"MCP server unavailable: {e}")
 
     assert len(tools) > 0, "Should retrieve tools from MCP server"

--- a/tests/integration/verification/test_pipeline_robustness.py
+++ b/tests/integration/verification/test_pipeline_robustness.py
@@ -547,11 +547,14 @@ class TestArtifactDependencies:
 
         # Mock get_llm (no MCP URLs → LLMPort path, not AgentPort)
         with patch("karenina.benchmark.verification.stages.pipeline.generate_answer.get_llm") as mock_get_llm:
+            from karenina.ports.capabilities import PortCapabilities
+
             mock_llm = MagicMock()
             mock_llm.invoke.return_value = LLMResponse(
                 content="The capital is Paris.",
                 usage=UsageMetadata(input_tokens=10, output_tokens=10, total_tokens=20),
             )
+            mock_llm.capabilities = PortCapabilities(supports_streaming=False)
             mock_get_llm.return_value = mock_llm
 
             stage = GenerateAnswerStage()
@@ -613,11 +616,14 @@ class TestPipelineIntegration:
             patch("karenina.benchmark.verification.stages.pipeline.parse_template.TemplateEvaluator") as MockEvaluator,
         ):
             # Answer generation mock - return LLMResponse
+            from karenina.ports.capabilities import PortCapabilities
+
             mock_llm = MagicMock()
             mock_llm.invoke.return_value = LLMResponse(
                 content="The capital of France is Paris.",
                 usage=UsageMetadata(input_tokens=10, output_tokens=10, total_tokens=20),
             )
+            mock_llm.capabilities = PortCapabilities(supports_streaming=False)
             mock_get_llm.return_value = mock_llm
 
             # Template parsing mock - use proper return types
@@ -693,11 +699,14 @@ class TestPipelineIntegration:
             ) as mock_abstention,
         ):
             # Generate a refusal response - return LLMResponse (no MCP URLs → LLMPort path)
+            from karenina.ports.capabilities import PortCapabilities
+
             mock_llm = MagicMock()
             mock_llm.invoke.return_value = LLMResponse(
                 content="I'm sorry, but I cannot provide information about that topic.",
                 usage=UsageMetadata(input_tokens=10, output_tokens=10, total_tokens=20),
             )
+            mock_llm.capabilities = PortCapabilities(supports_streaming=False)
             mock_get_llm.return_value = mock_llm
 
             # Abstention detector returns (detected, check_performed, reasoning, usage_metadata)

--- a/tests/unit/adapters/claude_agent_sdk/test_streaming.py
+++ b/tests/unit/adapters/claude_agent_sdk/test_streaming.py
@@ -48,17 +48,14 @@ def _build_fake_sdk() -> types.ModuleType:
             self.total_cost_usd = total_cost_usd
             self.structured_output = structured_output
 
-    # Placeholder async generator; each test replaces via monkeypatch.setattr.
-    async def _placeholder_query(prompt: str, options: Any) -> Any:  # pragma: no cover
-        yield  # Makes this an async generator; each test replaces via monkeypatch
-
     mod = types.ModuleType("claude_agent_sdk")
     for _name, _obj in [
         ("ClaudeAgentOptions", ClaudeAgentOptions),
         ("TextBlock", TextBlock),
         ("AssistantMessage", AssistantMessage),
         ("ResultMessage", ResultMessage),
-        ("query", _placeholder_query),
+        # query is a sentinel; every test replaces it via monkeypatch before use.
+        ("query", None),
     ]:
         setattr(mod, _name, _obj)
     return mod

--- a/tests/unit/adapters/claude_agent_sdk/test_streaming.py
+++ b/tests/unit/adapters/claude_agent_sdk/test_streaming.py
@@ -50,8 +50,7 @@ def _build_fake_sdk() -> types.ModuleType:
 
     # Placeholder async generator; each test replaces via monkeypatch.setattr.
     async def _placeholder_query(prompt: str, options: Any) -> Any:  # pragma: no cover
-        return
-        yield  # makes this an async generator  # type: ignore[misc]
+        yield  # Makes this an async generator; each test replaces via monkeypatch
 
     mod = types.ModuleType("claude_agent_sdk")
     for _name, _obj in [

--- a/tests/unit/adapters/claude_agent_sdk/test_streaming.py
+++ b/tests/unit/adapters/claude_agent_sdk/test_streaming.py
@@ -6,6 +6,7 @@ Tests astream() and _astream_with_timeout() using mocked claude_agent_sdk.query(
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import sys
 import types
 from typing import Any
@@ -66,8 +67,16 @@ def _build_fake_sdk() -> types.ModuleType:
 
 
 # Install the stub so that `from claude_agent_sdk import ...` inside the adapter
-# resolves all names. Preserved and restored to avoid polluting other tests.
+# resolves all names. We eagerly try to import the real SDK first so the
+# original module (if installed) is preserved and restored after these tests
+# finish. Without this preflight, the stub would shadow the real package even
+# in environments where it is installed, causing other test files that depend
+# on the real SDK to fail or be incorrectly skipped.
 _SDK = _build_fake_sdk()
+
+with contextlib.suppress(ImportError):
+    import claude_agent_sdk as _real_sdk  # noqa: F401
+
 _ORIGINAL_SDK = sys.modules.get("claude_agent_sdk")
 sys.modules["claude_agent_sdk"] = _SDK
 

--- a/tests/unit/adapters/claude_agent_sdk/test_streaming.py
+++ b/tests/unit/adapters/claude_agent_sdk/test_streaming.py
@@ -1,0 +1,183 @@
+"""Tests for ClaudeSDKLLMAdapter streaming methods.
+
+Tests astream() and _astream_with_timeout() using mocked claude_agent_sdk.query().
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from karenina.ports import Message
+
+# ---------------------------------------------------------------------------
+# Stub out claude_agent_sdk before importing the adapter
+# ---------------------------------------------------------------------------
+
+
+def _build_fake_sdk() -> types.ModuleType:
+    """Build a minimal claude_agent_sdk stub with all needed symbols."""
+
+    class ClaudeAgentOptions:
+        def __init__(self, **kwargs: Any) -> None:
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    class TextBlock:
+        def __init__(self, text: str = "") -> None:
+            self.text = text
+
+    class AssistantMessage:
+        def __init__(self, content: list[Any] | None = None) -> None:
+            self.content = content or []
+
+    class ResultMessage:
+        def __init__(
+            self,
+            result: str = "",
+            usage: dict[str, int] | None = None,
+            total_cost_usd: float | None = None,
+            structured_output: dict[str, Any] | None = None,
+        ) -> None:
+            self.result = result
+            self.usage = usage or {}
+            self.total_cost_usd = total_cost_usd
+            self.structured_output = structured_output
+
+    # Placeholder async generator; each test replaces via monkeypatch.setattr.
+    async def _placeholder_query(prompt: str, options: Any) -> Any:  # pragma: no cover
+        return
+        yield  # makes this an async generator  # type: ignore[misc]
+
+    mod = types.ModuleType("claude_agent_sdk")
+    for _name, _obj in [
+        ("ClaudeAgentOptions", ClaudeAgentOptions),
+        ("TextBlock", TextBlock),
+        ("AssistantMessage", AssistantMessage),
+        ("ResultMessage", ResultMessage),
+        ("query", _placeholder_query),
+    ]:
+        setattr(mod, _name, _obj)
+    return mod
+
+
+# Install the stub once at module level so that `from claude_agent_sdk import ...`
+# inside the adapter resolves all names. Individual tests replace mod.query.
+_SDK = _build_fake_sdk()
+if "claude_agent_sdk" not in sys.modules:
+    sys.modules["claude_agent_sdk"] = _SDK
+
+
+from karenina.adapters.claude_agent_sdk.llm import ClaudeSDKLLMAdapter  # noqa: E402
+
+
+@pytest.fixture
+def model_config() -> Any:
+    """Create a ModelConfig for the claude_agent_sdk interface."""
+    from karenina.schemas.config import ModelConfig
+
+    return ModelConfig(
+        id="test-sdk-stream",
+        model_name="claude-sonnet-4-20250514",
+        model_provider="anthropic",
+        interface="claude_agent_sdk",
+    )
+
+
+@pytest.mark.unit
+class TestClaudeSDKStreaming:
+    """Tests for ClaudeSDKLLMAdapter streaming."""
+
+    @pytest.mark.asyncio
+    async def test_astream_yields_text_chunks(self, model_config: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """astream() yields text deltas and accumulates content."""
+
+        async def fake_query(prompt: str, options: Any) -> Any:
+            yield _SDK.AssistantMessage(content=[_SDK.TextBlock("Hello")])
+            yield _SDK.AssistantMessage(content=[_SDK.TextBlock("Hello, world!")])
+            yield _SDK.ResultMessage(
+                result="Hello, world!",
+                usage={"input_tokens": 50, "output_tokens": 30},
+            )
+
+        monkeypatch.setattr(_SDK, "query", fake_query)
+
+        adapter = ClaudeSDKLLMAdapter(model_config)
+
+        async with adapter.astream([Message.user("Hi")]) as sr:
+            collected: list[str] = []
+            async for chunk in sr:
+                collected.append(chunk)
+
+        # First message yields "Hello", second yields delta ", world!"
+        assert sr.accumulated_content == "Hello, world!"
+        assert len(collected) == 2
+
+    @pytest.mark.asyncio
+    async def test_astream_extracts_usage_from_result(self, model_config: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """astream() extracts usage from the ResultMessage."""
+
+        async def fake_query(prompt: str, options: Any) -> Any:
+            yield _SDK.AssistantMessage(content=[_SDK.TextBlock("OK")])
+            yield _SDK.ResultMessage(
+                result="OK",
+                usage={"input_tokens": 200, "output_tokens": 80},
+                total_cost_usd=0.005,
+            )
+
+        monkeypatch.setattr(_SDK, "query", fake_query)
+
+        adapter = ClaudeSDKLLMAdapter(model_config)
+
+        async with adapter.astream([Message.user("Hi")]) as sr:
+            async for _ in sr:
+                pass
+
+        assert sr.usage.input_tokens == 200
+        assert sr.usage.output_tokens == 80
+
+    @pytest.mark.asyncio
+    async def test_astream_with_timeout_completes(self, model_config: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """_astream_with_timeout() completes without partial flag on fast responses."""
+
+        async def fake_query(prompt: str, options: Any) -> Any:
+            yield _SDK.AssistantMessage(content=[_SDK.TextBlock("All done.")])
+            yield _SDK.ResultMessage(
+                result="All done.",
+                usage={"input_tokens": 10, "output_tokens": 5},
+            )
+
+        monkeypatch.setattr(_SDK, "query", fake_query)
+
+        adapter = ClaudeSDKLLMAdapter(model_config)
+        result = await adapter._astream_with_timeout([Message.user("Hi")], timeout=10.0)
+
+        assert result.content == "All done."
+        assert result.is_partial is False
+        assert result.usage_unavailable is False
+
+    @pytest.mark.asyncio
+    async def test_astream_with_timeout_captures_partial(
+        self, model_config: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_astream_with_timeout() sets is_partial and usage_unavailable on timeout."""
+
+        async def slow_query(prompt: str, options: Any) -> Any:
+            yield _SDK.AssistantMessage(content=[_SDK.TextBlock("First")])
+            await asyncio.sleep(5.0)
+            yield _SDK.AssistantMessage(content=[_SDK.TextBlock("First Second")])
+            await asyncio.sleep(5.0)
+            yield _SDK.ResultMessage(result="First Second Third")
+
+        monkeypatch.setattr(_SDK, "query", slow_query)
+
+        adapter = ClaudeSDKLLMAdapter(model_config)
+        result = await adapter._astream_with_timeout([Message.user("Hi")], timeout=0.05)
+
+        assert result.is_partial is True
+        assert result.usage_unavailable is True
+        assert "First" in result.content

--- a/tests/unit/adapters/claude_agent_sdk/test_streaming.py
+++ b/tests/unit/adapters/claude_agent_sdk/test_streaming.py
@@ -27,6 +27,10 @@ def _build_fake_sdk() -> types.ModuleType:
             for key, value in kwargs.items():
                 setattr(self, key, value)
 
+        def __getattr__(self, name: str) -> None:
+            # Return None for any attribute not explicitly set (matches real SDK defaults)
+            return None
+
     class TextBlock:
         def __init__(self, text: str = "") -> None:
             self.text = text
@@ -61,14 +65,25 @@ def _build_fake_sdk() -> types.ModuleType:
     return mod
 
 
-# Install the stub once at module level so that `from claude_agent_sdk import ...`
-# inside the adapter resolves all names. Individual tests replace mod.query.
+# Install the stub so that `from claude_agent_sdk import ...` inside the adapter
+# resolves all names. Preserved and restored to avoid polluting other tests.
 _SDK = _build_fake_sdk()
-if "claude_agent_sdk" not in sys.modules:
-    sys.modules["claude_agent_sdk"] = _SDK
+_ORIGINAL_SDK = sys.modules.get("claude_agent_sdk")
+sys.modules["claude_agent_sdk"] = _SDK
 
 
 from karenina.adapters.claude_agent_sdk.llm import ClaudeSDKLLMAdapter  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _restore_sdk_module():
+    """Ensure the real SDK module is restored after each test."""
+    sys.modules["claude_agent_sdk"] = _SDK
+    yield
+    if _ORIGINAL_SDK is not None:
+        sys.modules["claude_agent_sdk"] = _ORIGINAL_SDK
+    else:
+        sys.modules.pop("claude_agent_sdk", None)
 
 
 @pytest.fixture

--- a/tests/unit/adapters/claude_tool/test_agent_timeout.py
+++ b/tests/unit/adapters/claude_tool/test_agent_timeout.py
@@ -1,0 +1,307 @@
+"""Tests for Claude Tool agent timeout recovery.
+
+Verifies that the ClaudeToolAgentAdapter handles timeout scenarios correctly:
+partial AgentResult on timeout with accumulated messages, normal completion
+without timeout, and AgentTimeoutError when no messages were collected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karenina.adapters.claude_tool import ClaudeToolAgentAdapter
+from karenina.ports import (
+    AgentConfig,
+    AgentResult,
+    AgentTimeoutError,
+    Message,
+)
+
+
+class MockTextBlock:
+    """Mock Anthropic text content block."""
+
+    def __init__(self, text: str) -> None:
+        self.type = "text"
+        self.text = text
+
+
+class MockUsage:
+    """Mock Anthropic usage object."""
+
+    def __init__(self, input_tokens: int = 100, output_tokens: int = 50) -> None:
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+
+
+class MockResponse:
+    """Mock Anthropic API response yielded by tool_runner."""
+
+    def __init__(
+        self,
+        content: list[Any] | None = None,
+        usage: MockUsage | None = None,
+        role: str = "assistant",
+        model: str = "claude-haiku-4-5",
+    ) -> None:
+        self.content = content or [MockTextBlock("Hello!")]
+        self.usage = usage or MockUsage()
+        self.role = role
+        self.model = model
+
+
+class SlowAsyncIterator:
+    """Async iterator that yields some items then blocks, simulating a timeout.
+
+    Yields ``fast_items`` immediately, then sleeps for ``slow_delay`` seconds
+    before yielding ``slow_items``. When wrapped in ``asyncio.wait_for``
+    with a short timeout, the fast items are collected and the slow ones
+    trigger ``TimeoutError``.
+    """
+
+    def __init__(
+        self,
+        fast_items: list[Any],
+        slow_items: list[Any] | None = None,
+        slow_delay: float = 10.0,
+    ) -> None:
+        self.fast_items = fast_items
+        self.slow_items = slow_items or []
+        self.slow_delay = slow_delay
+        self._items = list(fast_items)
+        self._slow_items = list(slow_items or [])
+        self._index = 0
+        self._in_slow = False
+
+    def __aiter__(self) -> SlowAsyncIterator:
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._index < len(self._items):
+            item = self._items[self._index]
+            self._index += 1
+            return item
+
+        if not self._in_slow:
+            self._in_slow = True
+            self._slow_index = 0
+
+        if self._slow_index < len(self._slow_items):
+            await asyncio.sleep(self.slow_delay)
+            item = self._slow_items[self._slow_index]
+            self._slow_index += 1
+            return item
+
+        # No slow items: just block
+        await asyncio.sleep(self.slow_delay)
+        raise StopAsyncIteration
+
+
+class FastAsyncIterator:
+    """Async iterator that yields all items immediately."""
+
+    def __init__(self, items: list[Any]) -> None:
+        self.items = items
+        self.index = 0
+
+    def __aiter__(self) -> FastAsyncIterator:
+        return self
+
+    async def __anext__(self) -> Any:
+        if self.index >= len(self.items):
+            raise StopAsyncIteration
+        item = self.items[self.index]
+        self.index += 1
+        return item
+
+
+@pytest.fixture
+def model_config() -> Any:
+    """Create a ModelConfig for claude_tool interface."""
+    from karenina.schemas.config import ModelConfig
+
+    return ModelConfig(
+        id="test-claude-tool-timeout",
+        model_name="claude-haiku-4-5",
+        model_provider="anthropic",
+        interface="claude_tool",
+        max_tokens=1024,
+    )
+
+
+@pytest.mark.unit
+class TestClaudeToolAgentTimeoutWithMessages:
+    """Test timeout recovery when the agent has accumulated messages."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_partial_result(self, model_config: Any) -> None:
+        """Verify that a timeout with accumulated messages returns a partial AgentResult."""
+        adapter = ClaudeToolAgentAdapter(model_config)
+
+        fast_responses = [
+            MockResponse(content=[MockTextBlock("Turn 1 response")]),
+            MockResponse(content=[MockTextBlock("Turn 2 response")]),
+        ]
+        # After yielding 2 fast responses, the iterator blocks until timeout
+        mock_iterator = SlowAsyncIterator(fast_items=fast_responses)
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.tool_runner = MagicMock(return_value=mock_iterator)
+
+        sentinel_tool = MagicMock()
+        with patch.object(adapter, "_get_async_client", return_value=mock_client):
+            result = await adapter._execute_agent_loop(
+                messages=[Message.user("Hello")],
+                tools=[sentinel_tool],
+                config=AgentConfig(timeout=0.05),
+            )
+
+        assert isinstance(result, AgentResult)
+        assert result.timeout_reached is True
+        assert result.turns == 2
+        assert len(result.trace_messages) == 2
+        assert "Turn 1 response" in result.raw_trace
+        assert "Turn 2 response" in result.raw_trace
+        assert "[Note: Agent timed out" in result.raw_trace
+
+    @pytest.mark.asyncio
+    async def test_timeout_preserves_usage(self, model_config: Any) -> None:
+        """Verify that usage metadata is accumulated even on timeout."""
+        adapter = ClaudeToolAgentAdapter(model_config)
+
+        fast_responses = [
+            MockResponse(
+                content=[MockTextBlock("First")],
+                usage=MockUsage(input_tokens=100, output_tokens=50),
+            ),
+            MockResponse(
+                content=[MockTextBlock("Second")],
+                usage=MockUsage(input_tokens=80, output_tokens=40),
+            ),
+        ]
+        mock_iterator = SlowAsyncIterator(fast_items=fast_responses)
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.tool_runner = MagicMock(return_value=mock_iterator)
+
+        sentinel_tool = MagicMock()
+        with patch.object(adapter, "_get_async_client", return_value=mock_client):
+            result = await adapter._execute_agent_loop(
+                messages=[Message.user("Hello")],
+                tools=[sentinel_tool],
+                config=AgentConfig(timeout=0.05),
+            )
+
+        assert result.timeout_reached is True
+        assert result.usage.input_tokens > 0
+        assert result.usage.output_tokens > 0
+
+    @pytest.mark.asyncio
+    async def test_timeout_extracts_final_response(self, model_config: Any) -> None:
+        """Verify that the final response is extracted from accumulated messages on timeout."""
+        adapter = ClaudeToolAgentAdapter(model_config)
+
+        fast_responses = [
+            MockResponse(content=[MockTextBlock("Partial answer so far")]),
+        ]
+        mock_iterator = SlowAsyncIterator(fast_items=fast_responses)
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.tool_runner = MagicMock(return_value=mock_iterator)
+
+        sentinel_tool = MagicMock()
+        with patch.object(adapter, "_get_async_client", return_value=mock_client):
+            result = await adapter._execute_agent_loop(
+                messages=[Message.user("Hello")],
+                tools=[sentinel_tool],
+                config=AgentConfig(timeout=0.05),
+            )
+
+        assert result.timeout_reached is True
+        assert result.final_response == "Partial answer so far"
+
+
+@pytest.mark.unit
+class TestClaudeToolAgentNormalCompletion:
+    """Test normal completion (no timeout)."""
+
+    @pytest.mark.asyncio
+    async def test_normal_completion_not_timed_out(self, model_config: Any) -> None:
+        """Verify that normal completion sets timeout_reached=False."""
+        adapter = ClaudeToolAgentAdapter(model_config)
+
+        responses = [
+            MockResponse(content=[MockTextBlock("Step 1")]),
+            MockResponse(content=[MockTextBlock("Final answer")]),
+        ]
+        mock_iterator = FastAsyncIterator(responses)
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.tool_runner = MagicMock(return_value=mock_iterator)
+
+        sentinel_tool = MagicMock()
+        with patch.object(adapter, "_get_async_client", return_value=mock_client):
+            result = await adapter._execute_agent_loop(
+                messages=[Message.user("Hello")],
+                tools=[sentinel_tool],
+                config=AgentConfig(),
+            )
+
+        assert result.timeout_reached is False
+        assert result.turns == 2
+        assert result.limit_reached is False
+        assert result.final_response == "Final answer"
+
+    @pytest.mark.asyncio
+    async def test_normal_completion_with_timeout_config(self, model_config: Any) -> None:
+        """Verify normal completion with a timeout configured but not hit."""
+        adapter = ClaudeToolAgentAdapter(model_config)
+
+        responses = [MockResponse(content=[MockTextBlock("Done")])]
+        mock_iterator = FastAsyncIterator(responses)
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.tool_runner = MagicMock(return_value=mock_iterator)
+
+        sentinel_tool = MagicMock()
+        with patch.object(adapter, "_get_async_client", return_value=mock_client):
+            result = await adapter._execute_agent_loop(
+                messages=[Message.user("Hello")],
+                tools=[sentinel_tool],
+                config=AgentConfig(timeout=60.0),
+            )
+
+        assert result.timeout_reached is False
+        assert result.turns == 1
+        assert "[Note: Agent timed out" not in result.raw_trace
+
+
+@pytest.mark.unit
+class TestClaudeToolAgentTimeoutNoMessages:
+    """Test timeout when no messages have been accumulated."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_with_no_messages_raises(self, model_config: Any) -> None:
+        """Verify that timeout with zero accumulated messages raises AgentTimeoutError."""
+        adapter = ClaudeToolAgentAdapter(model_config)
+
+        # Iterator that immediately blocks (no fast items)
+        mock_iterator = SlowAsyncIterator(fast_items=[])
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.tool_runner = MagicMock(return_value=mock_iterator)
+
+        sentinel_tool = MagicMock()
+        with (
+            patch.object(adapter, "_get_async_client", return_value=mock_client),
+            pytest.raises(AgentTimeoutError, match="timed out.*with no messages"),
+        ):
+            await adapter._execute_agent_loop(
+                messages=[Message.user("Hello")],
+                tools=[sentinel_tool],
+                config=AgentConfig(timeout=0.05),
+            )

--- a/tests/unit/adapters/claude_tool/test_streaming.py
+++ b/tests/unit/adapters/claude_tool/test_streaming.py
@@ -1,0 +1,163 @@
+"""Tests for ClaudeToolLLMAdapter streaming methods.
+
+Tests astream() and _astream_with_timeout() using mocked Anthropic client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from karenina.adapters.claude_tool import ClaudeToolLLMAdapter
+from karenina.ports import Message
+
+
+class _MockUsage:
+    """Mock Anthropic usage object."""
+
+    def __init__(self, input_tokens: int = 100, output_tokens: int = 50) -> None:
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.cache_read_input_tokens = None
+        self.cache_creation_input_tokens = None
+
+
+class _MockFinalMessage:
+    """Mock final message returned by stream.get_final_message()."""
+
+    def __init__(self, usage: _MockUsage | None = None) -> None:
+        self.usage = usage or _MockUsage()
+
+
+@pytest.fixture
+def model_config() -> Any:
+    """Create a ModelConfig for claude_tool interface."""
+    from karenina.schemas.config import ModelConfig
+
+    return ModelConfig(
+        id="test-stream",
+        model_name="claude-haiku-4-5",
+        model_provider="anthropic",
+        interface="claude_tool",
+        max_tokens=1024,
+    )
+
+
+def _make_fast_stream(chunks: list[str], final_message: _MockFinalMessage | None = None) -> MagicMock:
+    """Build a mock Anthropic stream context manager that yields chunks quickly.
+
+    Args:
+        chunks: Text chunks to yield from text_stream.
+        final_message: Final message for usage extraction.
+    """
+    if final_message is None:
+        final_message = _MockFinalMessage()
+
+    async def _text_stream() -> Any:
+        for chunk in chunks:
+            yield chunk
+
+    stream = MagicMock()
+    stream.text_stream = _text_stream()
+    stream.get_final_message = AsyncMock(return_value=final_message)
+
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=stream)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+def _make_slow_stream(chunks: list[str], delay: float = 5.0) -> MagicMock:
+    """Build a mock Anthropic stream that sleeps between chunks.
+
+    Args:
+        chunks: Text chunks to yield.
+        delay: Seconds to sleep between each chunk.
+    """
+
+    async def _text_stream() -> Any:
+        for chunk in chunks:
+            yield chunk
+            await asyncio.sleep(delay)
+
+    stream = MagicMock()
+    stream.text_stream = _text_stream()
+    stream.get_final_message = AsyncMock(side_effect=Exception("stream interrupted"))
+
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=stream)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+@pytest.mark.unit
+class TestClaudeToolStreaming:
+    """Tests for ClaudeToolLLMAdapter streaming."""
+
+    @pytest.mark.asyncio
+    async def test_astream_yields_text_chunks(self, model_config: Any) -> None:
+        """astream() yields text chunks and accumulates content."""
+        adapter = ClaudeToolLLMAdapter(model_config)
+
+        mock_client = AsyncMock()
+        mock_client.messages.stream = MagicMock(return_value=_make_fast_stream(["Hello", ", ", "world!"]))
+
+        with patch.object(adapter, "_get_async_client", return_value=mock_client):
+            async with adapter.astream([Message.user("Hi")]) as sr:
+                collected: list[str] = []
+                async for chunk in sr:
+                    collected.append(chunk)
+
+        assert collected == ["Hello", ", ", "world!"]
+        assert sr.accumulated_content == "Hello, world!"
+
+    @pytest.mark.asyncio
+    async def test_astream_extracts_usage(self, model_config: Any) -> None:
+        """astream() extracts usage from the final message."""
+        adapter = ClaudeToolLLMAdapter(model_config)
+
+        final_msg = _MockFinalMessage(_MockUsage(input_tokens=200, output_tokens=80))
+        mock_client = AsyncMock()
+        mock_client.messages.stream = MagicMock(return_value=_make_fast_stream(["OK"], final_message=final_msg))
+
+        with patch.object(adapter, "_get_async_client", return_value=mock_client):
+            async with adapter.astream([Message.user("Hi")]) as sr:
+                async for _ in sr:
+                    pass
+
+        assert sr.usage.input_tokens == 200
+        assert sr.usage.output_tokens == 80
+
+    @pytest.mark.asyncio
+    async def test_astream_with_timeout_completes(self, model_config: Any) -> None:
+        """_astream_with_timeout() completes without partial flag on fast responses."""
+        adapter = ClaudeToolLLMAdapter(model_config)
+
+        mock_client = AsyncMock()
+        mock_client.messages.stream = MagicMock(return_value=_make_fast_stream(["All ", "done."]))
+
+        with patch.object(adapter, "_get_async_client", return_value=mock_client):
+            result = await adapter._astream_with_timeout([Message.user("Hi")], timeout=10.0)
+
+        assert result.content == "All done."
+        assert result.is_partial is False
+        assert result.usage_unavailable is False
+
+    @pytest.mark.asyncio
+    async def test_astream_with_timeout_captures_partial(self, model_config: Any) -> None:
+        """_astream_with_timeout() sets is_partial and usage_unavailable on timeout."""
+        adapter = ClaudeToolLLMAdapter(model_config)
+
+        mock_client = AsyncMock()
+        mock_client.messages.stream = MagicMock(return_value=_make_slow_stream(["First", "Second", "Third"], delay=5.0))
+
+        with patch.object(adapter, "_get_async_client", return_value=mock_client):
+            result = await adapter._astream_with_timeout([Message.user("Hi")], timeout=0.05)
+
+        assert result.is_partial is True
+        assert result.usage_unavailable is True
+        # Should have captured at least the first chunk
+        assert "First" in result.content

--- a/tests/unit/adapters/langchain/test_agent_timeout.py
+++ b/tests/unit/adapters/langchain/test_agent_timeout.py
@@ -1,0 +1,273 @@
+"""Tests for LangChain agent timeout recovery.
+
+Verifies that the LangChainAgentAdapter handles timeout scenarios correctly:
+partial AgentResult on timeout via extract_partial_agent_state, and normal
+completion without timeout. Covers both the callback and non-callback
+code paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from karenina.adapters.langchain import LangChainAgentAdapter
+from karenina.ports import AgentConfig, AgentResult, Message
+
+
+@pytest.fixture
+def model_config() -> Any:
+    """Create a ModelConfig for LangChain interface."""
+    from karenina.schemas.config import ModelConfig
+
+    return ModelConfig(
+        id="test-langchain-timeout",
+        model_name="claude-sonnet-4-20250514",
+        model_provider="anthropic",
+        interface="langchain",
+    )
+
+
+def _make_mcp_servers() -> dict[str, Any]:
+    """Return a minimal MCP servers dict for agent adapter tests."""
+    return {"test": {"type": "http", "url": "http://localhost:8080"}}
+
+
+def _make_ai_message(content: str, input_tokens: int = 50, output_tokens: int = 25) -> AIMessage:
+    """Create an AIMessage with response_metadata for usage extraction."""
+    msg = AIMessage(content=content)
+    msg.response_metadata = {"usage": {"input_tokens": input_tokens, "output_tokens": output_tokens}}
+    return msg
+
+
+def _standard_patches():
+    """Return a context manager that patches the LangChain infrastructure.
+
+    Patches model init, middleware, MCP tool loading, agent creation,
+    and trace utilities. Returns a dict of the mocks keyed by short name.
+    """
+
+    class _PatchContext:
+        """Holds mock objects for standard LangChain agent test patches."""
+
+        def __init__(self) -> None:
+            self.mocks: dict[str, Any] = {}
+            self._stack: list[Any] = []
+
+        def __enter__(self) -> _PatchContext:
+            patches = [
+                (
+                    "init_model",
+                    patch(
+                        "karenina.adapters.langchain.initialization.init_chat_model_unified",
+                        return_value=MagicMock(),
+                    ),
+                ),
+                (
+                    "middleware",
+                    patch(
+                        "karenina.adapters.langchain.middleware.build_agent_middleware",
+                        return_value=[],
+                    ),
+                ),
+                (
+                    "mcp_tools",
+                    patch(
+                        "karenina.adapters.langchain.mcp.acreate_persistent_mcp_tools",
+                        new_callable=AsyncMock,
+                        return_value=[MagicMock()],
+                    ),
+                ),
+                ("create_agent", patch("langchain.agents.create_agent")),
+                ("memory_saver", patch("langgraph.checkpoint.memory.InMemorySaver")),
+                (
+                    "harmonize",
+                    patch(
+                        "karenina.adapters.langchain.trace.harmonize_agent_response",
+                        return_value="--- AI Message ---\ntest",
+                    ),
+                ),
+                (
+                    "extract_final",
+                    patch(
+                        "karenina.adapters.langchain.trace.extract_final_ai_message_from_response",
+                        return_value=("Partial answer", None),
+                    ),
+                ),
+            ]
+            for name, p in patches:
+                mock = p.start()
+                self.mocks[name] = mock
+                self._stack.append(p)
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            for p in reversed(self._stack):
+                p.stop()
+
+    return _PatchContext()
+
+
+@pytest.mark.unit
+class TestLangChainAgentTimeoutWithCallback:
+    """Test timeout recovery in the callback code path.
+
+    When ``langchain_core.callbacks.get_usage_metadata_callback`` is available,
+    the adapter wraps ``agent.ainvoke`` in a ``with get_usage_metadata_callback()``
+    block. These tests verify the timeout handling inside that branch.
+    """
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_partial_result(self, model_config: Any) -> None:
+        """Verify that a TimeoutError yields a partial AgentResult with timeout_reached=True."""
+        with _standard_patches() as ctx:
+            # Configure mock agent to raise TimeoutError
+            mock_agent = AsyncMock()
+
+            async def slow_invoke(*args: Any, **kwargs: Any) -> None:
+                await asyncio.sleep(10)
+
+            mock_agent.ainvoke = slow_invoke
+            # extract_partial_agent_state needs checkpointer attribute
+            mock_agent.checkpointer = None
+            ctx.mocks["create_agent"].return_value = mock_agent
+
+            adapter = LangChainAgentAdapter(model_config)
+            result = await adapter.arun(
+                [Message.user("Test question")],
+                mcp_servers=_make_mcp_servers(),
+                config=AgentConfig(timeout=0.05),
+            )
+
+            assert isinstance(result, AgentResult)
+            assert result.timeout_reached is True
+            assert "[Note: Agent timed out" in result.raw_trace
+
+    @pytest.mark.asyncio
+    async def test_timeout_calls_extract_partial_state(self, model_config: Any) -> None:
+        """Verify extract_partial_agent_state is called on timeout."""
+        with _standard_patches() as ctx:
+            mock_agent = AsyncMock()
+
+            async def slow_invoke(*args: Any, **kwargs: Any) -> None:
+                await asyncio.sleep(10)
+
+            mock_agent.ainvoke = slow_invoke
+            mock_agent.checkpointer = None
+            ctx.mocks["create_agent"].return_value = mock_agent
+
+            with patch(
+                "karenina.adapters.langchain.agent.extract_partial_agent_state",
+                return_value={"messages": [HumanMessage(content="Test")]},
+            ) as mock_extract:
+                adapter = LangChainAgentAdapter(model_config)
+                result = await adapter.arun(
+                    [Message.user("Test question")],
+                    mcp_servers=_make_mcp_servers(),
+                    config=AgentConfig(timeout=0.05),
+                )
+
+                mock_extract.assert_called_once()
+                assert result.timeout_reached is True
+
+
+@pytest.mark.unit
+class TestLangChainAgentTimeoutWithoutCallback:
+    """Test timeout recovery when the usage metadata callback is not available.
+
+    This exercises the else branch where ``agent.ainvoke`` is called without
+    the ``get_usage_metadata_callback`` context manager.
+    """
+
+    @pytest.mark.asyncio
+    async def test_timeout_without_callback_returns_partial(self, model_config: Any) -> None:
+        """Verify timeout handling in the non-callback branch."""
+        with _standard_patches() as ctx:
+            mock_agent = AsyncMock()
+
+            async def slow_invoke(*args: Any, **kwargs: Any) -> None:
+                await asyncio.sleep(10)
+
+            mock_agent.ainvoke = slow_invoke
+            mock_agent.checkpointer = None
+            ctx.mocks["create_agent"].return_value = mock_agent
+
+            # Force the non-callback path by making the import fail
+            with patch(
+                "karenina.adapters.langchain.agent.asyncio.wait_for",
+                side_effect=TimeoutError("timed out"),
+            ):
+                adapter = LangChainAgentAdapter(model_config)
+                result = await adapter.arun(
+                    [Message.user("Test question")],
+                    mcp_servers=_make_mcp_servers(),
+                    config=AgentConfig(timeout=0.05),
+                )
+
+                assert result.timeout_reached is True
+
+
+@pytest.mark.unit
+class TestLangChainAgentNormalCompletion:
+    """Test normal agent completion (no timeout)."""
+
+    @pytest.mark.asyncio
+    async def test_normal_completion_not_timed_out(self, model_config: Any) -> None:
+        """Verify normal completion sets timeout_reached=False."""
+        with _standard_patches() as ctx:
+            ai_msg = _make_ai_message("Final answer")
+            mock_response = {
+                "messages": [
+                    HumanMessage(content="Test question"),
+                    ai_msg,
+                ]
+            }
+
+            mock_agent = AsyncMock()
+            mock_agent.ainvoke = AsyncMock(return_value=mock_response)
+            ctx.mocks["create_agent"].return_value = mock_agent
+
+            ctx.mocks["extract_final"].return_value = ("Final answer", None)
+
+            adapter = LangChainAgentAdapter(model_config)
+            result = await adapter.arun(
+                [Message.user("Test question")],
+                mcp_servers=_make_mcp_servers(),
+            )
+
+            assert isinstance(result, AgentResult)
+            assert result.timeout_reached is False
+            assert result.limit_reached is False
+            assert result.final_response == "Final answer"
+
+    @pytest.mark.asyncio
+    async def test_normal_completion_with_timeout_config(self, model_config: Any) -> None:
+        """Verify normal completion with a large timeout configured but not hit."""
+        with _standard_patches() as ctx:
+            ai_msg = _make_ai_message("Done")
+            mock_response = {
+                "messages": [
+                    HumanMessage(content="Question"),
+                    ai_msg,
+                ]
+            }
+
+            mock_agent = AsyncMock()
+            mock_agent.ainvoke = AsyncMock(return_value=mock_response)
+            ctx.mocks["create_agent"].return_value = mock_agent
+
+            ctx.mocks["extract_final"].return_value = ("Done", None)
+
+            adapter = LangChainAgentAdapter(model_config)
+            result = await adapter.arun(
+                [Message.user("Question")],
+                mcp_servers=_make_mcp_servers(),
+                config=AgentConfig(timeout=60.0),
+            )
+
+            assert result.timeout_reached is False
+            assert "[Note: Agent timed out" not in result.raw_trace

--- a/tests/unit/adapters/langchain/test_agent_timeout.py
+++ b/tests/unit/adapters/langchain/test_agent_timeout.py
@@ -9,6 +9,7 @@ code paths.
 from __future__ import annotations
 
 import asyncio
+import sys
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -185,7 +186,15 @@ class TestLangChainAgentTimeoutWithoutCallback:
 
     @pytest.mark.asyncio
     async def test_timeout_without_callback_returns_partial(self, model_config: Any) -> None:
-        """Verify timeout handling in the non-callback branch."""
+        """Verify timeout handling in the non-callback branch.
+
+        Forces the non-callback branch by making the local import of
+        ``langchain_core.callbacks`` fail. The slow ``ainvoke`` is then
+        actually awaited by the real ``asyncio.wait_for``, which raises
+        ``TimeoutError`` after the configured timeout. This properly
+        exercises the timeout-recovery path without leaking an unawaited
+        coroutine.
+        """
         with _standard_patches() as ctx:
             mock_agent = AsyncMock()
 
@@ -196,11 +205,12 @@ class TestLangChainAgentTimeoutWithoutCallback:
             mock_agent.checkpointer = None
             ctx.mocks["create_agent"].return_value = mock_agent
 
-            # Force the non-callback path by making the import fail
-            with patch(
-                "karenina.adapters.langchain.agent.asyncio.wait_for",
-                side_effect=TimeoutError("timed out"),
-            ):
+            # Force the non-callback path by making the local import fail.
+            # Setting the module to None in sys.modules causes the
+            # ``from langchain_core.callbacks import ...`` statement inside
+            # ``arun`` to raise ImportError, which the adapter catches and
+            # falls through to the non-callback branch.
+            with patch.dict(sys.modules, {"langchain_core.callbacks": None}):
                 adapter = LangChainAgentAdapter(model_config)
                 result = await adapter.arun(
                     [Message.user("Test question")],

--- a/tests/unit/adapters/langchain/test_streaming.py
+++ b/tests/unit/adapters/langchain/test_streaming.py
@@ -1,0 +1,155 @@
+"""Tests for LangChainLLMAdapter streaming methods.
+
+Tests astream() and _astream_with_timeout() using mocked LangChain model.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karenina.adapters.langchain import LangChainLLMAdapter
+from karenina.ports import Message
+
+
+class _FakeChunk:
+    """Minimal mock of a LangChain AIMessageChunk."""
+
+    def __init__(self, content: str = "", usage_metadata: dict[str, Any] | None = None) -> None:
+        self.content = content
+        self.usage_metadata = usage_metadata
+
+
+@pytest.fixture
+def model_config() -> Any:
+    """Create a ModelConfig for the langchain interface."""
+    from karenina.schemas.config import ModelConfig
+
+    return ModelConfig(
+        id="test-lc-stream",
+        model_name="claude-sonnet-4-20250514",
+        model_provider="anthropic",
+        interface="langchain",
+    )
+
+
+def _build_adapter(model_config: Any, chunks: list[_FakeChunk]) -> LangChainLLMAdapter:
+    """Build a LangChainLLMAdapter with a mocked model that yields chunks.
+
+    Args:
+        model_config: ModelConfig fixture.
+        chunks: Fake AIMessageChunk objects to yield from astream.
+    """
+
+    async def _fake_astream(messages: Any) -> Any:
+        for chunk in chunks:
+            yield chunk
+
+    mock_model = MagicMock()
+    mock_model.astream = _fake_astream
+
+    with patch("karenina.adapters.langchain.initialization.init_chat_model_unified") as mock_init:
+        mock_init.return_value = mock_model
+        adapter = LangChainLLMAdapter(model_config)
+
+    return adapter
+
+
+def _build_slow_adapter(model_config: Any, chunks: list[_FakeChunk], delay: float = 5.0) -> LangChainLLMAdapter:
+    """Build a LangChainLLMAdapter whose astream sleeps between chunks.
+
+    Args:
+        model_config: ModelConfig fixture.
+        chunks: Fake AIMessageChunk objects to yield.
+        delay: Seconds to sleep between chunks.
+    """
+
+    async def _fake_astream(messages: Any) -> Any:
+        for chunk in chunks:
+            yield chunk
+            await asyncio.sleep(delay)
+
+    mock_model = MagicMock()
+    mock_model.astream = _fake_astream
+
+    with patch("karenina.adapters.langchain.initialization.init_chat_model_unified") as mock_init:
+        mock_init.return_value = mock_model
+        adapter = LangChainLLMAdapter(model_config)
+
+    return adapter
+
+
+@pytest.mark.unit
+class TestLangChainStreaming:
+    """Tests for LangChainLLMAdapter streaming."""
+
+    @pytest.mark.asyncio
+    async def test_astream_yields_text_chunks(self, model_config: Any) -> None:
+        """astream() yields text chunks and accumulates content."""
+        chunks = [
+            _FakeChunk(content="Hello"),
+            _FakeChunk(content=", "),
+            _FakeChunk(content="world!"),
+        ]
+        adapter = _build_adapter(model_config, chunks)
+
+        async with adapter.astream([Message.user("Hi")]) as sr:
+            collected: list[str] = []
+            async for chunk in sr:
+                collected.append(chunk)
+
+        assert collected == ["Hello", ", ", "world!"]
+        assert sr.accumulated_content == "Hello, world!"
+
+    @pytest.mark.asyncio
+    async def test_astream_extracts_usage_from_final_chunk(self, model_config: Any) -> None:
+        """astream() extracts usage from chunk with usage_metadata."""
+        chunks = [
+            _FakeChunk(content="Response"),
+            _FakeChunk(
+                content="",
+                usage_metadata={"input_tokens": 120, "output_tokens": 60},
+            ),
+        ]
+        adapter = _build_adapter(model_config, chunks)
+
+        async with adapter.astream([Message.user("Hi")]) as sr:
+            async for _ in sr:
+                pass
+
+        assert sr.usage.input_tokens == 120
+        assert sr.usage.output_tokens == 60
+
+    @pytest.mark.asyncio
+    async def test_astream_with_timeout_completes(self, model_config: Any) -> None:
+        """_astream_with_timeout() completes without partial flag on fast responses."""
+        chunks = [
+            _FakeChunk(content="All "),
+            _FakeChunk(content="done."),
+        ]
+        adapter = _build_adapter(model_config, chunks)
+
+        result = await adapter._astream_with_timeout([Message.user("Hi")], timeout=10.0)
+
+        assert result.content == "All done."
+        assert result.is_partial is False
+        assert result.usage_unavailable is False
+
+    @pytest.mark.asyncio
+    async def test_astream_with_timeout_captures_partial(self, model_config: Any) -> None:
+        """_astream_with_timeout() sets is_partial and usage_unavailable on timeout."""
+        chunks = [
+            _FakeChunk(content="First"),
+            _FakeChunk(content="Second"),
+            _FakeChunk(content="Third"),
+        ]
+        adapter = _build_slow_adapter(model_config, chunks, delay=5.0)
+
+        result = await adapter._astream_with_timeout([Message.user("Hi")], timeout=0.05)
+
+        assert result.is_partial is True
+        assert result.usage_unavailable is True
+        assert "First" in result.content

--- a/tests/unit/adapters/langchain/test_usage_streaming.py
+++ b/tests/unit/adapters/langchain/test_usage_streaming.py
@@ -1,0 +1,90 @@
+"""Tests for extract_usage_from_chunk from the LangChain usage module.
+
+Tests the streaming-specific usage extraction path that processes
+AIMessageChunk objects during LangChain streaming.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from karenina.adapters.langchain.usage import extract_usage_from_chunk
+
+
+@pytest.mark.unit
+class TestExtractUsageFromChunk:
+    """Tests for extract_usage_from_chunk()."""
+
+    def test_extracts_usage_from_dict_metadata(self) -> None:
+        """Chunk with usage_metadata dict yields correct token counts."""
+        chunk = MagicMock()
+        chunk.usage_metadata = {
+            "input_tokens": 150,
+            "output_tokens": 75,
+        }
+
+        result = extract_usage_from_chunk(chunk, model_name="claude-sonnet-4-20250514")
+
+        assert result.input_tokens == 150
+        assert result.output_tokens == 75
+        assert result.total_tokens == 225
+        assert result.model == "claude-sonnet-4-20250514"
+
+    def test_extracts_cache_tokens(self) -> None:
+        """Chunk with cache token fields populates cache metadata."""
+        chunk = MagicMock()
+        chunk.usage_metadata = {
+            "input_tokens": 200,
+            "output_tokens": 100,
+            "cache_read_input_tokens": 80,
+            "cache_creation_input_tokens": 20,
+        }
+
+        result = extract_usage_from_chunk(chunk)
+
+        assert result.cache_read_tokens == 80
+        assert result.cache_creation_tokens == 20
+
+    def test_returns_zero_usage_when_no_metadata(self) -> None:
+        """Chunk without usage_metadata returns zero token counts."""
+        chunk = MagicMock(spec=["content"])
+        # spec=["content"] means usage_metadata attribute does not exist
+
+        result = extract_usage_from_chunk(chunk, model_name="test-model")
+
+        assert result.input_tokens == 0
+        assert result.output_tokens == 0
+        assert result.total_tokens == 0
+        assert result.model == "test-model"
+
+    def test_returns_zero_usage_when_metadata_is_none(self) -> None:
+        """Chunk with None usage_metadata returns zero token counts."""
+        chunk = MagicMock()
+        chunk.usage_metadata = None
+
+        result = extract_usage_from_chunk(chunk)
+
+        assert result.input_tokens == 0
+        assert result.output_tokens == 0
+        assert result.total_tokens == 0
+
+    def test_handles_object_style_usage_metadata(self) -> None:
+        """Chunk with attribute-based usage_metadata (non-dict) extracts correctly."""
+        # LangChain sometimes returns an object instead of a dict
+        usage_obj = MagicMock()
+        usage_obj.input_tokens = 300
+        usage_obj.output_tokens = 150
+        usage_obj.cache_read_input_tokens = None
+        usage_obj.cache_creation_input_tokens = None
+
+        # Make it fail isinstance(um, dict) check
+        chunk = MagicMock()
+        chunk.usage_metadata = usage_obj
+
+        result = extract_usage_from_chunk(chunk, model_name="gpt-4o")
+
+        assert result.input_tokens == 300
+        assert result.output_tokens == 150
+        assert result.model == "gpt-4o"

--- a/tests/unit/adapters/langchain_deep_agents/test_streaming.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_streaming.py
@@ -1,0 +1,149 @@
+"""Tests for DeepAgentsLLMAdapter streaming methods.
+
+Tests astream() and _astream_with_timeout() using mocked LangChain chat model.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from karenina.adapters.langchain_deep_agents.llm import DeepAgentsLLMAdapter
+from karenina.ports import Message
+
+
+class _FakeChunk:
+    """Minimal mock of a LangChain AIMessageChunk."""
+
+    def __init__(self, content: str = "", usage_metadata: dict[str, Any] | None = None) -> None:
+        self.content = content
+        self.usage_metadata = usage_metadata
+
+
+@pytest.mark.unit
+class TestDeepAgentsStreaming:
+    """Tests for DeepAgentsLLMAdapter streaming."""
+
+    @pytest.mark.asyncio
+    async def test_astream_yields_text_chunks(self, deep_agents_model_config: Any, monkeypatch: Any) -> None:
+        """astream() yields text chunks and accumulates content."""
+        chunks = [
+            _FakeChunk(content="Hello"),
+            _FakeChunk(content=", "),
+            _FakeChunk(content="world!"),
+        ]
+
+        async def _fake_astream(messages: Any) -> Any:
+            for chunk in chunks:
+                yield chunk
+
+        mock_model = MagicMock()
+        mock_model.astream = _fake_astream
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.llm.create_chat_model",
+            lambda _config, **_kw: mock_model,
+        )
+
+        adapter = DeepAgentsLLMAdapter(deep_agents_model_config)
+
+        async with adapter.astream([Message.user("Hi")]) as sr:
+            collected: list[str] = []
+            async for chunk in sr:
+                collected.append(chunk)
+
+        assert collected == ["Hello", ", ", "world!"]
+        assert sr.accumulated_content == "Hello, world!"
+
+    @pytest.mark.asyncio
+    async def test_astream_extracts_usage_from_final_chunk(
+        self, deep_agents_model_config: Any, monkeypatch: Any
+    ) -> None:
+        """astream() extracts usage from chunk with usage_metadata."""
+        chunks = [
+            _FakeChunk(content="Response"),
+            _FakeChunk(
+                content="",
+                usage_metadata={"input_tokens": 120, "output_tokens": 60},
+            ),
+        ]
+
+        async def _fake_astream(messages: Any) -> Any:
+            for chunk in chunks:
+                yield chunk
+
+        mock_model = MagicMock()
+        mock_model.astream = _fake_astream
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.llm.create_chat_model",
+            lambda _config, **_kw: mock_model,
+        )
+
+        adapter = DeepAgentsLLMAdapter(deep_agents_model_config)
+
+        async with adapter.astream([Message.user("Hi")]) as sr:
+            async for _ in sr:
+                pass
+
+        assert sr.usage.input_tokens == 120
+        assert sr.usage.output_tokens == 60
+
+    @pytest.mark.asyncio
+    async def test_astream_with_timeout_completes(self, deep_agents_model_config: Any, monkeypatch: Any) -> None:
+        """_astream_with_timeout() completes without partial flag on fast responses."""
+        chunks = [
+            _FakeChunk(content="All "),
+            _FakeChunk(content="done."),
+        ]
+
+        async def _fake_astream(messages: Any) -> Any:
+            for chunk in chunks:
+                yield chunk
+
+        mock_model = MagicMock()
+        mock_model.astream = _fake_astream
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.llm.create_chat_model",
+            lambda _config, **_kw: mock_model,
+        )
+
+        adapter = DeepAgentsLLMAdapter(deep_agents_model_config)
+        result = await adapter._astream_with_timeout([Message.user("Hi")], timeout=10.0)
+
+        assert result.content == "All done."
+        assert result.is_partial is False
+        assert result.usage_unavailable is False
+
+    @pytest.mark.asyncio
+    async def test_astream_with_timeout_captures_partial(self, deep_agents_model_config: Any, monkeypatch: Any) -> None:
+        """_astream_with_timeout() sets is_partial and usage_unavailable on timeout."""
+        chunks = [
+            _FakeChunk(content="First"),
+            _FakeChunk(content="Second"),
+            _FakeChunk(content="Third"),
+        ]
+
+        async def _slow_astream(messages: Any) -> Any:
+            for chunk in chunks:
+                yield chunk
+                await asyncio.sleep(5.0)
+
+        mock_model = MagicMock()
+        mock_model.astream = _slow_astream
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.llm.create_chat_model",
+            lambda _config, **_kw: mock_model,
+        )
+
+        adapter = DeepAgentsLLMAdapter(deep_agents_model_config)
+        result = await adapter._astream_with_timeout([Message.user("Hi")], timeout=0.05)
+
+        assert result.is_partial is True
+        assert result.usage_unavailable is True
+        assert "First" in result.content

--- a/tests/unit/adapters/test_trace_message_collection.py
+++ b/tests/unit/adapters/test_trace_message_collection.py
@@ -381,17 +381,17 @@ class TestLangchainTraceCollection:
 # ======================================================================
 
 
-try:
-    import claude_agent_sdk  # noqa: F401
-
-    _has_claude_sdk = True
-except ImportError:
-    _has_claude_sdk = False
-
-
-@pytest.mark.skipif(not _has_claude_sdk, reason="claude_agent_sdk not installed")
 class TestClaudeSDKTraceCollection:
-    """Tests for trace message collection via the claude_agent_sdk adapter."""
+    """Tests for trace message collection via the claude_agent_sdk adapter.
+
+    The claude_agent_sdk package is not a declared dependency of karenina;
+    it must be installed separately. Each test uses ``pytest.importorskip``
+    on ``claude_agent_sdk.types`` to skip when the real package is not
+    available. We probe the ``.types`` submodule because another test
+    module installs a stub for ``claude_agent_sdk`` in ``sys.modules`` and
+    that stub does not provide ``.types``; checking for the submodule
+    reliably distinguishes the real package from the stub.
+    """
 
     def _to_trace(self, messages) -> list[dict]:
         from karenina.adapters.claude_agent_sdk.trace import sdk_messages_to_trace_messages
@@ -399,6 +399,7 @@ class TestClaudeSDKTraceCollection:
         return sdk_messages_to_trace_messages(messages)
 
     def test_simple_response_no_tools(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
         from claude_agent_sdk import AssistantMessage
         from claude_agent_sdk.types import TextBlock
 
@@ -410,6 +411,7 @@ class TestClaudeSDKTraceCollection:
         assert trace[0]["content"] == "The answer is 42."
 
     def test_single_tool_call_round_trip(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
         from claude_agent_sdk import AssistantMessage
         from claude_agent_sdk.types import TextBlock, ToolResultBlock, ToolUseBlock
 
@@ -433,6 +435,7 @@ class TestClaudeSDKTraceCollection:
         assert trace[0]["tool_result"]["tool_use_id"] == "tc_001"
 
     def test_multi_turn_with_tools(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
         from claude_agent_sdk import AssistantMessage
         from claude_agent_sdk.types import TextBlock, ToolResultBlock, ToolUseBlock
 

--- a/tests/unit/benchmark/verification/stages/test_generate_answer_prompt_config.py
+++ b/tests/unit/benchmark/verification/stages/test_generate_answer_prompt_config.py
@@ -39,11 +39,14 @@ def _capture_adapter_messages(context: VerificationContext) -> list[Message]:
     stage = GenerateAnswerStage()
     captured: list[Message] = []
 
+    from karenina.ports.capabilities import PortCapabilities
+
     mock_llm = MagicMock()
     mock_response = MagicMock()
     mock_response.content = "4"
     mock_response.usage = None
     mock_llm.invoke.side_effect = lambda msgs: (captured.extend(msgs), mock_response)[1]
+    mock_llm.capabilities = PortCapabilities(supports_streaming=False)
 
     with patch("karenina.benchmark.verification.stages.pipeline.generate_answer.get_llm", return_value=mock_llm):
         stage.execute(context)

--- a/tests/unit/benchmark/verification/stages/test_generate_answer_streaming.py
+++ b/tests/unit/benchmark/verification/stages/test_generate_answer_streaming.py
@@ -1,0 +1,309 @@
+"""Tests for streaming path and agent timeout handling in GenerateAnswerStage."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import ArtifactKeys, VerificationContext
+from karenina.benchmark.verification.stages.pipeline.generate_answer import GenerateAnswerStage
+from karenina.ports.capabilities import PortCapabilities
+from karenina.ports.llm import LLMResponse
+from karenina.ports.usage import UsageMetadata
+from karenina.schemas.config import ModelConfig
+
+# The generate_answer stage imports AdapterRegistry inline (lazy import inside execute()),
+# so we must patch it at its source module rather than at the stage module.
+_REGISTRY_PATCH_TARGET = "karenina.adapters.registry.AdapterRegistry.get_spec"
+
+
+def _make_context() -> VerificationContext:
+    """Create a minimal VerificationContext for streaming/timeout tests."""
+    model = ModelConfig(
+        id="test",
+        model_name="test-model",
+        model_provider="openai",
+        system_prompt="You are helpful.",
+        request_timeout=30.0,
+    )
+    return VerificationContext(
+        question_id="q1",
+        template_id="t1",
+        question_text="What is 2+2?",
+        template_code="class Answer(BaseAnswer): value: str",
+        answering_model=model,
+        parsing_model=model,
+    )
+
+
+def _make_mock_llm(*, supports_streaming: bool = True) -> MagicMock:
+    """Create a mock LLMPort with configurable streaming support."""
+    mock = MagicMock()
+    mock.capabilities = PortCapabilities(supports_streaming=supports_streaming)
+    return mock
+
+
+def _make_agent_result(
+    *,
+    timeout_reached: bool = False,
+    raw_trace: str = "--- AI Message ---\nSome response",
+    turns: int = 1,
+    limit_reached: bool = False,
+) -> MagicMock:
+    """Create a mock AgentResult with configurable timeout behavior."""
+    result = MagicMock()
+    result.timeout_reached = timeout_reached
+    result.raw_trace = raw_trace
+    result.limit_reached = limit_reached
+    result.turns = turns
+    result.usage = None
+    result.trace_messages = None
+    return result
+
+
+@pytest.mark.unit
+class TestStreamingLLMPath:
+    """Tests for the LLMPort streaming invocation path in generate_answer."""
+
+    def test_streaming_partial_response_sets_timeout_and_usage_artifacts(self) -> None:
+        """When stream_invoke returns a partial response, RESPONSE_TIMEOUT_PARTIAL
+        and USAGE_UNAVAILABLE artifacts should be set."""
+        ctx = _make_context()
+        stage = GenerateAnswerStage()
+        mock_llm = _make_mock_llm(supports_streaming=True)
+
+        partial_response = LLMResponse(
+            content="partial content here",
+            usage=UsageMetadata(),
+            is_partial=True,
+            usage_unavailable=True,
+        )
+        mock_llm.stream_invoke.return_value = partial_response
+
+        with (
+            patch(
+                "karenina.benchmark.verification.stages.pipeline.generate_answer.get_llm",
+                return_value=mock_llm,
+            ),
+            patch(_REGISTRY_PATCH_TARGET, return_value=None),
+        ):
+            stage.execute(ctx)
+
+        # stream_invoke should have been called (not invoke)
+        mock_llm.stream_invoke.assert_called_once()
+        mock_llm.invoke.assert_not_called()
+
+        # Partial response artifacts
+        assert ctx.get_artifact(ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL) is True
+        assert ctx.get_result_field("response_timeout_partial") is True
+
+        # Usage unavailable flag
+        assert ctx.get_artifact(ArtifactKeys.USAGE_UNAVAILABLE) is True
+        assert ctx.get_result_field(ArtifactKeys.USAGE_UNAVAILABLE) is True
+
+        # Raw response should still be captured
+        assert "partial content here" in ctx.get_artifact(ArtifactKeys.RAW_LLM_RESPONSE)
+
+    def test_streaming_no_content_raises_timeout_error(self) -> None:
+        """When stream_invoke returns partial with empty content, a TimeoutError
+        should propagate and mark_error on the context."""
+        ctx = _make_context()
+        stage = GenerateAnswerStage()
+        mock_llm = _make_mock_llm(supports_streaming=True)
+
+        empty_partial = LLMResponse(
+            content="",
+            usage=UsageMetadata(),
+            is_partial=True,
+            usage_unavailable=True,
+        )
+        mock_llm.stream_invoke.return_value = empty_partial
+
+        with (
+            patch(
+                "karenina.benchmark.verification.stages.pipeline.generate_answer.get_llm",
+                return_value=mock_llm,
+            ),
+            patch(_REGISTRY_PATCH_TARGET, return_value=None),
+        ):
+            stage.execute(ctx)
+
+        # The TimeoutError is caught by the outer except block and marks error
+        assert ctx.error is not None
+        assert "timed out" in ctx.error.lower() or "TimeoutError" in ctx.error
+        assert ctx.completed_without_errors is False
+
+    def test_non_streaming_fallback_uses_invoke(self) -> None:
+        """When LLM does not support streaming, invoke() should be called
+        instead of stream_invoke()."""
+        ctx = _make_context()
+        stage = GenerateAnswerStage()
+        mock_llm = _make_mock_llm(supports_streaming=False)
+
+        normal_response = LLMResponse(
+            content="The answer is 4",
+            usage=UsageMetadata(input_tokens=10, output_tokens=5, total_tokens=15),
+        )
+        mock_llm.invoke.return_value = normal_response
+
+        with (
+            patch(
+                "karenina.benchmark.verification.stages.pipeline.generate_answer.get_llm",
+                return_value=mock_llm,
+            ),
+            patch(_REGISTRY_PATCH_TARGET, return_value=None),
+        ):
+            stage.execute(ctx)
+
+        # invoke() called, not stream_invoke()
+        mock_llm.invoke.assert_called_once()
+        mock_llm.stream_invoke.assert_not_called()
+
+        # Response should be stored normally
+        assert "The answer is 4" in ctx.get_artifact(ArtifactKeys.RAW_LLM_RESPONSE)
+        assert ctx.error is None
+
+    def test_streaming_complete_response_no_timeout_artifacts(self) -> None:
+        """A complete (non-partial) streaming response should not set
+        timeout or usage_unavailable artifacts."""
+        ctx = _make_context()
+        stage = GenerateAnswerStage()
+        mock_llm = _make_mock_llm(supports_streaming=True)
+
+        complete_response = LLMResponse(
+            content="The answer is 4",
+            usage=UsageMetadata(input_tokens=10, output_tokens=5, total_tokens=15),
+            is_partial=False,
+            usage_unavailable=False,
+        )
+        mock_llm.stream_invoke.return_value = complete_response
+
+        with (
+            patch(
+                "karenina.benchmark.verification.stages.pipeline.generate_answer.get_llm",
+                return_value=mock_llm,
+            ),
+            patch(_REGISTRY_PATCH_TARGET, return_value=None),
+        ):
+            stage.execute(ctx)
+
+        # No timeout artifacts should be set
+        assert ctx.get_artifact(ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL) is None
+        assert ctx.get_artifact(ArtifactKeys.USAGE_UNAVAILABLE) is None
+        assert ctx.error is None
+
+    def test_streaming_passes_request_timeout(self) -> None:
+        """stream_invoke should receive the request_timeout from the model config."""
+        ctx = _make_context()
+        ctx.answering_model.request_timeout = 42.0
+        stage = GenerateAnswerStage()
+        mock_llm = _make_mock_llm(supports_streaming=True)
+
+        mock_llm.stream_invoke.return_value = LLMResponse(
+            content="ok",
+            usage=UsageMetadata(),
+        )
+
+        with (
+            patch(
+                "karenina.benchmark.verification.stages.pipeline.generate_answer.get_llm",
+                return_value=mock_llm,
+            ),
+            patch(_REGISTRY_PATCH_TARGET, return_value=None),
+        ):
+            stage.execute(ctx)
+
+        call_kwargs = mock_llm.stream_invoke.call_args
+        assert call_kwargs[1]["timeout"] == 42.0
+
+
+@pytest.mark.unit
+class TestAgentTimeoutPath:
+    """Tests for agent timeout_reached handling in generate_answer."""
+
+    def _run_agent_stage(self, ctx: VerificationContext, agent_result: MagicMock) -> None:
+        """Helper to run GenerateAnswerStage with a mocked AgentPort.
+
+        Forces the use_agent path by setting an MCP URL on the model config
+        and patching get_agent to return a mock that yields the given result.
+        """
+        stage = GenerateAnswerStage()
+        mock_agent = MagicMock()
+        mock_agent.run.return_value = agent_result
+
+        # Force the agent path by adding an MCP server URL
+        ctx.answering_model.mcp_urls_dict = {"test-server": "http://localhost:8080"}
+
+        with (
+            patch(
+                "karenina.benchmark.verification.stages.pipeline.generate_answer.get_agent",
+                return_value=mock_agent,
+            ),
+            patch(_REGISTRY_PATCH_TARGET, return_value=None),
+        ):
+            stage.execute(ctx)
+
+    def test_agent_timeout_with_trace_sets_partial_and_usage_unavailable(self) -> None:
+        """When agent times out but has a partial trace, RESPONSE_TIMEOUT_PARTIAL
+        and USAGE_UNAVAILABLE should be set, and the trace should be stored."""
+        ctx = _make_context()
+        result = _make_agent_result(
+            timeout_reached=True,
+            raw_trace="--- AI Message ---\nPartial response from agent",
+            turns=3,
+        )
+
+        self._run_agent_stage(ctx, result)
+
+        # Timeout artifacts should be set
+        assert ctx.get_artifact(ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL) is True
+        assert ctx.get_result_field("response_timeout_partial") is True
+        assert ctx.get_artifact(ArtifactKeys.USAGE_UNAVAILABLE) is True
+        assert ctx.get_result_field(ArtifactKeys.USAGE_UNAVAILABLE) is True
+
+        # The partial trace should still be stored as the raw response
+        raw = ctx.get_artifact(ArtifactKeys.RAW_LLM_RESPONSE)
+        assert "Partial response from agent" in raw
+
+        # Pipeline should continue (no error)
+        assert ctx.error is None
+
+    def test_agent_timeout_with_no_trace_marks_error(self) -> None:
+        """When agent times out with no trace at all, the context should be
+        marked with an error and the pipeline should stop."""
+        ctx = _make_context()
+        result = _make_agent_result(
+            timeout_reached=True,
+            raw_trace="",
+            turns=0,
+        )
+
+        self._run_agent_stage(ctx, result)
+
+        # Error should be set
+        assert ctx.error is not None
+        assert "timed out" in ctx.error.lower()
+        assert ctx.completed_without_errors is False
+
+        # RAW_LLM_RESPONSE should be empty string (set explicitly in the early return)
+        assert ctx.get_artifact(ArtifactKeys.RAW_LLM_RESPONSE) == ""
+        assert ctx.get_artifact(ArtifactKeys.RECURSION_LIMIT_REACHED) is False
+
+    def test_agent_no_timeout_does_not_set_timeout_artifacts(self) -> None:
+        """When agent completes normally (no timeout), no timeout artifacts
+        should be set."""
+        ctx = _make_context()
+        result = _make_agent_result(
+            timeout_reached=False,
+            raw_trace="--- AI Message ---\nComplete response",
+            turns=2,
+        )
+
+        self._run_agent_stage(ctx, result)
+
+        # No timeout artifacts
+        assert ctx.get_artifact(ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL) is None
+        assert ctx.get_artifact(ArtifactKeys.USAGE_UNAVAILABLE) is None
+        assert ctx.error is None
+
+        # Normal response stored
+        assert "Complete response" in ctx.get_artifact(ArtifactKeys.RAW_LLM_RESPONSE)

--- a/tests/unit/benchmark/verification/stages/test_timeout_partial_guards.py
+++ b/tests/unit/benchmark/verification/stages/test_timeout_partial_guards.py
@@ -1,0 +1,78 @@
+"""Tests that downstream stages skip when RESPONSE_TIMEOUT_PARTIAL is True."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import ArtifactKeys
+from karenina.benchmark.verification.stages.pipeline.abstention_check import AbstentionCheckStage
+from karenina.benchmark.verification.stages.pipeline.agentic_parse_template import AgenticParseTemplateStage
+from karenina.benchmark.verification.stages.pipeline.parse_template import ParseTemplateStage
+from karenina.benchmark.verification.stages.pipeline.sufficiency_check import SufficiencyCheckStage
+from karenina.benchmark.verification.stages.pipeline.verify_template import VerifyTemplateStage
+
+GUARDED_STAGES = [
+    AbstentionCheckStage,
+    SufficiencyCheckStage,
+    ParseTemplateStage,
+    AgenticParseTemplateStage,
+    VerifyTemplateStage,
+]
+
+
+@pytest.fixture
+def mock_stage_context():
+    """Minimal mock of VerificationContext for should_run testing.
+
+    The mock must satisfy BaseVerificationStage.should_run(), which checks
+    ``not context.error``. Setting error to None makes that check pass,
+    allowing the stage's own guards (including the timeout guard) to run.
+    """
+    ctx = MagicMock()
+    ctx.error = None
+    ctx.get_artifact = MagicMock(return_value=None)
+    ctx.get_result_field = MagicMock(return_value=None)
+    ctx.has_artifact = MagicMock(return_value=True)
+    # Stage-specific feature flags checked after the timeout guard
+    ctx.abstention_enabled = True
+    ctx.sufficiency_enabled = True
+    ctx.agentic_parsing = True
+    return ctx
+
+
+@pytest.mark.unit
+class TestTimeoutPartialGuards:
+    """Verify that RESPONSE_TIMEOUT_PARTIAL causes stages to skip."""
+
+    @pytest.mark.parametrize("stage_cls", GUARDED_STAGES, ids=lambda c: c.__name__)
+    def test_skips_when_partial_true(self, stage_cls, mock_stage_context):
+        """Stage should_run returns False when response was truncated."""
+
+        def get_artifact_side_effect(key, default=None):
+            if key == ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL:
+                return True
+            return default
+
+        mock_stage_context.get_artifact = MagicMock(side_effect=get_artifact_side_effect)
+
+        stage = stage_cls()
+        result = stage.should_run(mock_stage_context)
+        assert result is False
+
+    @pytest.mark.parametrize("stage_cls", GUARDED_STAGES, ids=lambda c: c.__name__)
+    def test_does_not_skip_when_partial_false(self, stage_cls, mock_stage_context):
+        """Stage should_run does not skip solely due to timeout when partial is False."""
+
+        def get_artifact_side_effect(key, default=None):
+            if key == ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL:
+                return False
+            return default
+
+        mock_stage_context.get_artifact = MagicMock(side_effect=get_artifact_side_effect)
+
+        stage = stage_cls()
+        result = stage.should_run(mock_stage_context)
+        # The result depends on other conditions (abstention_enabled, agentic_parsing,
+        # etc.) which are MagicMock truthy values, so we only verify the timeout
+        # guard itself did not cause a skip: the result must be a bool.
+        assert isinstance(result, bool)

--- a/tests/unit/benchmark/verification/test_scenario_executor_timeout.py
+++ b/tests/unit/benchmark/verification/test_scenario_executor_timeout.py
@@ -1,0 +1,374 @@
+"""Tests for ScenarioExecutor timeout handling with partial progress.
+
+Tests verify:
+- Slow combos that exceed batch timeout produce a TimeoutError with in-flight progress info
+- All combos completing before timeout returns normal results with no timeout errors
+- The per-turn progress callback populates partial_progress with scenario_id, turn, and node
+- Mixed batches (some complete, some timed out) report both results and timeout errors
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karenina.benchmark.verification.scenario_executor import (
+    ScenarioExecutor,
+    ScenarioExecutorConfig,
+)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _make_combo(scenario_name: str, model_name: str = "test-model") -> tuple:
+    """Create a mock (scenario_def, answering_model, parsing_model) combo."""
+    scenario_def = MagicMock()
+    scenario_def.name = scenario_name
+
+    ans_model = MagicMock()
+    ans_model.model_name = model_name
+    ans_model.id = f"{model_name}-ans"
+
+    parse_model = MagicMock()
+    parse_model.model_name = model_name
+    parse_model.id = f"{model_name}-parse"
+
+    return (scenario_def, ans_model, parse_model)
+
+
+def _make_exec_result(scenario_id: str = "s1") -> MagicMock:
+    """Create a mock ScenarioExecutionResult."""
+    result = MagicMock()
+    result.scenario_id = scenario_id
+    result.status = "completed"
+    result.turn_count = 3
+    return result
+
+
+# ============================================================================
+# Slow combos with batch timeout
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestSlowCombosWithBatchTimeout:
+    """Slow combos exceeding the batch timeout produce a TimeoutError with progress info."""
+
+    @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
+    def test_timeout_includes_in_flight_progress(self, mock_manager_cls: MagicMock) -> None:
+        """When combos exceed the timeout after reporting partial progress,
+        the timeout error message includes turn count and node info.
+
+        Uses a never-set event to block the worker past both the batch timeout
+        and the 5s worker join, so the combo stays in partial_progress.
+        """
+        combos = [_make_combo("slow_scenario")]
+
+        # Block forever (daemon thread is cleaned up after test)
+        block_forever = threading.Event()
+
+        def mock_run(**kwargs):
+            cb = kwargs.get("progress_callback")
+            if cb:
+                cb(scenario_id="slow_scenario", scenario_turn=5, scenario_node="node_B")
+            # Block past both batch timeout (0.5s) and worker join (5s)
+            block_forever.wait(timeout=30.0)
+            return _make_exec_result("slow_scenario")
+
+        mock_manager_cls.return_value.run.side_effect = mock_run
+
+        config = MagicMock()
+        executor = ScenarioExecutor(
+            parallel=True,
+            config=ScenarioExecutorConfig(
+                max_workers=1,
+                enable_cache=False,
+                timeout_seconds=0.5,
+            ),
+        )
+        results, errors = executor.run_batch(combos, config)
+
+        # Unblock the worker so it can exit cleanly
+        block_forever.set()
+
+        # A timeout error must be present
+        timeout_errors = [(desc, exc) for desc, exc in errors if isinstance(exc, TimeoutError)]
+        assert len(timeout_errors) >= 1
+
+        timeout_msg = str(timeout_errors[0][1])
+        assert "timed out" in timeout_msg
+        # The message must include in-flight progress details
+        assert "slow_scenario" in timeout_msg
+        assert "turn 5" in timeout_msg
+        assert "node_B" in timeout_msg
+
+    @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
+    def test_timeout_reports_counts(self, mock_manager_cls: MagicMock) -> None:
+        """The timeout message reports completed, in-flight, and not-started counts."""
+        combos = [_make_combo("s1"), _make_combo("s2")]
+
+        block_forever = threading.Event()
+
+        def mock_run(**kwargs):
+            cb = kwargs.get("progress_callback")
+            if cb:
+                cb(scenario_id=kwargs["scenario"].name, scenario_turn=1, scenario_node="root")
+            block_forever.wait(timeout=30.0)
+            return _make_exec_result(kwargs["scenario"].name)
+
+        mock_manager_cls.return_value.run.side_effect = mock_run
+
+        config = MagicMock()
+        executor = ScenarioExecutor(
+            parallel=True,
+            config=ScenarioExecutorConfig(
+                max_workers=2,
+                enable_cache=False,
+                timeout_seconds=0.5,
+            ),
+        )
+        results, errors = executor.run_batch(combos, config)
+
+        block_forever.set()
+
+        timeout_errors = [(desc, exc) for desc, exc in errors if isinstance(exc, TimeoutError)]
+        assert len(timeout_errors) >= 1
+
+        timeout_msg = str(timeout_errors[0][1])
+        # Should mention "of 2 combos"
+        assert "2 combos" in timeout_msg
+
+
+# ============================================================================
+# All combos complete before timeout
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestAllCombosCompleteBeforeTimeout:
+    """All combos completing before the timeout produces normal results, no timeout errors."""
+
+    @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
+    def test_no_timeout_errors_when_fast(self, mock_manager_cls: MagicMock) -> None:
+        """Fast combos complete within the timeout; no TimeoutError in errors."""
+        combos = [
+            _make_combo("fast_a"),
+            _make_combo("fast_b"),
+            _make_combo("fast_c"),
+        ]
+
+        def mock_run(**kwargs):
+            return _make_exec_result(kwargs["scenario"].name)
+
+        mock_manager_cls.return_value.run.side_effect = mock_run
+
+        config = MagicMock()
+        executor = ScenarioExecutor(
+            parallel=True,
+            config=ScenarioExecutorConfig(
+                max_workers=3,
+                enable_cache=False,
+                timeout_seconds=30.0,
+            ),
+        )
+        results, errors = executor.run_batch(combos, config)
+
+        assert len(results) == 3
+        result_ids = {r.scenario_id for r in results}
+        assert result_ids == {"fast_a", "fast_b", "fast_c"}
+
+        # No timeout errors at all
+        timeout_errors = [e for _, e in errors if isinstance(e, TimeoutError)]
+        assert len(timeout_errors) == 0
+        assert len(errors) == 0
+
+    @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
+    def test_no_timeout_entries_in_failed_tasks(self, mock_manager_cls: MagicMock) -> None:
+        """Even with one runtime failure, no timeout errors when within deadline."""
+        combos = [_make_combo("ok"), _make_combo("fail")]
+
+        def mock_run(**kwargs):
+            if kwargs["scenario"].name == "fail":
+                raise RuntimeError("scenario broke")
+            return _make_exec_result(kwargs["scenario"].name)
+
+        mock_manager_cls.return_value.run.side_effect = mock_run
+
+        config = MagicMock()
+        executor = ScenarioExecutor(
+            parallel=True,
+            config=ScenarioExecutorConfig(
+                max_workers=2,
+                enable_cache=False,
+                timeout_seconds=30.0,
+            ),
+        )
+        results, errors = executor.run_batch(combos, config)
+
+        assert len(results) == 1
+        assert results[0].scenario_id == "ok"
+        assert len(errors) == 1
+        # The error is a RuntimeError, not a TimeoutError
+        _, exc = errors[0]
+        assert isinstance(exc, RuntimeError)
+        timeout_errors = [e for _, e in errors if isinstance(e, TimeoutError)]
+        assert len(timeout_errors) == 0
+
+
+# ============================================================================
+# Progress callback wiring
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestProgressCallbackWiring:
+    """The per-turn progress callback populates partial_progress correctly."""
+
+    @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
+    def test_partial_progress_populated_by_callback(self, mock_manager_cls: MagicMock) -> None:
+        """When manager.run() calls the progress callback, the partial_progress dict
+        is updated with scenario_id, turn, and node before the combo finishes.
+
+        We verify this indirectly: if the combo times out after the callback fires,
+        the timeout message must contain the progress data from the last callback.
+        """
+        combos = [_make_combo("multi_turn")]
+
+        block_forever = threading.Event()
+
+        def mock_run(**kwargs):
+            cb = kwargs.get("progress_callback")
+            if cb:
+                # Simulate multiple turn callbacks; the last one wins
+                cb(scenario_id="multi_turn", scenario_turn=1, scenario_node="intro")
+                cb(scenario_id="multi_turn", scenario_turn=2, scenario_node="followup")
+                cb(scenario_id="multi_turn", scenario_turn=3, scenario_node="conclusion")
+            # Block past batch timeout and worker join
+            block_forever.wait(timeout=30.0)
+            return _make_exec_result("multi_turn")
+
+        mock_manager_cls.return_value.run.side_effect = mock_run
+
+        config = MagicMock()
+        executor = ScenarioExecutor(
+            parallel=True,
+            config=ScenarioExecutorConfig(
+                max_workers=1,
+                enable_cache=False,
+                timeout_seconds=0.5,
+            ),
+        )
+        results, errors = executor.run_batch(combos, config)
+
+        block_forever.set()
+
+        timeout_errors = [(desc, exc) for desc, exc in errors if isinstance(exc, TimeoutError)]
+        assert len(timeout_errors) >= 1
+
+        timeout_msg = str(timeout_errors[0][1])
+        # The latest callback values should be reflected
+        assert "multi_turn" in timeout_msg
+        assert "turn 3" in timeout_msg
+        assert "conclusion" in timeout_msg
+
+    @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
+    def test_callback_receives_expected_kwargs(self, mock_manager_cls: MagicMock) -> None:
+        """The make_turn_callback closure correctly receives and stores kwargs."""
+        combos = [_make_combo("kwarg_check")]
+
+        captured_kwargs: list[dict] = []
+
+        original_run = None
+
+        def mock_run(**kwargs):
+            cb = kwargs.get("progress_callback")
+            if cb:
+                # The callback is _on_turn(**kwargs) which reads scenario_turn and scenario_node
+                cb(
+                    scenario_id="kwarg_check",
+                    scenario_turn=7,
+                    scenario_node="deep_node",
+                    verify_result=MagicMock(),
+                    next_node="exit",
+                )
+            return _make_exec_result("kwarg_check")
+
+        mock_manager_cls.return_value.run.side_effect = mock_run
+
+        config = MagicMock()
+        executor = ScenarioExecutor(
+            parallel=True,
+            config=ScenarioExecutorConfig(
+                max_workers=1,
+                enable_cache=False,
+                timeout_seconds=30.0,
+            ),
+        )
+        results, errors = executor.run_batch(combos, config)
+
+        # Combo completes successfully (no timeout), so no error
+        assert len(results) == 1
+        assert len(errors) == 0
+
+
+# ============================================================================
+# Mixed: some complete, some timed out
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestMixedCompletionAndTimeout:
+    """When some combos complete before the timeout and others do not,
+    the completed results are returned alongside a timeout error.
+    """
+
+    @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
+    def test_completed_results_returned_with_timeout_error(self, mock_manager_cls: MagicMock) -> None:
+        """Fast combos have their results collected; slow combos produce a timeout error."""
+        combos = [
+            _make_combo("fast"),
+            _make_combo("slow"),
+        ]
+
+        block_forever = threading.Event()
+
+        def mock_run(**kwargs):
+            name = kwargs["scenario"].name
+            cb = kwargs.get("progress_callback")
+            if name == "slow":
+                if cb:
+                    cb(scenario_id="slow", scenario_turn=2, scenario_node="stuck_node")
+                # Block past both batch timeout and worker join
+                block_forever.wait(timeout=30.0)
+                return _make_exec_result("slow")
+            return _make_exec_result("fast")
+
+        mock_manager_cls.return_value.run.side_effect = mock_run
+
+        config = MagicMock()
+        executor = ScenarioExecutor(
+            parallel=True,
+            config=ScenarioExecutorConfig(
+                max_workers=2,
+                enable_cache=False,
+                timeout_seconds=1.0,
+            ),
+        )
+        results, errors = executor.run_batch(combos, config)
+
+        block_forever.set()
+
+        # The fast combo should have completed
+        assert len(results) >= 1
+        fast_results = [r for r in results if r.scenario_id == "fast"]
+        assert len(fast_results) == 1
+
+        # A timeout error should be present with the slow combo's progress
+        timeout_errors = [(desc, exc) for desc, exc in errors if isinstance(exc, TimeoutError)]
+        assert len(timeout_errors) >= 1
+        timeout_msg = str(timeout_errors[0][1])
+        assert "slow" in timeout_msg
+        assert "stuck_node" in timeout_msg

--- a/tests/unit/benchmark/verification/test_scenario_executor_timeout.py
+++ b/tests/unit/benchmark/verification/test_scenario_executor_timeout.py
@@ -17,7 +17,6 @@ from karenina.benchmark.verification.scenario_executor import (
     ScenarioExecutorConfig,
 )
 
-
 # ============================================================================
 # Helpers
 # ============================================================================
@@ -278,10 +277,6 @@ class TestProgressCallbackWiring:
     def test_callback_receives_expected_kwargs(self, mock_manager_cls: MagicMock) -> None:
         """The make_turn_callback closure correctly receives and stores kwargs."""
         combos = [_make_combo("kwarg_check")]
-
-        captured_kwargs: list[dict] = []
-
-        original_run = None
 
         def mock_run(**kwargs):
             cb = kwargs.get("progress_callback")

--- a/tests/unit/ports/test_protocols.py
+++ b/tests/unit/ports/test_protocols.py
@@ -10,6 +10,8 @@ Tests cover:
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from pydantic import BaseModel
 
@@ -39,7 +41,8 @@ from karenina.ports.capabilities import PortCapabilities
 class MockLLMPort:
     """Mock implementation of LLMPort for testing isinstance checks.
 
-    Implements all required members: capabilities, ainvoke, invoke, with_structured_output.
+    Implements all required members: capabilities, ainvoke, invoke,
+    with_structured_output, astream, stream_invoke, aclose.
     """
 
     @property
@@ -63,6 +66,14 @@ class MockLLMPort:
     def with_structured_output(self, schema: type[BaseModel]) -> LLMPort:
         """Mock structured output configuration."""
         return self
+
+    def astream(self, messages: list[Message]) -> Any:
+        """Mock streaming (raises NotImplementedError)."""
+        raise NotImplementedError
+
+    def stream_invoke(self, messages: list[Message], timeout: float | None = None) -> LLMResponse:
+        """Mock stream invoke (raises NotImplementedError)."""
+        raise NotImplementedError
 
     async def aclose(self) -> None:
         """Mock cleanup."""

--- a/tests/unit/ports/test_streaming.py
+++ b/tests/unit/ports/test_streaming.py
@@ -1,0 +1,77 @@
+"""Tests for StreamingLLMResponse accumulation behavior."""
+
+import asyncio
+
+import pytest
+
+from karenina.ports.llm import StreamingLLMResponse
+
+
+async def _make_chunks(*texts: str):
+    """Async generator yielding text chunks."""
+    for t in texts:
+        yield t
+
+
+async def _make_slow_chunks(*texts: str, delay: float = 0.5):
+    """Async generator yielding text chunks with delay."""
+    for t in texts:
+        await asyncio.sleep(delay)
+        yield t
+
+
+async def _make_error_chunks(*texts: str):
+    """Async generator that yields some chunks then raises."""
+    for t in texts:
+        yield t
+    raise RuntimeError("stream interrupted")
+
+
+@pytest.mark.unit
+class TestStreamingLLMResponse:
+    """Tests for StreamingLLMResponse chunk accumulation."""
+
+    @pytest.mark.asyncio
+    async def test_accumulates_chunks(self):
+        sr = StreamingLLMResponse()
+        sr._set_chunk_source(_make_chunks("Hello", " ", "world"))
+        chunks = []
+        async for chunk in sr:
+            chunks.append(chunk)
+        assert chunks == ["Hello", " ", "world"]
+        assert sr.accumulated_content == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_empty_stream(self):
+        sr = StreamingLLMResponse()
+        sr._set_chunk_source(_make_chunks())
+        async for _chunk in sr:
+            pass
+        assert sr.accumulated_content == ""
+
+    @pytest.mark.asyncio
+    async def test_no_chunk_source_stops_immediately(self):
+        sr = StreamingLLMResponse()
+        chunks = [c async for c in sr]
+        assert chunks == []
+        assert sr.accumulated_content == ""
+
+    @pytest.mark.asyncio
+    async def test_error_midstream_preserves_partial(self):
+        sr = StreamingLLMResponse()
+        sr._set_chunk_source(_make_error_chunks("partial", " content"))
+        with pytest.raises(RuntimeError, match="stream interrupted"):
+            async for _chunk in sr:
+                pass
+        assert sr.accumulated_content == "partial content"
+
+    @pytest.mark.asyncio
+    async def test_is_complete_default_false(self):
+        sr = StreamingLLMResponse()
+        assert sr.is_complete is False
+
+    @pytest.mark.asyncio
+    async def test_usage_default_empty(self):
+        sr = StreamingLLMResponse()
+        assert sr.usage.input_tokens == 0
+        assert sr.usage.output_tokens == 0


### PR DESCRIPTION
## Summary

Adds streaming response support to all LLM adapters (LangChain, ClaudeSDK, ClaudeTool, DeepAgents) and salvages partial content or partial traces when LLM streams or agent runs hit their request timeout. Replaces opaque timeout failures with best-effort recovered state that flows through the pipeline and into verification results, so downstream stages can reason about incomplete outputs instead of simply failing.

## Changes Made

### Adapters: streaming
- Added streaming support to LangChain, ClaudeSDK, and DeepAgents LLM adapters (`adapters/{langchain,claude_agent_sdk,langchain_deep_agents}/llm.py`)
- New `StreamingLLMResponse` type exposed via the LLM port (`ports/llm.py`, `ports/__init__.py`, `ports/capabilities.py`)
- Usage-metadata handling updated for streaming in `adapters/langchain/usage.py`

### Adapters: partial capture on timeout
- New `usage_unavailable` field on `LLMResponse`, set when a stream times out before usage metadata is produced; propagated through the pipeline to results (`schemas/verification/result_components.py`)
- New `timeout_reached` field on `AgentResult` (`ports/agent.py`)
- Claude Tool and LangChain agent adapters recover partial trace when the run hits timeout (`adapters/claude_tool/agent.py`, `adapters/langchain/agent.py`)
- `generate_answer` stage handles `timeout_reached` from agent adapters
- `scenario_executor` recovers partial combo state when a batch hits timeout (`benchmark/verification/scenario_executor.py`, `schemas/scenario/state.py`)

### Pipeline: `response_timeout_partial` guards
New guard added to 5 pipeline stages so they skip cleanly when only partial state is available:
- `generate_answer`, `parse_template`, `verify_template`, `abstention_check`, `sufficiency_check`
- Plus `agentic_parse_template` and propagation through `finalize_result`
- Shared guard plumbing in `stages/core/base.py`

### SDK subprocess bypass for parsing
- `adapters/claude_agent_sdk/parser.py` and `adapters/claude_agent_sdk/prompts/parsing.py`: parsing calls now use direct API calls instead of the SDK subprocess, eliminating a class of subprocess hangs that blocked the parser path

### Fixes
- Prevent the Claude SDK stub from polluting other tests
- Avoid cancel-scope conflict in the `claude_agent_sdk` portal path
- Persist `response_timeout_partial` flag on zero-content streaming timeouts

## Testing

New test files:
- `tests/unit/ports/test_streaming.py`: `StreamingLLMResponse` unit tests
- `tests/unit/adapters/{langchain,claude_agent_sdk,claude_tool,langchain_deep_agents}/test_streaming.py`: streaming tests for all four LLM adapters
- `tests/unit/adapters/langchain/test_usage_streaming.py`: usage-metadata edge cases during streaming
- `tests/unit/adapters/{claude_tool,langchain}/test_agent_timeout.py`: agent timeout recovery tests
- `tests/unit/benchmark/verification/stages/test_timeout_partial_guards.py`: `RESPONSE_TIMEOUT_PARTIAL` guard tests across 5 stages
- `tests/unit/benchmark/verification/stages/test_generate_answer_streaming.py`: streaming path through `generate_answer`
- `tests/unit/benchmark/verification/test_scenario_executor_timeout.py`: scenario executor partial-progress on timeout

Updated:
- `tests/integration/verification/test_pipeline_robustness.py`: updated for new timeout handling
- `tests/unit/ports/test_protocols.py`, `tests/unit/benchmark/verification/stages/test_generate_answer_prompt_config.py`: updated to match new port protocol fields

## Additional Context

- **No breaking API changes** for user-facing benchmark code. The LLM and Agent port protocols gain optional fields (`usage_unavailable`, `timeout_reached`, streaming), and existing adapters preserve their current behavior when the new paths are not used.
- **Behavior change for timeouts**: runs that previously hard-failed on LLM or agent timeout will now surface `response_timeout_partial` flagged results with whatever content was captured before the timeout. Downstream tooling that interprets verification results should check this flag when deciding how to treat incomplete outputs.
- **Scale**: 41 files changed, +3,292 / -266 lines; 21 commits.