### PR TITLE
fix(verification): bounded retry, prefix-cache task ordering, and transient error handling

### DIFF
--- a/src/karenina/adapters/langchain/llm.py
+++ b/src/karenina/adapters/langchain/llm.py
@@ -36,7 +36,7 @@ from karenina.ports.llm import StreamingLLMResponse
 from karenina.utils.errors import is_retryable_error
 from karenina.utils.json_extraction import extract_json_from_response
 from karenina.utils.messages import append_error_feedback
-from karenina.utils.retry import TRANSIENT_RETRY
+from karenina.utils.retry import TRANSIENT_RETRY, create_transient_retry
 
 from .messages import LangChainMessageConverter
 from .prompts import FORMAT_INSTRUCTIONS
@@ -108,6 +108,7 @@ class LangChainLLMAdapter:
         self._structured_model = _structured_model
         self._base_model = _base_model
         self._max_retries = _max_retries
+        self._max_transient_retries = model_config.max_transient_retries
 
         if _base_model is not None:
             self._model = _structured_model if _structured_model else _base_model
@@ -138,6 +139,10 @@ class LangChainLLMAdapter:
 
         if self._config.extra_kwargs:
             kwargs.update(self._config.extra_kwargs)
+
+        # Suppress SDK-level retries. TRANSIENT_RETRY is the sole retry layer.
+        # Placed after extra_kwargs merge to ensure SDK retries stay at 0.
+        kwargs["max_retries"] = 0
 
         # Initialize model via existing infrastructure
         model = init_chat_model_unified(
@@ -596,8 +601,8 @@ class LangChainLLMAdapter:
     async def _invoke_model_with_retry(self, model: Any, lc_messages: list[Any]) -> Any:
         """Invoke a LangChain model with automatic retry for transient errors.
 
-        This is a helper that applies the standard transient retry policy
-        to any model invocation.
+        Uses the configurable max_transient_retries from ModelConfig when set,
+        otherwise falls back to the module-level TRANSIENT_RETRY singleton.
 
         Args:
             model: The LangChain model to invoke.
@@ -609,8 +614,12 @@ class LangChainLLMAdapter:
         Raises:
             Exception: After all retries are exhausted.
         """
+        if self._max_transient_retries is not None:
+            retry_decorator = create_transient_retry(max_attempts=self._max_transient_retries)
+        else:
+            retry_decorator = TRANSIENT_RETRY
 
-        @TRANSIENT_RETRY
+        @retry_decorator
         async def _invoke() -> Any:
             return await model.ainvoke(lc_messages)
 

--- a/src/karenina/adapters/langchain/parser.py
+++ b/src/karenina/adapters/langchain/parser.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel
 
 from karenina.ports import Message, ParseError, ParsePortResult, ParserPort, UsageMetadata
 from karenina.ports.capabilities import PortCapabilities
+from karenina.utils.errors import is_retryable_error
 from karenina.utils.json_extraction import extract_json_from_response, is_invalid_json_error
 
 from .llm import LangChainLLMAdapter
@@ -221,7 +222,9 @@ class LangChainParserAdapter:
             return ParsePortResult(parsed=result, usage=total_usage)
 
         except Exception as structured_error:
-            logger.debug(f"Structured output parsing failed: {structured_error}")
+            if is_retryable_error(structured_error):
+                raise
+            logger.debug("Structured output parsing failed: %s", structured_error)
 
         # Strategy 2: Fallback to regular LLM invocation with manual JSON parsing
         llm_response = await self._llm_adapter.ainvoke(messages)
@@ -234,7 +237,7 @@ class LangChainParserAdapter:
             logger.debug("Template parsing succeeded via fallback JSON parsing")
             return ParsePortResult(parsed=result, usage=total_usage)
         except Exception as parse_error:
-            logger.debug(f"Fallback JSON parsing failed: {parse_error}")
+            logger.debug("Fallback JSON parsing failed: %s", parse_error)
 
             # Check if retries are disabled
             if self._max_retries <= 0:
@@ -337,7 +340,7 @@ class LangChainParserAdapter:
             data = json.loads(json_str)
             return schema.model_validate(data)
         except (json.JSONDecodeError, ValidationError, ValueError) as e:
-            logger.debug(f"JSON extraction failed: {e}")
+            logger.debug("JSON extraction failed: %s", e)
 
         # Strategy 2: JSON repair for malformed JSON
         try:
@@ -349,7 +352,7 @@ class LangChainParserAdapter:
         except ImportError:
             logger.debug("json-repair not installed, skipping repair strategy")
         except Exception as e:
-            logger.debug(f"JSON repair failed: {e}")
+            logger.debug("JSON repair failed: %s", e)
 
         # All strategies failed
         preview = content[:200] if len(content) > 200 else content
@@ -402,7 +405,7 @@ class LangChainParserAdapter:
             logger.debug("Parsing error is not null-related, skipping null-value retry")
             return None, empty_usage
 
-        logger.info(f"Detected null values in required fields: {null_fields}. Retrying with feedback...")
+        logger.info("Detected null values in required fields: %s. Retrying with feedback...", null_fields)
 
         # Build feedback message
         field_list = ", ".join(null_fields)
@@ -416,11 +419,13 @@ class LangChainParserAdapter:
             llm_response = await self._llm_adapter.ainvoke(retry_messages)
             retry_usage = llm_response.usage if llm_response.usage else empty_usage
             result = self._parse_response_content(llm_response.content, schema)
-            logger.info(f"Successfully parsed after null-value retry. Fixed fields: {field_list}")
+            logger.info("Successfully parsed after null-value retry. Fixed fields: %s", field_list)
             return result, retry_usage
 
         except Exception as e:
-            logger.warning(f"Retry parsing failed after null-value feedback: {e}")
+            if is_retryable_error(e):
+                raise
+            logger.warning("Retry parsing failed after null-value feedback: %s", e)
             return None, empty_usage
 
     async def _retry_with_format_feedback(
@@ -484,7 +489,9 @@ class LangChainParserAdapter:
             return result, retry_usage
 
         except Exception as e:
-            logger.warning(f"Retry parsing failed after format feedback: {e}")
+            if is_retryable_error(e):
+                raise
+            logger.warning("Retry parsing failed after format feedback: %s", e)
             return None, empty_usage
 
     async def aclose(self) -> None:

--- a/src/karenina/benchmark/benchmark.py
+++ b/src/karenina/benchmark/benchmark.py
@@ -841,6 +841,23 @@ class Benchmark:
             for parse_model in config.parsing_models
         ]
 
+        # Apply task ordering to scenario combos
+        from karenina.benchmark.verification.utils.task_helpers import model_sort_key
+
+        if config.task_ordering == "prefix_cache":
+            combos.sort(
+                key=lambda c: (
+                    model_sort_key(c[1]),  # answering_model
+                    c[0].name,  # scenario name
+                    model_sort_key(c[2]),  # parsing_model
+                )
+            )
+        elif config.task_ordering == "random":
+            import random
+
+            random.shuffle(combos)
+        # "generation_order": no-op, preserve original list comprehension order
+
         executor = ScenarioExecutor(
             parallel=bool(async_enabled) and len(combos) > 1,
             config=ScenarioExecutorConfig(

--- a/src/karenina/benchmark/benchmark.py
+++ b/src/karenina/benchmark/benchmark.py
@@ -834,8 +834,16 @@ class Benchmark:
                 return model.model_copy(update={"request_timeout": config.request_timeout})
             return model
 
+        def _apply_retry(model: Any) -> Any:
+            if config.max_transient_retries is not None and model.max_transient_retries is None:
+                return model.model_copy(update={"max_transient_retries": config.max_transient_retries})
+            return model
+
+        def _prepare_model(model: Any) -> Any:
+            return _apply_retry(_apply_timeout(model))
+
         combos = [
-            (scenario_def, _apply_timeout(ans_model), _apply_timeout(parse_model))
+            (scenario_def, _prepare_model(ans_model), _prepare_model(parse_model))
             for scenario_def in self._scenarios.values()
             for ans_model in config.answering_models
             for parse_model in config.parsing_models

--- a/src/karenina/benchmark/verification/batch_runner.py
+++ b/src/karenina/benchmark/verification/batch_runner.py
@@ -49,6 +49,21 @@ def _apply_request_timeout(model: Any, pipeline_timeout: float | None) -> Any:
 
 
 # ============================================================================
+# Config Helpers
+# ============================================================================
+
+
+def _apply_retry_config(model: Any, max_transient_retries: int | None) -> Any:
+    """Stamp pipeline-level max_transient_retries onto a ModelConfig if not already set.
+
+    Returns the original model if no change is needed, or a copy with the value applied.
+    """
+    if max_transient_retries is not None and model.max_transient_retries is None:
+        return model.model_copy(update={"max_transient_retries": max_transient_retries})
+    return model
+
+
+# ============================================================================
 # Task Queue Generation
 # ============================================================================
 
@@ -95,6 +110,9 @@ def generate_task_queue(
                 # Stamp pipeline-level request_timeout onto models that don't have their own
                 ans_model = _apply_request_timeout(ans_model_raw, config.request_timeout)
                 parse_model = _apply_request_timeout(parse_model_raw, config.request_timeout)
+                # Stamp pipeline-level max_transient_retries onto models that don't have their own
+                ans_model = _apply_retry_config(ans_model, config.max_transient_retries)
+                parse_model = _apply_retry_config(parse_model, config.max_transient_retries)
                 # Expand over replicates
                 for rep in range(1, config.replicate_count + 1):
                     # For single replicate, don't include replicate numbers

--- a/src/karenina/benchmark/verification/batch_runner.py
+++ b/src/karenina/benchmark/verification/batch_runner.py
@@ -367,6 +367,24 @@ def run_verification_batch(
         workspace_root=workspace_root,
     )
 
+    # Apply task ordering strategy
+    from .utils.task_helpers import model_sort_key
+
+    if config.task_ordering == "prefix_cache":
+        task_queue.sort(
+            key=lambda t: (
+                model_sort_key(t["answering_model"]),
+                t["question_id"],
+                model_sort_key(t["parsing_model"]),
+                t.get("replicate") or 0,
+            )
+        )
+    elif config.task_ordering == "random":
+        import random
+
+        random.shuffle(task_queue)
+    # "generation_order": no-op, preserve loop order
+
     # Log execution plan
     logger.info(f"Starting verification: {len(task_queue)} tasks ({'parallel' if async_enabled else 'sequential'})")
 

--- a/src/karenina/benchmark/verification/batch_runner.py
+++ b/src/karenina/benchmark/verification/batch_runner.py
@@ -375,7 +375,10 @@ def run_verification_batch(
 
     executor = VerificationExecutor(
         parallel=async_enabled,
-        config=ExecutorConfig(max_workers=max_workers),
+        config=ExecutorConfig(
+            max_workers=max_workers,
+            max_requeue_count=config.max_requeue_count,
+        ),
     )
     results = executor.run_batch(task_queue, progress_callback)
 

--- a/src/karenina/benchmark/verification/executor.py
+++ b/src/karenina/benchmark/verification/executor.py
@@ -1,7 +1,7 @@
 """Verification task execution with parallel/sequential support.
 
 This module provides the VerificationExecutor class for running verification
-tasks either sequentially or in parallel using a thread pool with asyncio
+tasks either sequentially or in parallel using ThreadPoolExecutor with asyncio
 BlockingPortal for proper async event loop management.
 
 The thread-local portal storage allows worker threads to share async execution
@@ -10,12 +10,11 @@ context without passing the portal through all function signatures.
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import os
-import queue
 import threading
 from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -242,13 +241,11 @@ class VerificationExecutor:
         tasks: list[dict[str, Any]],
         progress_callback: Callable[[int, int, VerificationResult | None], None] | None,
     ) -> dict[str, VerificationResult]:
-        """Execute tasks in parallel with thread pool.
+        """Execute tasks in parallel using ThreadPoolExecutor.
 
-        Uses intelligent retry and answer cache optimization with task shuffling
-        and progressive retry to maximize cache hits while avoiding blocking.
-
-        Uses AnyIO BlockingPortal to properly manage async event loops across
-        worker threads, preventing connection pool degradation.
+        Each task is submitted as a separate Future with its own BlockingPortal.
+        Cache retry logic runs internally within each callable. Every submission
+        produces a Future, so no task can be silently lost.
 
         Args:
             tasks: List of task dictionaries
@@ -269,175 +266,114 @@ class VerificationExecutor:
         max_workers = self.config.max_workers
         logger.info("Parallel execution: %d tasks with %d workers", len(tasks), max_workers)
 
-        # Create thread-safe answer cache for sharing traces across judges
         answer_cache = AnswerTraceCache() if self.config.enable_cache else None
-
-        # Preserve incoming order (ordering is controlled by task_ordering config)
-        indexed_tasks = list(enumerate(tasks))
-
-        # Create work queue with (original_index, task, retry_count)
-        work_queue: queue.Queue[tuple[int, dict[str, Any], int] | None] = queue.Queue()
-        for idx, task in indexed_tasks:
-            work_queue.put((idx, task, 0))
-
-        # Thread-safe storage for results (indexed by original position)
-        results_lock = threading.Lock()
-        results_by_index: dict[int, tuple[str, VerificationResult]] = {}
-
-        # Thread-safe error tracking
-        failed_count = [0]
-        failed_tasks: list[tuple[str, BaseException]] = []
+        total = len(tasks)
+        max_requeue = self.config.max_requeue_count
+        retry_wait = self.config.retry_wait_seconds
 
         # Thread-safe progress tracking
         progress_lock = threading.Lock()
         completed_count = [0]
-        total = len(tasks)
 
-        # Completion tracking
-        tasks_completed_event = threading.Event()
-
-        retry_wait_seconds = self.config.retry_wait_seconds
-
-        def worker() -> None:
-            """Worker function that processes tasks from queue with retry logic.
-
-            Each worker creates its own BlockingPortal with its own event loop.
-            This eliminates the shared event loop bottleneck at high concurrency.
-            """
+        def execute_task_with_retry(idx: int, task: dict[str, Any]) -> tuple[int, tuple[str, VerificationResult]]:
+            """Execute a single verification task with cache retry and its own portal."""
             with start_blocking_portal(backend="asyncio") as portal:
                 set_async_portal(portal)
                 try:
-                    while True:
-                        try:
-                            # Get next task (non-blocking to allow checking for shutdown)
-                            try:
-                                item = work_queue.get(timeout=1.0)
-                            except queue.Empty:
-                                # Check if all tasks are completed (successes + failures)
-                                with results_lock:
-                                    if len(results_by_index) + failed_count[0] >= total:
-                                        tasks_completed_event.set()
+                    # Call preview progress callback
+                    if progress_callback:
+                        preview_result = create_preview_result(task)
+                        with progress_lock:
+                            progress_callback(completed_count[0] + 1, total, preview_result)
+
+                    if not answer_cache:
+                        return idx, execute_task(task, answer_cache)
+
+                    cache_key = generate_answer_cache_key(task)
+                    for attempt in range(max_requeue + 1):
+                        status, cached_answer_data = answer_cache.get_or_reserve(cache_key)
+
+                        if status == "IN_PROGRESS":
+                            if attempt == 0:
+                                logger.debug(
+                                    "Task %s in progress (retry=%d), retrying immediately",
+                                    cache_key,
+                                    attempt,
+                                )
                                 continue
 
-                            # Check for shutdown signal
-                            if item is None:
-                                work_queue.task_done()
-                                break
-
-                            original_index, task, retry_count = item
-
-                            # Check answer cache first
-                            if answer_cache:
-                                cache_key = generate_answer_cache_key(task)
-                                status, cached_answer_data = answer_cache.get_or_reserve(cache_key)
-
-                                if status == "IN_PROGRESS":
-                                    # Another worker is generating this answer
-                                    # Always call task_done() immediately after get()
-                                    work_queue.task_done()
-
-                                    max_requeue = self.config.max_requeue_count
-
-                                    if retry_count >= max_requeue:
-                                        # Requeue limit exceeded: force reset and generate fresh
-                                        logger.warning(
-                                            "Task %s exceeded max requeue count (%d), generating fresh",
-                                            cache_key,
-                                            max_requeue,
-                                        )
-                                        answer_cache.force_reset(cache_key)
-                                        work_queue.put((original_index, task, 0))
-                                        continue
-
-                                    if retry_count == 0:
-                                        # First encounter: immediately requeue and move to next task
-                                        logger.debug(
-                                            "Task %s in progress (retry=%d), requeueing immediately",
-                                            cache_key,
-                                            retry_count,
-                                        )
-                                        work_queue.put((original_index, task, retry_count + 1))
-                                        continue
-                                    else:
-                                        # Subsequent encounter: use cache event-based waiting
-                                        completed = answer_cache.wait_for_completion(
-                                            cache_key, timeout=retry_wait_seconds
-                                        )
-                                        if not completed:
-                                            logger.debug(
-                                                "Task %s still in progress after %ss, requeueing",
-                                                cache_key,
-                                                retry_wait_seconds,
-                                            )
-                                        work_queue.put((original_index, task, retry_count + 1))
-                                        continue
-                            else:
-                                status, cached_answer_data = "MISS", None
-
-                            # Status is MISS or HIT, ready to execute
-                            # Call preview progress callback
-                            if progress_callback:
-                                preview_result = create_preview_result(task)
-                                with progress_lock:
-                                    progress_callback(completed_count[0] + 1, total, preview_result)
-
-                            # Execute the task with pre-checked cache status
-                            try:
-                                result_key, verification_result = execute_task(
-                                    task, answer_cache, cache_status=status, cached_answer_data=cached_answer_data
+                            completed = answer_cache.wait_for_completion(cache_key, timeout=retry_wait)
+                            if not completed:
+                                logger.debug(
+                                    "Task %s still in progress after %ss, retrying",
+                                    cache_key,
+                                    retry_wait,
                                 )
+                            continue
 
-                                # Store result at original index
-                                with results_lock:
-                                    results_by_index[original_index] = (result_key, verification_result)
-                                    # Check if all tasks are now complete
-                                    if len(results_by_index) + failed_count[0] >= total:
-                                        tasks_completed_event.set()
+                        # MISS or HIT: execute
+                        return idx, execute_task(
+                            task,
+                            answer_cache,
+                            cache_status=status,
+                            cached_answer_data=cached_answer_data,
+                        )
 
-                                # Call completion progress callback
-                                if progress_callback:
-                                    with progress_lock:
-                                        completed_count[0] += 1
-                                        progress_callback(completed_count[0], total, verification_result)
-
-                            except Exception as e:
-                                logger.error("Parallel task %s failed: %s", task["question_id"], e)
-                                with results_lock:
-                                    failed_count[0] += 1
-                                    failed_tasks.append((task["question_id"], e))
-                                    if len(results_by_index) + failed_count[0] >= total:
-                                        tasks_completed_event.set()
-
-                            finally:
-                                work_queue.task_done()
-
-                        except Exception as e:
-                            logger.error("Worker error: %s", e)
-                            with contextlib.suppress(ValueError):
-                                # task_done() called more times than get()
-                                work_queue.task_done()
-
+                    # Exceeded max requeue: force reset, generate fresh
+                    logger.warning(
+                        "Task %s exceeded max requeue count (%d), generating fresh",
+                        cache_key,
+                        max_requeue,
+                    )
+                    answer_cache.force_reset(cache_key)
+                    return idx, execute_task(task, answer_cache)
                 finally:
-                    # Clear the portal when worker exits
                     set_async_portal(None)
 
-        # Start worker threads, each creating its own BlockingPortal
-        workers = []
-        for _ in range(max_workers):
-            t = threading.Thread(target=worker, daemon=True)
-            t.start()
-            workers.append(t)
+        # Preserve incoming order (ordering is controlled by task_ordering config)
+        indexed_tasks = list(enumerate(tasks))
 
-        # Wait for all tasks to complete, with timeout
-        completed = tasks_completed_event.wait(timeout=self.config.timeout_seconds)
+        results_by_index: dict[int, tuple[str, VerificationResult]] = {}
+        failed_tasks: list[tuple[str, BaseException]] = []
 
-        # Send shutdown signal to workers
-        for _ in range(max_workers):
-            work_queue.put(None)
+        pool = ThreadPoolExecutor(max_workers=max_workers)
+        try:
+            # Submit all tasks
+            future_to_meta: dict[Future[tuple[int, tuple[str, VerificationResult]]], tuple[int, str]] = {}
+            for idx, task in indexed_tasks:
+                future = pool.submit(execute_task_with_retry, idx, task)
+                future_to_meta[future] = (idx, task["question_id"])
 
-        # Wait for workers to finish
-        for t in workers:
-            t.join(timeout=5.0)
+            # Collect results as they complete
+            collected: set[Future[tuple[int, tuple[str, VerificationResult]]]] = set()
+            timed_out = False
+            try:
+                for future in as_completed(future_to_meta, timeout=self.config.timeout_seconds):
+                    collected.add(future)
+                    idx, question_id = future_to_meta[future]
+                    try:
+                        result_idx, (result_key, verification_result) = future.result()
+                        results_by_index[result_idx] = (result_key, verification_result)
+
+                        if progress_callback:
+                            with progress_lock:
+                                completed_count[0] += 1
+                                progress_callback(completed_count[0], total, verification_result)
+                    except BaseException as e:
+                        logger.error("Parallel task %s failed: %s", question_id, e)
+                        failed_tasks.append((question_id, e))
+            except TimeoutError:
+                timed_out = True
+                # Sweep futures that completed between last yield and timeout
+                for future, (_idx, question_id) in future_to_meta.items():
+                    if future.done() and future not in collected:
+                        try:
+                            result_idx, (result_key, verification_result) = future.result()
+                            results_by_index[result_idx] = (result_key, verification_result)
+                        except BaseException as e:
+                            failed_tasks.append((question_id, e))
+        finally:
+            pool.shutdown(wait=False, cancel_futures=True)
 
         # Restore original order and convert to dictionary
         results: dict[str, VerificationResult] = {}
@@ -450,9 +386,10 @@ class VerificationExecutor:
             log_cache_stats(answer_cache, mode="parallel mode")
 
         # Handle timeout
-        if not completed:
+        if timed_out:
             raise VerificationBatchError(
-                f"Parallel batch timed out after {self.config.timeout_seconds:.0f} seconds ({len(results)} of {total} tasks completed)",
+                f"Parallel batch timed out after {self.config.timeout_seconds:.0f} seconds "
+                f"({len(results)} of {total} tasks completed)",
                 partial_results=results,
                 errors=failed_tasks,
             )

--- a/src/karenina/benchmark/verification/executor.py
+++ b/src/karenina/benchmark/verification/executor.py
@@ -105,12 +105,16 @@ class ExecutorConfig:
         enable_cache: Whether to enable answer caching (default: True)
         retry_wait_seconds: Seconds to wait for IN_PROGRESS cache entries (default: 5.0)
         timeout_seconds: Maximum wall-clock seconds for a parallel batch (default: 600.0)
+        max_requeue_count: Maximum times a task can be requeued before forcing a
+            fresh generation (default: 5). When exceeded, the cache entry is reset
+            and the task restarts with retry_count=0.
     """
 
     max_workers: int = DEFAULT_ASYNC_MAX_WORKERS
     enable_cache: bool = True
     retry_wait_seconds: float = 5.0
     timeout_seconds: float = 600.0
+    max_requeue_count: int = 5
 
 
 # ============================================================================
@@ -264,7 +268,7 @@ class VerificationExecutor:
         from .utils.task_helpers import create_preview_result
 
         max_workers = self.config.max_workers
-        logger.info(f"Parallel execution: {len(tasks)} tasks with {max_workers} workers")
+        logger.info("Parallel execution: %d tasks with %d workers", len(tasks), max_workers)
 
         # Create thread-safe answer cache for sharing traces across judges
         answer_cache = AnswerTraceCache() if self.config.enable_cache else None
@@ -330,10 +334,25 @@ class VerificationExecutor:
                                 # Always call task_done() immediately after get()
                                 work_queue.task_done()
 
+                                max_requeue = self.config.max_requeue_count
+
+                                if retry_count >= max_requeue:
+                                    # Requeue limit exceeded: force reset and generate fresh
+                                    logger.warning(
+                                        "Task %s exceeded max requeue count (%d), generating fresh",
+                                        cache_key,
+                                        max_requeue,
+                                    )
+                                    answer_cache.force_reset(cache_key)
+                                    work_queue.put((original_index, task, 0))
+                                    continue
+
                                 if retry_count == 0:
                                     # First encounter: immediately requeue and move to next task
                                     logger.debug(
-                                        f"Task {cache_key} in progress (retry={retry_count}), requeueing immediately"
+                                        "Task %s in progress (retry=%d), requeueing immediately",
+                                        cache_key,
+                                        retry_count,
                                     )
                                     work_queue.put((original_index, task, retry_count + 1))
                                     continue
@@ -342,7 +361,9 @@ class VerificationExecutor:
                                     completed = answer_cache.wait_for_completion(cache_key, timeout=retry_wait_seconds)
                                     if not completed:
                                         logger.debug(
-                                            f"Task {cache_key} still in progress after {retry_wait_seconds}s, requeueing"
+                                            "Task %s still in progress after %ss, requeueing",
+                                            cache_key,
+                                            retry_wait_seconds,
                                         )
                                     work_queue.put((original_index, task, retry_count + 1))
                                     continue
@@ -387,7 +408,7 @@ class VerificationExecutor:
                             work_queue.task_done()
 
                     except Exception as e:
-                        logger.error(f"Worker error: {e}")
+                        logger.error("Worker error: %s", e)
                         with contextlib.suppress(ValueError):
                             # task_done() called more times than get()
                             work_queue.task_done()

--- a/src/karenina/benchmark/verification/executor.py
+++ b/src/karenina/benchmark/verification/executor.py
@@ -14,7 +14,6 @@ import contextlib
 import logging
 import os
 import queue
-import random
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -273,9 +272,8 @@ class VerificationExecutor:
         # Create thread-safe answer cache for sharing traces across judges
         answer_cache = AnswerTraceCache() if self.config.enable_cache else None
 
-        # Preserve original order and shuffle for better cache distribution
-        indexed_tasks = [(idx, task) for idx, task in enumerate(tasks)]
-        random.shuffle(indexed_tasks)
+        # Preserve incoming order (ordering is controlled by task_ordering config)
+        indexed_tasks = list(enumerate(tasks))
 
         # Create work queue with (original_index, task, retry_count)
         work_queue: queue.Queue[tuple[int, dict[str, Any], int] | None] = queue.Queue()
@@ -300,142 +298,146 @@ class VerificationExecutor:
 
         retry_wait_seconds = self.config.retry_wait_seconds
 
-        def worker(portal: BlockingPortal) -> None:
-            """Worker function that processes tasks from queue with retry logic."""
-            # Each worker sets its own thread-local portal
-            set_async_portal(portal)
-            try:
-                while True:
-                    try:
-                        # Get next task (non-blocking to allow checking for shutdown)
+        def worker() -> None:
+            """Worker function that processes tasks from queue with retry logic.
+
+            Each worker creates its own BlockingPortal with its own event loop.
+            This eliminates the shared event loop bottleneck at high concurrency.
+            """
+            with start_blocking_portal(backend="asyncio") as portal:
+                set_async_portal(portal)
+                try:
+                    while True:
                         try:
-                            item = work_queue.get(timeout=1.0)
-                        except queue.Empty:
-                            # Check if all tasks are completed (successes + failures)
-                            with results_lock:
-                                if len(results_by_index) + failed_count[0] >= total:
-                                    tasks_completed_event.set()
-                            continue
+                            # Get next task (non-blocking to allow checking for shutdown)
+                            try:
+                                item = work_queue.get(timeout=1.0)
+                            except queue.Empty:
+                                # Check if all tasks are completed (successes + failures)
+                                with results_lock:
+                                    if len(results_by_index) + failed_count[0] >= total:
+                                        tasks_completed_event.set()
+                                continue
 
-                        # Check for shutdown signal
-                        if item is None:
-                            work_queue.task_done()
-                            break
+                            # Check for shutdown signal
+                            if item is None:
+                                work_queue.task_done()
+                                break
 
-                        original_index, task, retry_count = item
+                            original_index, task, retry_count = item
 
-                        # Check answer cache first
-                        if answer_cache:
-                            cache_key = generate_answer_cache_key(task)
-                            status, cached_answer_data = answer_cache.get_or_reserve(cache_key)
+                            # Check answer cache first
+                            if answer_cache:
+                                cache_key = generate_answer_cache_key(task)
+                                status, cached_answer_data = answer_cache.get_or_reserve(cache_key)
 
-                            if status == "IN_PROGRESS":
-                                # Another worker is generating this answer
-                                # Always call task_done() immediately after get()
+                                if status == "IN_PROGRESS":
+                                    # Another worker is generating this answer
+                                    # Always call task_done() immediately after get()
+                                    work_queue.task_done()
+
+                                    max_requeue = self.config.max_requeue_count
+
+                                    if retry_count >= max_requeue:
+                                        # Requeue limit exceeded: force reset and generate fresh
+                                        logger.warning(
+                                            "Task %s exceeded max requeue count (%d), generating fresh",
+                                            cache_key,
+                                            max_requeue,
+                                        )
+                                        answer_cache.force_reset(cache_key)
+                                        work_queue.put((original_index, task, 0))
+                                        continue
+
+                                    if retry_count == 0:
+                                        # First encounter: immediately requeue and move to next task
+                                        logger.debug(
+                                            "Task %s in progress (retry=%d), requeueing immediately",
+                                            cache_key,
+                                            retry_count,
+                                        )
+                                        work_queue.put((original_index, task, retry_count + 1))
+                                        continue
+                                    else:
+                                        # Subsequent encounter: use cache event-based waiting
+                                        completed = answer_cache.wait_for_completion(
+                                            cache_key, timeout=retry_wait_seconds
+                                        )
+                                        if not completed:
+                                            logger.debug(
+                                                "Task %s still in progress after %ss, requeueing",
+                                                cache_key,
+                                                retry_wait_seconds,
+                                            )
+                                        work_queue.put((original_index, task, retry_count + 1))
+                                        continue
+                            else:
+                                status, cached_answer_data = "MISS", None
+
+                            # Status is MISS or HIT, ready to execute
+                            # Call preview progress callback
+                            if progress_callback:
+                                preview_result = create_preview_result(task)
+                                with progress_lock:
+                                    progress_callback(completed_count[0] + 1, total, preview_result)
+
+                            # Execute the task with pre-checked cache status
+                            try:
+                                result_key, verification_result = execute_task(
+                                    task, answer_cache, cache_status=status, cached_answer_data=cached_answer_data
+                                )
+
+                                # Store result at original index
+                                with results_lock:
+                                    results_by_index[original_index] = (result_key, verification_result)
+                                    # Check if all tasks are now complete
+                                    if len(results_by_index) + failed_count[0] >= total:
+                                        tasks_completed_event.set()
+
+                                # Call completion progress callback
+                                if progress_callback:
+                                    with progress_lock:
+                                        completed_count[0] += 1
+                                        progress_callback(completed_count[0], total, verification_result)
+
+                            except Exception as e:
+                                logger.error("Parallel task %s failed: %s", task["question_id"], e)
+                                with results_lock:
+                                    failed_count[0] += 1
+                                    failed_tasks.append((task["question_id"], e))
+                                    if len(results_by_index) + failed_count[0] >= total:
+                                        tasks_completed_event.set()
+
+                            finally:
                                 work_queue.task_done()
 
-                                max_requeue = self.config.max_requeue_count
-
-                                if retry_count >= max_requeue:
-                                    # Requeue limit exceeded: force reset and generate fresh
-                                    logger.warning(
-                                        "Task %s exceeded max requeue count (%d), generating fresh",
-                                        cache_key,
-                                        max_requeue,
-                                    )
-                                    answer_cache.force_reset(cache_key)
-                                    work_queue.put((original_index, task, 0))
-                                    continue
-
-                                if retry_count == 0:
-                                    # First encounter: immediately requeue and move to next task
-                                    logger.debug(
-                                        "Task %s in progress (retry=%d), requeueing immediately",
-                                        cache_key,
-                                        retry_count,
-                                    )
-                                    work_queue.put((original_index, task, retry_count + 1))
-                                    continue
-                                else:
-                                    # Subsequent encounter: use cache event-based waiting
-                                    completed = answer_cache.wait_for_completion(cache_key, timeout=retry_wait_seconds)
-                                    if not completed:
-                                        logger.debug(
-                                            "Task %s still in progress after %ss, requeueing",
-                                            cache_key,
-                                            retry_wait_seconds,
-                                        )
-                                    work_queue.put((original_index, task, retry_count + 1))
-                                    continue
-                        else:
-                            status, cached_answer_data = "MISS", None
-
-                        # Status is MISS or HIT - ready to execute
-                        # Call preview progress callback
-                        if progress_callback:
-                            preview_result = create_preview_result(task)
-                            with progress_lock:
-                                progress_callback(completed_count[0] + 1, total, preview_result)
-
-                        # Execute the task with pre-checked cache status
-                        try:
-                            result_key, verification_result = execute_task(
-                                task, answer_cache, cache_status=status, cached_answer_data=cached_answer_data
-                            )
-
-                            # Store result at original index
-                            with results_lock:
-                                results_by_index[original_index] = (result_key, verification_result)
-                                # Check if all tasks are now complete
-                                if len(results_by_index) + failed_count[0] >= total:
-                                    tasks_completed_event.set()
-
-                            # Call completion progress callback
-                            if progress_callback:
-                                with progress_lock:
-                                    completed_count[0] += 1
-                                    progress_callback(completed_count[0], total, verification_result)
-
                         except Exception as e:
-                            logger.error("Parallel task %s failed: %s", task["question_id"], e)
-                            with results_lock:
-                                failed_count[0] += 1
-                                failed_tasks.append((task["question_id"], e))
-                                if len(results_by_index) + failed_count[0] >= total:
-                                    tasks_completed_event.set()
+                            logger.error("Worker error: %s", e)
+                            with contextlib.suppress(ValueError):
+                                # task_done() called more times than get()
+                                work_queue.task_done()
 
-                        finally:
-                            work_queue.task_done()
+                finally:
+                    # Clear the portal when worker exits
+                    set_async_portal(None)
 
-                    except Exception as e:
-                        logger.error("Worker error: %s", e)
-                        with contextlib.suppress(ValueError):
-                            # task_done() called more times than get()
-                            work_queue.task_done()
+        # Start worker threads, each creating its own BlockingPortal
+        workers = []
+        for _ in range(max_workers):
+            t = threading.Thread(target=worker, daemon=True)
+            t.start()
+            workers.append(t)
 
-            finally:
-                # Clear the portal when worker exits
-                set_async_portal(None)
+        # Wait for all tasks to complete, with timeout
+        completed = tasks_completed_event.wait(timeout=self.config.timeout_seconds)
 
-        # Use BlockingPortal to properly manage async event loop for all worker threads
-        with start_blocking_portal(backend="asyncio") as portal:
-            # Start worker threads, each with a reference to the shared portal
-            workers = []
-            for _ in range(max_workers):
-                t = threading.Thread(target=worker, args=(portal,), daemon=True)
-                t.start()
-                workers.append(t)
+        # Send shutdown signal to workers
+        for _ in range(max_workers):
+            work_queue.put(None)
 
-            # Wait for all tasks to complete, with timeout
-            completed = tasks_completed_event.wait(timeout=self.config.timeout_seconds)
-
-            # Send shutdown signal to workers
-            for _ in range(max_workers):
-                work_queue.put(None)
-
-            # Wait for workers to finish
-            for t in workers:
-                t.join(timeout=5.0)
+        # Wait for workers to finish
+        for t in workers:
+            t.join(timeout=5.0)
 
         # Restore original order and convert to dictionary
         results: dict[str, VerificationResult] = {}

--- a/src/karenina/benchmark/verification/executor.py
+++ b/src/karenina/benchmark/verification/executor.py
@@ -29,6 +29,8 @@ from karenina.utils.answer_cache import AnswerTraceCache
 
 logger = logging.getLogger(__name__)
 
+_SENTINEL = object()  # Distinguishes "attribute missing" from "attribute is None"
+
 # ============================================================================
 # Thread-Local Portal Storage
 # ============================================================================
@@ -40,11 +42,20 @@ def get_async_portal() -> BlockingPortal | None:
     """Get the current async portal for running async code from threads.
 
     Each worker thread has its own thread-local portal reference.
+    Returns None (and clears the stale reference) if the portal's event loop
+    has ended, allowing callers to fall back to asyncio.run().
 
     Returns:
         The BlockingPortal if one is active for this thread, None otherwise
     """
-    return getattr(_portal_storage, "portal", None)
+    portal = getattr(_portal_storage, "portal", None)
+    if portal is not None:
+        thread_id = getattr(portal, "_event_loop_thread_id", _SENTINEL)
+        if thread_id is None:
+            logger.warning("Clearing stale portal reference (event loop thread ended)")
+            _portal_storage.portal = None
+            return None
+    return portal
 
 
 def set_async_portal(portal: BlockingPortal | None) -> None:
@@ -275,60 +286,74 @@ class VerificationExecutor:
         progress_lock = threading.Lock()
         completed_count = [0]
 
+        # Per-worker portal management: each worker thread creates one portal
+        # that is reused across all tasks on that thread. This preserves httpx
+        # connection pools and avoids "Event loop is closed" errors from rapid
+        # portal churn.
+        _portal_cms: list[Any] = []
+        _portal_init_lock = threading.Lock()
+
+        def _ensure_worker_portal() -> None:
+            """Lazily create a BlockingPortal for this worker thread."""
+            if get_async_portal() is not None:
+                return
+            cm = start_blocking_portal(backend="asyncio")
+            portal = cm.__enter__()
+            set_async_portal(portal)
+            with _portal_init_lock:
+                _portal_cms.append(cm)
+
         def execute_task_with_retry(idx: int, task: dict[str, Any]) -> tuple[int, tuple[str, VerificationResult]]:
-            """Execute a single verification task with cache retry and its own portal."""
-            with start_blocking_portal(backend="asyncio") as portal:
-                set_async_portal(portal)
-                try:
-                    # Call preview progress callback
-                    if progress_callback:
-                        preview_result = create_preview_result(task)
-                        with progress_lock:
-                            progress_callback(completed_count[0] + 1, total, preview_result)
+            """Execute a single verification task with cache retry."""
+            _ensure_worker_portal()
 
-                    if not answer_cache:
-                        return idx, execute_task(task, answer_cache)
+            # Call preview progress callback
+            if progress_callback:
+                preview_result = create_preview_result(task)
+                with progress_lock:
+                    progress_callback(completed_count[0] + 1, total, preview_result)
 
-                    cache_key = generate_answer_cache_key(task)
-                    for attempt in range(max_requeue + 1):
-                        status, cached_answer_data = answer_cache.get_or_reserve(cache_key)
+            if not answer_cache:
+                return idx, execute_task(task, answer_cache)
 
-                        if status == "IN_PROGRESS":
-                            if attempt == 0:
-                                logger.debug(
-                                    "Task %s in progress (retry=%d), retrying immediately",
-                                    cache_key,
-                                    attempt,
-                                )
-                                continue
+            cache_key = generate_answer_cache_key(task)
+            for attempt in range(max_requeue + 1):
+                status, cached_answer_data = answer_cache.get_or_reserve(cache_key)
 
-                            completed = answer_cache.wait_for_completion(cache_key, timeout=retry_wait)
-                            if not completed:
-                                logger.debug(
-                                    "Task %s still in progress after %ss, retrying",
-                                    cache_key,
-                                    retry_wait,
-                                )
-                            continue
-
-                        # MISS or HIT: execute
-                        return idx, execute_task(
-                            task,
-                            answer_cache,
-                            cache_status=status,
-                            cached_answer_data=cached_answer_data,
+                if status == "IN_PROGRESS":
+                    if attempt == 0:
+                        logger.debug(
+                            "Task %s in progress (retry=%d), retrying immediately",
+                            cache_key,
+                            attempt,
                         )
+                        continue
 
-                    # Exceeded max requeue: force reset, generate fresh
-                    logger.warning(
-                        "Task %s exceeded max requeue count (%d), generating fresh",
-                        cache_key,
-                        max_requeue,
-                    )
-                    answer_cache.force_reset(cache_key)
-                    return idx, execute_task(task, answer_cache)
-                finally:
-                    set_async_portal(None)
+                    completed = answer_cache.wait_for_completion(cache_key, timeout=retry_wait)
+                    if not completed:
+                        logger.debug(
+                            "Task %s still in progress after %ss, retrying",
+                            cache_key,
+                            retry_wait,
+                        )
+                    continue
+
+                # MISS or HIT: execute
+                return idx, execute_task(
+                    task,
+                    answer_cache,
+                    cache_status=status,
+                    cached_answer_data=cached_answer_data,
+                )
+
+            # Exceeded max requeue: force reset, generate fresh
+            logger.warning(
+                "Task %s exceeded max requeue count (%d), generating fresh",
+                cache_key,
+                max_requeue,
+            )
+            answer_cache.force_reset(cache_key)
+            return idx, execute_task(task, answer_cache)
 
         # Preserve incoming order (ordering is controlled by task_ordering config)
         indexed_tasks = list(enumerate(tasks))
@@ -373,7 +398,13 @@ class VerificationExecutor:
                         except BaseException as e:
                             failed_tasks.append((question_id, e))
         finally:
-            pool.shutdown(wait=False, cancel_futures=True)
+            pool.shutdown(wait=not timed_out, cancel_futures=timed_out)
+            # Clean up worker portals (event loops)
+            for cm in _portal_cms:
+                try:
+                    cm.__exit__(None, None, None)
+                except Exception:
+                    logger.debug("Portal cleanup error", exc_info=True)
 
         # Restore original order and convert to dictionary
         results: dict[str, VerificationResult] = {}

--- a/src/karenina/benchmark/verification/executor.py
+++ b/src/karenina/benchmark/verification/executor.py
@@ -193,7 +193,7 @@ class VerificationExecutor:
 
         answer_cache = AnswerTraceCache() if self.config.enable_cache else None
         results: dict[str, VerificationResult] = {}
-        errors: list[tuple[str, Exception]] = []
+        errors: list[tuple[str, BaseException]] = []
         total = len(tasks)
 
         # Use a shared BlockingPortal so that sync invoke() calls reuse the
@@ -286,7 +286,7 @@ class VerificationExecutor:
 
         # Thread-safe error tracking
         failed_count = [0]
-        failed_tasks: list[tuple[str, Exception]] = []
+        failed_tasks: list[tuple[str, BaseException]] = []
 
         # Thread-safe progress tracking
         progress_lock = threading.Lock()

--- a/src/karenina/benchmark/verification/scenario_executor.py
+++ b/src/karenina/benchmark/verification/scenario_executor.py
@@ -29,7 +29,7 @@ from karenina.schemas.scenario.state import ScenarioExecutionResult
 from karenina.schemas.verification.config import DEFAULT_ASYNC_MAX_WORKERS
 from karenina.utils.answer_cache import AnswerTraceCache
 
-from .executor import set_async_portal, set_global_llm_semaphore
+from .executor import get_async_portal, set_async_portal, set_global_llm_semaphore
 
 logger = logging.getLogger(__name__)
 
@@ -248,26 +248,39 @@ class ScenarioExecutor:
 
             return _on_turn
 
+        # Per-worker portal management: each worker thread creates one portal
+        # that is reused across all combos on that thread. This preserves httpx
+        # connection pools and avoids "Event loop is closed" errors from rapid
+        # portal churn.
+        _portal_cms: list[Any] = []
+        _portal_init_lock = threading.Lock()
+
+        def _ensure_worker_portal() -> None:
+            """Lazily create a BlockingPortal for this worker thread."""
+            if get_async_portal() is not None:
+                return
+            cm = start_blocking_portal(backend="asyncio")
+            portal = cm.__enter__()
+            set_async_portal(portal)
+            with _portal_init_lock:
+                _portal_cms.append(cm)
+
         def execute_combo(idx: int, combo: ScenarioCombo) -> tuple[int, ScenarioExecutionResult]:
-            """Execute a single scenario combo with its own BlockingPortal."""
+            """Execute a single scenario combo using the worker's portal."""
+            _ensure_worker_portal()
             scenario_def, ans_model, parse_model = combo
-            with start_blocking_portal(backend="asyncio") as portal:
-                set_async_portal(portal)
-                try:
-                    manager = ScenarioManager()
-                    result = manager.run(
-                        scenario=scenario_def,
-                        config=config,
-                        base_answering_model=ans_model,
-                        base_parsing_model=parse_model,
-                        run_name=run_name,
-                        global_rubric=global_rubric,
-                        answer_cache=answer_cache,
-                        progress_callback=make_turn_callback(idx, scenario_def.name),
-                    )
-                    return (idx, result)
-                finally:
-                    set_async_portal(None)
+            manager = ScenarioManager()
+            result = manager.run(
+                scenario=scenario_def,
+                config=config,
+                base_answering_model=ans_model,
+                base_parsing_model=parse_model,
+                run_name=run_name,
+                global_rubric=global_rubric,
+                answer_cache=answer_cache,
+                progress_callback=make_turn_callback(idx, scenario_def.name),
+            )
+            return (idx, result)
 
         results_by_index: dict[int, ScenarioExecutionResult] = {}
         failed_tasks: list[tuple[str, BaseException]] = []
@@ -312,7 +325,13 @@ class ScenarioExecutor:
                             except BaseException as e:
                                 failed_tasks.append((combo_desc, e))
             finally:
-                pool.shutdown(wait=False, cancel_futures=True)
+                pool.shutdown(wait=not timed_out, cancel_futures=timed_out)
+                # Clean up worker portals (event loops)
+                for cm in _portal_cms:
+                    try:
+                        cm.__exit__(None, None, None)
+                    except Exception:
+                        logger.debug("Portal cleanup error", exc_info=True)
         finally:
             set_global_llm_semaphore(None)
 

--- a/src/karenina/benchmark/verification/scenario_executor.py
+++ b/src/karenina/benchmark/verification/scenario_executor.py
@@ -21,8 +21,6 @@ from typing import TYPE_CHECKING, Any
 from anyio.from_thread import start_blocking_portal
 
 if TYPE_CHECKING:
-    from anyio.from_thread import BlockingPortal
-
     from karenina.schemas.entities import Rubric
     from karenina.schemas.verification import VerificationConfig
 
@@ -204,10 +202,11 @@ class ScenarioExecutor:
         run_name: str | None,
         progress_callback: ProgressCallback | None,
     ) -> tuple[list[ScenarioExecutionResult], list[tuple[str, BaseException]]]:
-        """Execute combos in parallel with thread pool and shared BlockingPortal.
+        """Execute combos in parallel with per-worker BlockingPortals.
 
-        Uses threading.Thread workers with a shared work queue, mirroring the
-        pattern in VerificationExecutor._run_parallel.
+        Each worker thread creates its own BlockingPortal, giving it a
+        dedicated asyncio event loop. This eliminates the shared event loop
+        bottleneck that occurs when all workers funnel through a single portal.
 
         Args:
             combos: Scenario combos to execute.
@@ -252,104 +251,106 @@ class ScenarioExecutor:
         # Completion tracking
         tasks_completed_event = threading.Event()
 
-        def worker(portal: BlockingPortal) -> None:
+        def worker() -> None:
             """Worker that processes scenario combos from the shared queue."""
-            set_async_portal(portal)
-            try:
-                while True:
-                    try:
-                        item = work_queue.get(timeout=1.0)
-                    except queue.Empty:
-                        with results_lock:
-                            if len(results_by_index) + len(failed_tasks) >= total:
-                                tasks_completed_event.set()
-                        continue
+            with start_blocking_portal(backend="asyncio") as portal:
+                set_async_portal(portal)
+                try:
+                    while True:
+                        try:
+                            item = work_queue.get(timeout=1.0)
+                        except queue.Empty:
+                            with results_lock:
+                                if len(results_by_index) + len(failed_tasks) >= total:
+                                    tasks_completed_event.set()
+                            continue
 
-                    if item is None:
-                        work_queue.task_done()
-                        break
+                        if item is None:
+                            work_queue.task_done()
+                            break
 
-                    original_index, (scenario_def, ans_model, parse_model) = item
-                    combo_desc = f"Scenario '{scenario_def.name}' with {ans_model.model_name}/{parse_model.model_name}"
-
-                    # Progress callback before starting (result=None)
-                    if progress_callback:
-                        with progress_lock:
-                            progress_callback(completed_count[0] + 1, total, None)
-
-                    try:
-                        manager = ScenarioManager()
-
-                        def make_turn_callback(idx: int, scenario_name: str) -> Callable[..., None]:
-                            """Create a per-turn callback that tracks progress."""
-
-                            def _on_turn(**kwargs: Any) -> None:
-                                turn_num = kwargs.get("scenario_turn", 0)
-                                node_id = kwargs.get("scenario_node", "")
-                                with results_lock:
-                                    partial_progress[idx] = {
-                                        "scenario_id": scenario_name,
-                                        "turn": turn_num,
-                                        "node": node_id,
-                                    }
-
-                            return _on_turn
-
-                        exec_result = manager.run(
-                            scenario=scenario_def,
-                            config=config,
-                            base_answering_model=ans_model,
-                            base_parsing_model=parse_model,
-                            run_name=run_name,
-                            global_rubric=global_rubric,
-                            answer_cache=answer_cache,
-                            progress_callback=make_turn_callback(original_index, scenario_def.name),
+                        original_index, (scenario_def, ans_model, parse_model) = item
+                        combo_desc = (
+                            f"Scenario '{scenario_def.name}' with {ans_model.model_name}/{parse_model.model_name}"
                         )
 
-                        with results_lock:
-                            results_by_index[original_index] = exec_result
-                            if len(results_by_index) + len(failed_tasks) >= total:
-                                tasks_completed_event.set()
-
-                        # Progress callback after completion (with result)
+                        # Progress callback before starting (result=None)
                         if progress_callback:
                             with progress_lock:
-                                completed_count[0] += 1
-                                progress_callback(completed_count[0], total, exec_result)
+                                progress_callback(completed_count[0] + 1, total, None)
 
-                    except Exception as e:
-                        logger.error("Parallel scenario failed: %s: %s", combo_desc, e)
-                        with results_lock:
-                            failed_tasks.append((combo_desc, e))
-                            if len(results_by_index) + len(failed_tasks) >= total:
-                                tasks_completed_event.set()
+                        try:
+                            manager = ScenarioManager()
 
-                    finally:
-                        work_queue.task_done()
+                            def make_turn_callback(idx: int, scenario_name: str) -> Callable[..., None]:
+                                """Create a per-turn callback that tracks progress."""
 
-            finally:
-                set_async_portal(None)
+                                def _on_turn(**kwargs: Any) -> None:
+                                    turn_num = kwargs.get("scenario_turn", 0)
+                                    node_id = kwargs.get("scenario_node", "")
+                                    with results_lock:
+                                        partial_progress[idx] = {
+                                            "scenario_id": scenario_name,
+                                            "turn": turn_num,
+                                            "node": node_id,
+                                        }
+
+                                return _on_turn
+
+                            exec_result = manager.run(
+                                scenario=scenario_def,
+                                config=config,
+                                base_answering_model=ans_model,
+                                base_parsing_model=parse_model,
+                                run_name=run_name,
+                                global_rubric=global_rubric,
+                                answer_cache=answer_cache,
+                                progress_callback=make_turn_callback(original_index, scenario_def.name),
+                            )
+
+                            with results_lock:
+                                results_by_index[original_index] = exec_result
+                                if len(results_by_index) + len(failed_tasks) >= total:
+                                    tasks_completed_event.set()
+
+                            # Progress callback after completion (with result)
+                            if progress_callback:
+                                with progress_lock:
+                                    completed_count[0] += 1
+                                    progress_callback(completed_count[0], total, exec_result)
+
+                        except Exception as e:
+                            logger.error("Parallel scenario failed: %s: %s", combo_desc, e)
+                            with results_lock:
+                                failed_tasks.append((combo_desc, e))
+                                if len(results_by_index) + len(failed_tasks) >= total:
+                                    tasks_completed_event.set()
+
+                        finally:
+                            work_queue.task_done()
+
+                finally:
+                    set_async_portal(None)
 
         # Set global semaphore before spawning workers
         set_global_llm_semaphore(sem)
         try:
-            with start_blocking_portal(backend="asyncio") as portal:
-                workers = []
-                for _ in range(max_workers):
-                    t = threading.Thread(target=worker, args=(portal,), daemon=True)
-                    t.start()
-                    workers.append(t)
+            workers = []
+            for _ in range(max_workers):
+                t = threading.Thread(target=worker, daemon=True)
+                t.start()
+                workers.append(t)
 
-                # Wait for all combos to complete, with timeout
-                completed = tasks_completed_event.wait(timeout=self.config.timeout_seconds)
+            # Wait for all combos to complete, with timeout
+            completed = tasks_completed_event.wait(timeout=self.config.timeout_seconds)
 
-                # Send shutdown signal to workers
-                for _ in range(max_workers):
-                    work_queue.put(None)
+            # Send shutdown signal to workers
+            for _ in range(max_workers):
+                work_queue.put(None)
 
-                # Wait for workers to finish
-                for t in workers:
-                    t.join(timeout=5.0)
+            # Wait for workers to finish
+            for t in workers:
+                t.join(timeout=5.0)
         finally:
             set_global_llm_semaphore(None)
 

--- a/src/karenina/benchmark/verification/scenario_executor.py
+++ b/src/karenina/benchmark/verification/scenario_executor.py
@@ -1,7 +1,7 @@
 """Scenario execution with parallel/sequential support.
 
 This module provides the ScenarioExecutor class for running scenario verification
-combos either sequentially or in parallel using a thread pool with asyncio
+combos either sequentially or in parallel using ThreadPoolExecutor with asyncio
 BlockingPortal for proper async event loop management.
 
 Peer to VerificationExecutor, adapted for multi-turn scenario execution
@@ -12,9 +12,9 @@ question verification.
 from __future__ import annotations
 
 import logging
-import queue
 import threading
 from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -202,11 +202,11 @@ class ScenarioExecutor:
         run_name: str | None,
         progress_callback: ProgressCallback | None,
     ) -> tuple[list[ScenarioExecutionResult], list[tuple[str, BaseException]]]:
-        """Execute combos in parallel with per-worker BlockingPortals.
+        """Execute combos in parallel using ThreadPoolExecutor.
 
-        Each worker thread creates its own BlockingPortal, giving it a
-        dedicated asyncio event loop. This eliminates the shared event loop
-        bottleneck that occurs when all workers funnel through a single portal.
+        Each combo is submitted as a separate Future with its own BlockingPortal.
+        Results are collected via as_completed() with a timeout. Every submission
+        produces a Future, so no combo can be silently lost.
 
         Args:
             combos: Scenario combos to execute.
@@ -229,128 +229,90 @@ class ScenarioExecutor:
         )
 
         total = len(combos)
-
-        # Create work queue with (original_index, combo)
-        work_queue: queue.Queue[tuple[int, ScenarioCombo] | None] = queue.Queue()
-        for idx, combo in enumerate(combos):
-            work_queue.put((idx, combo))
-
-        # Thread-safe storage for results (indexed by original position)
-        results_lock = threading.Lock()
-        results_by_index: dict[int, ScenarioExecutionResult] = {}
-        # Partial progress for in-flight combos (turn tracking via callback)
         partial_progress: dict[int, dict[str, Any]] = {}
-
-        # Thread-safe error tracking
-        failed_tasks: list[tuple[str, BaseException]] = []
-
-        # Thread-safe progress tracking
         progress_lock = threading.Lock()
         completed_count = [0]
 
-        # Completion tracking
-        tasks_completed_event = threading.Event()
+        def make_turn_callback(idx: int, scenario_name: str) -> Callable[..., None]:
+            """Create a per-turn callback that tracks progress."""
 
-        def worker() -> None:
-            """Worker that processes scenario combos from the shared queue."""
+            def _on_turn(**kwargs: Any) -> None:
+                turn_num = kwargs.get("scenario_turn", 0)
+                node_id = kwargs.get("scenario_node", "")
+                with progress_lock:
+                    partial_progress[idx] = {
+                        "scenario_id": scenario_name,
+                        "turn": turn_num,
+                        "node": node_id,
+                    }
+
+            return _on_turn
+
+        def execute_combo(idx: int, combo: ScenarioCombo) -> tuple[int, ScenarioExecutionResult]:
+            """Execute a single scenario combo with its own BlockingPortal."""
+            scenario_def, ans_model, parse_model = combo
             with start_blocking_portal(backend="asyncio") as portal:
                 set_async_portal(portal)
                 try:
-                    while True:
+                    manager = ScenarioManager()
+                    result = manager.run(
+                        scenario=scenario_def,
+                        config=config,
+                        base_answering_model=ans_model,
+                        base_parsing_model=parse_model,
+                        run_name=run_name,
+                        global_rubric=global_rubric,
+                        answer_cache=answer_cache,
+                        progress_callback=make_turn_callback(idx, scenario_def.name),
+                    )
+                    return (idx, result)
+                finally:
+                    set_async_portal(None)
+
+        results_by_index: dict[int, ScenarioExecutionResult] = {}
+        failed_tasks: list[tuple[str, BaseException]] = []
+
+        set_global_llm_semaphore(sem)
+        try:
+            pool = ThreadPoolExecutor(max_workers=max_workers)
+            try:
+                # Submit all combos
+                future_to_meta: dict[Future[tuple[int, ScenarioExecutionResult]], tuple[int, str]] = {}
+                for idx, (scenario_def, ans_model, parse_model) in enumerate(combos):
+                    combo_desc = f"Scenario '{scenario_def.name}' with {ans_model.model_name}/{parse_model.model_name}"
+                    future = pool.submit(execute_combo, idx, (scenario_def, ans_model, parse_model))
+                    future_to_meta[future] = (idx, combo_desc)
+
+                # Collect results as they complete
+                collected: set[Future[tuple[int, ScenarioExecutionResult]]] = set()
+                timed_out = False
+                try:
+                    for future in as_completed(future_to_meta, timeout=self.config.timeout_seconds):
+                        collected.add(future)
+                        idx, combo_desc = future_to_meta[future]
                         try:
-                            item = work_queue.get(timeout=1.0)
-                        except queue.Empty:
-                            with results_lock:
-                                if len(results_by_index) + len(failed_tasks) >= total:
-                                    tasks_completed_event.set()
-                            continue
+                            result_idx, exec_result = future.result()
+                            results_by_index[result_idx] = exec_result
 
-                        if item is None:
-                            work_queue.task_done()
-                            break
-
-                        original_index, (scenario_def, ans_model, parse_model) = item
-                        combo_desc = (
-                            f"Scenario '{scenario_def.name}' with {ans_model.model_name}/{parse_model.model_name}"
-                        )
-
-                        # Progress callback before starting (result=None)
-                        if progress_callback:
-                            with progress_lock:
-                                progress_callback(completed_count[0] + 1, total, None)
-
-                        try:
-                            manager = ScenarioManager()
-
-                            def make_turn_callback(idx: int, scenario_name: str) -> Callable[..., None]:
-                                """Create a per-turn callback that tracks progress."""
-
-                                def _on_turn(**kwargs: Any) -> None:
-                                    turn_num = kwargs.get("scenario_turn", 0)
-                                    node_id = kwargs.get("scenario_node", "")
-                                    with results_lock:
-                                        partial_progress[idx] = {
-                                            "scenario_id": scenario_name,
-                                            "turn": turn_num,
-                                            "node": node_id,
-                                        }
-
-                                return _on_turn
-
-                            exec_result = manager.run(
-                                scenario=scenario_def,
-                                config=config,
-                                base_answering_model=ans_model,
-                                base_parsing_model=parse_model,
-                                run_name=run_name,
-                                global_rubric=global_rubric,
-                                answer_cache=answer_cache,
-                                progress_callback=make_turn_callback(original_index, scenario_def.name),
-                            )
-
-                            with results_lock:
-                                results_by_index[original_index] = exec_result
-                                if len(results_by_index) + len(failed_tasks) >= total:
-                                    tasks_completed_event.set()
-
-                            # Progress callback after completion (with result)
                             if progress_callback:
                                 with progress_lock:
                                     completed_count[0] += 1
                                     progress_callback(completed_count[0], total, exec_result)
-
-                        except Exception as e:
+                        except BaseException as e:
                             logger.error("Parallel scenario failed: %s: %s", combo_desc, e)
-                            with results_lock:
+                            failed_tasks.append((combo_desc, e))
+                except TimeoutError:
+                    timed_out = True
+                    # Sweep futures that completed between last yield and timeout
+                    for future, (_idx, combo_desc) in future_to_meta.items():
+                        if future.done() and future not in collected:
+                            try:
+                                result_idx, exec_result = future.result()
+                                results_by_index[result_idx] = exec_result
+                            except BaseException as e:
                                 failed_tasks.append((combo_desc, e))
-                                if len(results_by_index) + len(failed_tasks) >= total:
-                                    tasks_completed_event.set()
-
-                        finally:
-                            work_queue.task_done()
-
-                finally:
-                    set_async_portal(None)
-
-        # Set global semaphore before spawning workers
-        set_global_llm_semaphore(sem)
-        try:
-            workers = []
-            for _ in range(max_workers):
-                t = threading.Thread(target=worker, daemon=True)
-                t.start()
-                workers.append(t)
-
-            # Wait for all combos to complete, with timeout
-            completed = tasks_completed_event.wait(timeout=self.config.timeout_seconds)
-
-            # Send shutdown signal to workers
-            for _ in range(max_workers):
-                work_queue.put(None)
-
-            # Wait for workers to finish
-            for t in workers:
-                t.join(timeout=5.0)
+            finally:
+                pool.shutdown(wait=False, cancel_futures=True)
         finally:
             set_global_llm_semaphore(None)
 
@@ -359,7 +321,7 @@ class ScenarioExecutor:
         for idx in sorted(results_by_index.keys()):
             results.append(results_by_index[idx])
 
-        if not completed:
+        if timed_out:
             # Log partial progress for in-flight combos
             in_flight_info: list[str] = []
             for idx in range(total):

--- a/src/karenina/benchmark/verification/stages/core/base.py
+++ b/src/karenina/benchmark/verification/stages/core/base.py
@@ -365,6 +365,7 @@ class VerificationContext:
     # Error Tracking
     error: str | None = None
     completed_without_errors: bool = True
+    is_transient_error: bool = False
 
     def set_artifact(self, key: str, value: Any) -> None:
         """Store an artifact produced by a stage."""
@@ -386,10 +387,18 @@ class VerificationContext:
         """Get a field from the result builder."""
         return self.result_builder.get(key, default)
 
-    def mark_error(self, error_message: str) -> None:
-        """Mark the context as failed with an error message."""
+    def mark_error(self, error_message: str, *, transient: bool = False) -> None:
+        """Mark the context as failed with an error message.
+
+        Args:
+            error_message: Human-readable error description.
+            transient: Whether the error is transient (retryable). Sticky: once
+                True, subsequent calls with transient=False keep it True.
+        """
         self.error = error_message
         self.completed_without_errors = False
+        if transient:
+            self.is_transient_error = True
 
 
 class VerificationStage(Protocol):

--- a/src/karenina/benchmark/verification/stages/core/orchestrator.py
+++ b/src/karenina/benchmark/verification/stages/core/orchestrator.py
@@ -9,6 +9,7 @@ import time
 from karenina.schemas.entities import Rubric
 from karenina.schemas.entities.rubric import DynamicRubric
 from karenina.schemas.verification import VerificationResult
+from karenina.utils.errors import is_retryable_error
 
 from ..pipeline.abstention_check import AbstentionCheckStage
 from ..pipeline.agentic_parse_template import AgenticParseTemplateStage
@@ -281,7 +282,7 @@ class StageOrchestrator:
                 # Stage execution failed - mark error and continue to finalize
                 error_msg = f"Stage {stage.name} raised exception: {type(e).__name__}: {e}"
                 logger.error(error_msg, exc_info=True)
-                context.mark_error(error_msg)
+                context.mark_error(error_msg, transient=is_retryable_error(e))
                 # Continue to FinalizeResultStage even on error
 
             # Update execution time after each stage so FinalizeResultStage has access to it

--- a/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
@@ -171,6 +171,7 @@ class FinalizeResultStage(BaseVerificationStage):
             template_id=context.template_id,
             completed_without_errors=context.completed_without_errors,
             error=context.error,
+            is_transient_error=context.is_transient_error,
             failed_stage=context.get_result_field(ArtifactKeys.FAILED_STAGE),
             keywords=context.keywords,
             question_text=context.question_text,

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -18,6 +18,7 @@ from karenina.benchmark.verification.utils.trace_agent_metrics import extract_ag
 from karenina.benchmark.verification.utils.trace_usage_tracker import UsageTracker
 from karenina.ports import AgentConfig, AgentPort, LLMPort, LLMResponse, Message
 from karenina.schemas.verification.model_identity import ModelIdentity
+from karenina.utils.errors import is_retryable_error
 
 from ..core.base import ArtifactKeys, BaseVerificationStage, VerificationContext
 
@@ -251,7 +252,7 @@ class GenerateAnswerStage(BaseVerificationStage):
         except Exception as e:
             error_msg = f"Failed to initialize answering model: {type(e).__name__}: {e}"
             logger.error(error_msg)
-            context.mark_error(error_msg)
+            context.mark_error(error_msg, transient=is_retryable_error(e))
             return
 
         # Step 3: Construct prompt text
@@ -329,15 +330,14 @@ class GenerateAnswerStage(BaseVerificationStage):
                     if result.raw_trace:
                         self.set_artifact_and_result(context, "response_timeout_partial", True)
                         self.set_artifact_and_result(context, ArtifactKeys.USAGE_UNAVAILABLE, True)
-                        logger.warning(
-                            "Question %s: agent timed out with partial trace (%d chars, %d turns)",
-                            context.question_id,
-                            len(result.raw_trace),
-                            result.turns,
+                        error_msg = (
+                            f"Agent timed out with partial trace ({len(result.raw_trace)} chars, {result.turns} turns)"
                         )
+                        context.mark_error(error_msg, transient=True)
+                        logger.warning("Question %s: %s", context.question_id, error_msg)
                     else:
                         error_msg = "Agent timed out with no trace messages"
-                        context.mark_error(error_msg)
+                        context.mark_error(error_msg, transient=True)
                         context.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "")
                         context.set_artifact(ArtifactKeys.RECURSION_LIMIT_REACHED, False)
                         return
@@ -418,11 +418,9 @@ class GenerateAnswerStage(BaseVerificationStage):
                 # Mark partial response if streaming timed out with some content
                 if llm_response.is_partial:
                     self.set_artifact_and_result(context, "response_timeout_partial", True)
-                    logger.warning(
-                        "Question %s: response truncated by streaming timeout (%d chars captured)",
-                        context.question_id,
-                        len(llm_response.content),
-                    )
+                    error_msg = f"Response truncated by streaming timeout ({len(llm_response.content)} chars captured)"
+                    context.mark_error(error_msg, transient=True)
+                    logger.warning("Question %s: %s", context.question_id, error_msg)
 
                 # Propagate usage_unavailable flag if present
                 if llm_response.usage_unavailable:
@@ -462,9 +460,9 @@ class GenerateAnswerStage(BaseVerificationStage):
                 f"Full traceback:\n{error_details}"
             )
 
-            # Mark as fatal error
+            # Mark error (transient classification determines if scenario retries)
             error_msg = f"Adapter call failed: {type(e).__name__}: {e}"
-            context.mark_error(error_msg)
+            context.mark_error(error_msg, transient=is_retryable_error(e))
             context.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "")
             context.set_artifact(ArtifactKeys.RECURSION_LIMIT_REACHED, False)
             return

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -16,7 +16,7 @@ from karenina.adapters import get_agent, get_llm
 from karenina.benchmark.verification.utils.llm_invocation import _construct_few_shot_prompt
 from karenina.benchmark.verification.utils.trace_agent_metrics import extract_agent_metrics_from_messages
 from karenina.benchmark.verification.utils.trace_usage_tracker import UsageTracker
-from karenina.ports import AgentConfig, AgentPort, LLMPort, Message
+from karenina.ports import AgentConfig, AgentPort, LLMPort, LLMResponse, Message
 from karenina.schemas.verification.model_identity import ModelIdentity
 
 from ..core.base import ArtifactKeys, BaseVerificationStage, VerificationContext
@@ -378,23 +378,46 @@ class GenerateAnswerStage(BaseVerificationStage):
                 # LLMPort path: Use for simple LLM calls without tools
                 assert answering_llm is not None
 
-                # Use streaming when available to capture partial output on timeout
-                if answering_llm.capabilities.supports_streaming:
-                    llm_response = answering_llm.stream_invoke(
-                        adapter_messages,
-                        timeout=context.answering_model.request_timeout,
-                    )
-                else:
-                    llm_response = answering_llm.invoke(adapter_messages)
+                # Use streaming when available to capture partial output on timeout.
+                # Zero-content streaming timeouts are retried at this level because
+                # stream_invoke handles the timeout internally (returns a partial
+                # response) rather than raising, so TRANSIENT_RETRY never sees it.
+                max_attempts = context.answering_model.max_transient_retries or 3
+                llm_response: LLMResponse | None = None
+                for attempt in range(1, max_attempts + 1):
+                    if answering_llm.capabilities.supports_streaming:
+                        llm_response = answering_llm.stream_invoke(
+                            adapter_messages,
+                            timeout=context.answering_model.request_timeout,
+                        )
+                    else:
+                        llm_response = answering_llm.invoke(adapter_messages)
+
+                    if not llm_response.is_partial or llm_response.content:
+                        break
+
+                    # Zero-content streaming timeout: retry if attempts remain
+                    if attempt < max_attempts:
+                        logger.warning(
+                            "Question %s: zero-content streaming timeout (attempt %d/%d), retrying",
+                            context.question_id,
+                            attempt,
+                            max_attempts,
+                        )
+                        continue
+
+                    # Final attempt also returned zero content
+                    self.set_artifact_and_result(context, "response_timeout_partial", True)
+                    raise TimeoutError("LLM request timed out with no content received")
+
+                assert llm_response is not None  # Loop always breaks or raises
 
                 # Format response as trace (AI message only, question is not part of the trace)
                 raw_llm_response = f"--- AI Message ---\n{llm_response.content}"
 
-                # Mark partial response if streaming timed out
+                # Mark partial response if streaming timed out with some content
                 if llm_response.is_partial:
                     self.set_artifact_and_result(context, "response_timeout_partial", True)
-                    if not llm_response.content:
-                        raise TimeoutError("LLM request timed out with no content received")
                     logger.warning(
                         "Question %s: response truncated by streaming timeout (%d chars captured)",
                         context.question_id,

--- a/src/karenina/benchmark/verification/stages/pipeline/parse_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/parse_template.py
@@ -9,6 +9,7 @@ from typing import Any
 from karenina.benchmark.verification.evaluators import TemplateEvaluator
 from karenina.benchmark.verification.utils.template_parsing_helpers import is_regex_only_template
 from karenina.schemas.entities.answer import BaseAnswer
+from karenina.utils.errors import is_retryable_error
 
 from ..core.base import ArtifactKeys, BaseVerificationStage, VerificationContext
 
@@ -196,7 +197,7 @@ class ParseTemplateStage(BaseVerificationStage):
         except Exception as e:
             error_msg = f"Failed to create TemplateEvaluator: {type(e).__name__}: {e}"
             logger.error(error_msg)
-            context.mark_error(error_msg)
+            context.mark_error(error_msg, transient=is_retryable_error(e))
             return
 
         # Store evaluator for reuse by verify stage

--- a/src/karenina/benchmark/verification/utils/task_helpers.py
+++ b/src/karenina/benchmark/verification/utils/task_helpers.py
@@ -19,6 +19,22 @@ from karenina.schemas.verification import (
 logger = logging.getLogger(__name__)
 
 
+def model_sort_key(model: Any) -> str:
+    """Return a stable string key for sorting models by identity.
+
+    Uses the model's ``id`` if available, falling back to ``model_name``,
+    then to an empty string. This groups tasks by answering model so that
+    prefix caches (KV caches) can be reused across consecutive requests.
+
+    Args:
+        model: A ModelConfig instance (or any object with ``id`` / ``model_name``).
+
+    Returns:
+        A string suitable for use as a sort key.
+    """
+    return getattr(model, "id", None) or getattr(model, "model_name", None) or ""
+
+
 def merge_rubrics_for_task(
     global_rubric: Rubric | None,
     template: FinishedTemplate,
@@ -210,3 +226,14 @@ def extract_feature_flags(config: VerificationConfig) -> dict[str, Any]:
         "agentic_rubric_strategy": getattr(config, "agentic_rubric_strategy", "individual"),
         "agentic_rubric_parallel": getattr(config, "agentic_rubric_parallel", False),
     }
+
+
+def replicate_range(count: int) -> list[int | None]:
+    """Replicate iteration matching the task queue convention.
+
+    Returns [None] for count <= 1 (no replicate numbering),
+    list[1..count] otherwise.
+    """
+    if count <= 1:
+        return [None]
+    return list(range(1, count + 1))

--- a/src/karenina/exceptions.py
+++ b/src/karenina/exceptions.py
@@ -97,7 +97,7 @@ class VerificationBatchError(KareninaError):
         message: Human-readable summary of the batch failure.
         partial_results: Mapping of question ID to its completed
             VerificationResult for questions that succeeded.
-        errors: List of (question_id, exception) pairs for questions
+        errors: List of (identifier, exception) pairs for items
             that failed during verification.
     """
 
@@ -105,7 +105,7 @@ class VerificationBatchError(KareninaError):
         self,
         message: str,
         partial_results: dict[str, VerificationResult],
-        errors: list[tuple[str, Exception]],
+        errors: list[tuple[str, BaseException]],
     ) -> None:
         super().__init__(message)
         self.partial_results = partial_results

--- a/src/karenina/scenario/manager.py
+++ b/src/karenina/scenario/manager.py
@@ -9,6 +9,7 @@ import contextlib
 import copy
 import hashlib
 import logging
+import time
 import warnings
 from collections.abc import Callable
 from typing import Any, Literal
@@ -171,24 +172,43 @@ class ScenarioManager:
                 if cache_status == "HIT":
                     logger.debug("Scenario cache hit for %s/%s", scenario.name, state.current_node)
 
-            # Run the verification pipeline for this turn
-            vr, trace_messages, parsed_answer, raw_response = self._run_turn(
-                node=node,
-                conversation_history=conversation_history,
-                answering_model=answering_model,
-                parsing_model=parsing_model,
-                config=config,
-                run_name=run_name,
-                global_rubric=global_rubric,
-                turn_index=state.turn,
-                scenario_id=scenario.name,
-                scenario_node=state.current_node,
-                scenario_path=list(path),
-                question_text_override=question_text_override,
-                cached_answer_data=cached_answer_data,
-            )
+            # Run the verification pipeline for this turn (with retry on transient errors)
+            max_turn_attempts = config.max_scenario_turn_retries
+            for turn_attempt in range(1, max_turn_attempts + 1):
+                vr, trace_messages, parsed_answer, raw_response = self._run_turn(
+                    node=node,
+                    conversation_history=conversation_history,
+                    answering_model=answering_model,
+                    parsing_model=parsing_model,
+                    config=config,
+                    run_name=run_name,
+                    global_rubric=global_rubric,
+                    turn_index=state.turn,
+                    scenario_id=scenario.name,
+                    scenario_node=state.current_node,
+                    scenario_path=list(path),
+                    question_text_override=question_text_override,
+                    cached_answer_data=cached_answer_data,
+                )
 
-            # Complete cache entry after generation
+                if vr.metadata.completed_without_errors:
+                    break
+
+                if not vr.metadata.is_transient_error:
+                    break  # permanent error, no retry
+
+                if turn_attempt < max_turn_attempts:
+                    logger.warning(
+                        "Scenario %s, node %s: transient pipeline error on attempt %d/%d, retrying: %s",
+                        scenario.name,
+                        state.current_node,
+                        turn_attempt,
+                        max_turn_attempts,
+                        vr.metadata.error,
+                    )
+                    time.sleep(1)
+
+            # Complete cache entry after final attempt
             if answer_cache is not None and cache_key is not None and cached_answer_data is None:
                 from karenina.benchmark.verification.utils.cache_helpers import extract_answer_data_from_result
 

--- a/src/karenina/schemas/config/models.py
+++ b/src/karenina/schemas/config/models.py
@@ -584,6 +584,11 @@ class ModelConfig(BaseModel):
     # Typically set by the pipeline from VerificationConfig.request_timeout.
     # None means use the provider SDK default (no timeout).
     request_timeout: float | None = None
+    # Maximum retry attempts for transient LLM errors (timeouts, connection errors,
+    # rate limits). Controls the tenacity TRANSIENT_RETRY decorator.
+    # None means use the default (3 attempts). Typically stamped by the pipeline
+    # from VerificationConfig.max_transient_retries.
+    max_transient_retries: int | None = None
 
     @model_validator(mode="after")
     def validate_manual_interface(self) -> "ModelConfig":

--- a/src/karenina/schemas/verification/config.py
+++ b/src/karenina/schemas/verification/config.py
@@ -303,6 +303,16 @@ class VerificationConfig(BaseModel):
         "IN_PROGRESS cache loop before generating the answer fresh.",
     )
 
+    max_scenario_turn_retries: int = Field(
+        default=2,
+        ge=1,
+        description=(
+            "Maximum attempts for a scenario turn that fails with a transient "
+            "error. Each attempt runs the full verification pipeline. Separate "
+            "from max_transient_retries (which controls per-LLM-call retries)."
+        ),
+    )
+
     def __init__(self, **data: Any) -> None:
         """
         Initialize with environment variable support and default system prompts.

--- a/src/karenina/schemas/verification/config.py
+++ b/src/karenina/schemas/verification/config.py
@@ -280,6 +280,20 @@ class VerificationConfig(BaseModel):
             raise TypeError(f"db_config must be a DBConfig instance or None, got {type(v).__name__}")
         return v
 
+    # Retry settings for transient errors and executor requeue
+    max_transient_retries: int = Field(
+        default=3,
+        ge=1,
+        description="Maximum retry attempts for transient LLM errors (timeouts, "
+        "connection errors, rate limits). Controls TRANSIENT_RETRY behavior.",
+    )
+    max_requeue_count: int = Field(
+        default=5,
+        ge=1,
+        description="Maximum times a task can be requeued in the parallel executor's "
+        "IN_PROGRESS cache loop before generating the answer fresh.",
+    )
+
     def __init__(self, **data: Any) -> None:
         """
         Initialize with environment variable support and default system prompts.

--- a/src/karenina/schemas/verification/config.py
+++ b/src/karenina/schemas/verification/config.py
@@ -142,6 +142,15 @@ class VerificationConfig(BaseModel):
         "Set to 16-64 for self-hosted inference servers (vLLM, SGLang).",
     )
 
+    # Task ordering strategy for queue generation
+    task_ordering: Literal["prefix_cache", "generation_order", "random"] = Field(
+        default="prefix_cache",
+        description="Task queue ordering strategy. "
+        "'prefix_cache' (default) groups by answering model for KV cache hits. "
+        "'generation_order' preserves template-first loop order. "
+        "'random' shuffles tasks.",
+    )
+
     # Deep-judgment settings (multi-stage parsing with excerpts and reasoning)
     deep_judgment_mode: Literal["disabled", "reasoning_only", "full"] = "disabled"  # Template deep-judgment mode
     deep_judgment_max_excerpts_per_attribute: int = DEFAULT_DEEP_JUDGMENT_MAX_EXCERPTS  # Max excerpts per attribute

--- a/src/karenina/schemas/verification/result_components.py
+++ b/src/karenina/schemas/verification/result_components.py
@@ -18,6 +18,7 @@ class VerificationResultMetadata(BaseModel):
     )  # MD5 of template or "no_template" (composite key component)
     completed_without_errors: bool = Field(default=..., json_schema_extra={"index": True})
     error: str | None = None
+    is_transient_error: bool = False
     failed_stage: str | None = None  # Stage name of the first guard that caused an auto-fail
     question_text: str
     raw_answer: str | None = None  # Ground truth answer from checkpoint

--- a/src/karenina/utils/answer_cache.py
+++ b/src/karenina/utils/answer_cache.py
@@ -180,6 +180,21 @@ class AnswerTraceCache:
             self._stats_timeouts += 1
         return completed
 
+    def force_reset(self, key: str) -> None:
+        """Remove a cache entry, allowing fresh generation on next access.
+
+        Used by the executor when the requeue limit is exceeded for an
+        IN_PROGRESS entry. The next call to get_or_reserve for this key
+        will return MISS.
+
+        Args:
+            key: Cache key to remove.
+        """
+        with self._lock:
+            if key in self._cache:
+                del self._cache[key]
+                logger.debug("Force-reset cache entry: %s", key)
+
     def get_stats(self) -> dict[str, int]:
         """Get cache statistics.
 

--- a/src/karenina/utils/errors.py
+++ b/src/karenina/utils/errors.py
@@ -47,6 +47,8 @@ def is_retryable_error(exception: BaseException) -> bool:
         "network",
         "temporary failure",
         "overloaded",
+        "event loop",
+        "portal",
     ]
 
     if any(keyword in exception_str for keyword in transient_keywords):

--- a/tests/unit/adapters/langchain/test_llm_adapter.py
+++ b/tests/unit/adapters/langchain/test_llm_adapter.py
@@ -13,6 +13,59 @@ from pydantic import BaseModel
 
 from karenina.adapters.langchain import LangChainLLMAdapter
 from karenina.ports import Message
+from karenina.schemas.config import ModelConfig
+
+
+@pytest.mark.unit
+class TestSDKRetrySuppression:
+    """Tests for SDK max_retries=0."""
+
+    def test_initialize_model_passes_max_retries_zero(self) -> None:
+        """Test that _initialize_model passes max_retries=0 to suppress SDK retries."""
+        config = ModelConfig(
+            id="test",
+            model_name="test-model",
+            model_provider="openai",
+            interface="langchain",
+        )
+        with patch("karenina.adapters.langchain.initialization.init_chat_model") as mock_init:
+            mock_init.return_value = MagicMock()
+            LangChainLLMAdapter(config)
+            _, kwargs = mock_init.call_args
+            assert kwargs.get("max_retries") == 0
+
+
+@pytest.mark.unit
+class TestConfigurableTransientRetry:
+    """Tests for configurable max_transient_retries."""
+
+    def test_default_uses_singleton(self) -> None:
+        """Test that default config (None) uses the TRANSIENT_RETRY singleton."""
+        config = ModelConfig(
+            id="test",
+            model_name="test-model",
+            model_provider="openai",
+            interface="langchain",
+        )
+        with patch("karenina.adapters.langchain.initialization.init_chat_model") as mock_init:
+            mock_init.return_value = MagicMock()
+            adapter = LangChainLLMAdapter(config)
+            # None means use the default singleton
+            assert adapter._max_transient_retries is None
+
+    def test_custom_value_stored(self) -> None:
+        """Test that custom max_transient_retries is stored on adapter."""
+        config = ModelConfig(
+            id="test",
+            model_name="test-model",
+            model_provider="openai",
+            interface="langchain",
+            max_transient_retries=1,
+        )
+        with patch("karenina.adapters.langchain.initialization.init_chat_model") as mock_init:
+            mock_init.return_value = MagicMock()
+            adapter = LangChainLLMAdapter(config)
+            assert adapter._max_transient_retries == 1
 
 
 class TestLangChainLLMAdapter:

--- a/tests/unit/adapters/langchain/test_parser_adapter.py
+++ b/tests/unit/adapters/langchain/test_parser_adapter.py
@@ -1,17 +1,25 @@
 """Tests for LangChainParserAdapter.
 
-Tests structured output parsing.
+Tests structured output parsing and transient error propagation.
 """
 
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel
 
 from karenina.adapters.langchain import LangChainParserAdapter
+from karenina.ports import LLMResponse, Message, UsageMetadata
+
+
+class SimpleSchema(BaseModel):
+    """Simple schema used across test classes."""
+
+    name: str
+    value: int
 
 
 class TestLangChainParserAdapter:
@@ -95,3 +103,138 @@ class TestLangChainParserAdapter:
             result = parser._parse_response_content(content, SimpleSchema)
 
             assert result.name == "test"
+
+
+@pytest.mark.unit
+class TestTransientErrorPropagation:
+    """Tests for transient error propagation in parser strategies."""
+
+    @pytest.fixture
+    def model_config(self) -> Any:
+        """Create a mock ModelConfig."""
+        from karenina.schemas.config import ModelConfig
+
+        return ModelConfig(
+            id="test-parser",
+            model_name="claude-sonnet-4-20250514",
+            model_provider="anthropic",
+            interface="langchain",
+        )
+
+    @pytest.fixture
+    def parser(self, model_config: Any) -> LangChainParserAdapter:
+        """Create a parser with mocked LLM initialization."""
+        with patch("karenina.adapters.langchain.initialization.init_chat_model") as mock_init:
+            mock_init.return_value = MagicMock()
+            return LangChainParserAdapter(model_config)
+
+    @pytest.fixture
+    def messages(self) -> list[Message]:
+        """Create sample messages for parsing."""
+        return [
+            Message.system("Parse the following into JSON."),
+            Message.user('The name is "test" and the value is 42.'),
+        ]
+
+    async def test_strategy1_transient_error_propagates(
+        self, parser: LangChainParserAdapter, messages: list[Message]
+    ) -> None:
+        """Transient error in Strategy 1 re-raises without trying Strategy 2."""
+        # Make with_structured_output return an adapter whose ainvoke raises TimeoutError
+        mock_structured = MagicMock()
+        mock_structured.ainvoke = AsyncMock(side_effect=TimeoutError("connection timed out"))
+        parser._llm_adapter.with_structured_output = MagicMock(return_value=mock_structured)
+
+        # Strategy 2's ainvoke should NOT be called
+        parser._llm_adapter.ainvoke = AsyncMock(side_effect=AssertionError("Strategy 2 should not be reached"))
+
+        with pytest.raises(TimeoutError, match="connection timed out"):
+            await parser.aparse_to_pydantic(messages, SimpleSchema)
+
+        # Confirm Strategy 1 was attempted exactly once
+        mock_structured.ainvoke.assert_called_once()
+        # Confirm Strategy 2 was NOT attempted
+        parser._llm_adapter.ainvoke.assert_not_called()
+
+    async def test_strategy1_parse_error_falls_through_to_strategy2(
+        self, parser: LangChainParserAdapter, messages: list[Message]
+    ) -> None:
+        """Parse error in Strategy 1 falls through to Strategy 2."""
+        # Strategy 1: structured output raises a non-transient parse error
+        mock_structured = MagicMock()
+        mock_structured.ainvoke = AsyncMock(side_effect=ValueError("invalid JSON"))
+        parser._llm_adapter.with_structured_output = MagicMock(return_value=mock_structured)
+
+        # Strategy 2: regular ainvoke returns valid JSON
+        strategy2_response = LLMResponse(
+            content='{"name": "test", "value": 42}',
+            raw='{"name": "test", "value": 42}',
+            usage=UsageMetadata(input_tokens=10, output_tokens=5, total_tokens=15),
+        )
+        parser._llm_adapter.ainvoke = AsyncMock(return_value=strategy2_response)
+
+        result = await parser.aparse_to_pydantic(messages, SimpleSchema)
+
+        # Both strategies were tried
+        mock_structured.ainvoke.assert_called_once()
+        parser._llm_adapter.ainvoke.assert_called_once()
+        assert result.parsed.name == "test"
+        assert result.parsed.value == 42
+
+    async def test_retry_with_null_feedback_propagates_transient_error(
+        self, parser: LangChainParserAdapter, messages: list[Message]
+    ) -> None:
+        """_retry_with_null_feedback re-raises transient errors."""
+        # Mock ainvoke to raise a transient error
+        parser._llm_adapter.ainvoke = AsyncMock(side_effect=ConnectionError("connection reset by peer"))
+
+        # Craft an error whose string contains embedded JSON with null values,
+        # so _extract_null_fields_from_error finds null fields and the method
+        # proceeds to the LLM call (where our ConnectionError mock fires).
+        fake_error = ValueError('Failed to parse from completion {"name": null, "value": 42}. Error details.')
+
+        with pytest.raises(ConnectionError, match="connection reset by peer"):
+            await parser._retry_with_null_feedback(
+                original_messages=messages,
+                failed_response='{"name": null, "value": 42}',
+                error=fake_error,
+                schema=SimpleSchema,
+            )
+
+    async def test_retry_with_format_feedback_propagates_transient_error(
+        self, parser: LangChainParserAdapter, messages: list[Message]
+    ) -> None:
+        """_retry_with_format_feedback re-raises transient errors."""
+        from karenina.ports import ParseError
+
+        # Mock ainvoke to raise a transient error
+        parser._llm_adapter.ainvoke = AsyncMock(side_effect=TimeoutError("read timed out"))
+
+        # Create a JSON-format-related error so the method does not bail early
+        fake_error = ParseError("Invalid JSON output: expecting value")
+
+        with pytest.raises(TimeoutError, match="read timed out"):
+            await parser._retry_with_format_feedback(
+                original_messages=messages,
+                failed_response="This is not JSON at all, just plain text",
+                error=fake_error,
+                schema=SimpleSchema,
+            )
+
+    def test_parser_forwards_max_transient_retries_to_llm_adapter(self) -> None:
+        """Parser passes max_transient_retries from ModelConfig to its LLM adapter."""
+        from karenina.schemas.config import ModelConfig
+
+        config = ModelConfig(
+            id="test-retry-config",
+            model_name="claude-sonnet-4-20250514",
+            model_provider="anthropic",
+            interface="langchain",
+            max_transient_retries=2,
+        )
+
+        with patch("karenina.adapters.langchain.initialization.init_chat_model") as mock_init:
+            mock_init.return_value = MagicMock()
+            parser = LangChainParserAdapter(config)
+
+            assert parser._llm_adapter._max_transient_retries == 2

--- a/tests/unit/benchmark/test_benchmark_scenario_ordering.py
+++ b/tests/unit/benchmark/test_benchmark_scenario_ordering.py
@@ -1,0 +1,134 @@
+"""Test scenario combo ordering follows task_ordering config."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from karenina.benchmark.verification.utils.task_helpers import model_sort_key
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification import VerificationConfig
+
+
+def _make_model(model_id: str, model_name: str | None = None) -> ModelConfig:
+    """Create a ModelConfig with the given id and optional model_name."""
+    return ModelConfig(
+        id=model_id,
+        model_provider="anthropic",
+        model_name=model_name or model_id,
+        temperature=0.0,
+    )
+
+
+@pytest.mark.unit
+class TestScenarioComboOrdering:
+    """Verify that scenario combos respect the task_ordering config."""
+
+    def test_prefix_cache_groups_by_answering_model(self) -> None:
+        """Combos sorted with prefix_cache put all model-a combos before model-b."""
+        model_a = _make_model("model-a")
+        model_b = _make_model("model-b")
+
+        config = VerificationConfig(
+            answering_models=[model_b, model_a],  # intentionally reversed
+            parsing_models=[model_a],
+            task_ordering="prefix_cache",
+        )
+
+        # Three mock scenarios with .name attributes
+        scenarios = []
+        for name in ["scenario-z", "scenario-a", "scenario-m"]:
+            s = MagicMock()
+            s.name = name
+            scenarios.append(s)
+
+        # Build combos the same way benchmark.py does
+        combos = [
+            (scenario_def, ans_model, parse_model)
+            for scenario_def in scenarios
+            for ans_model in config.answering_models
+            for parse_model in config.parsing_models
+        ]
+
+        # Apply prefix_cache sort (same logic as in benchmark.py)
+        combos.sort(
+            key=lambda c: (
+                model_sort_key(c[1]),  # answering_model
+                c[0].name,  # scenario name
+                model_sort_key(c[2]),  # parsing_model
+            )
+        )
+
+        answering_ids = [c[1].id for c in combos]
+
+        # All model-a combos must come before all model-b combos
+        first_b = answering_ids.index("model-b")
+        last_a = len(answering_ids) - 1 - answering_ids[::-1].index("model-a")
+        assert last_a < first_b, (
+            f"Expected all model-a combos before model-b, "
+            f"but last model-a at index {last_a} and first model-b at index {first_b}"
+        )
+
+    def test_prefix_cache_sorts_scenarios_within_model_group(self) -> None:
+        """Within a model group, scenarios are sorted alphabetically by name."""
+        model_a = _make_model("model-a")
+
+        config = VerificationConfig(
+            answering_models=[model_a],
+            parsing_models=[model_a],
+            task_ordering="prefix_cache",
+        )
+
+        scenarios = []
+        for name in ["zeta", "alpha", "mu"]:
+            s = MagicMock()
+            s.name = name
+            scenarios.append(s)
+
+        combos = [
+            (scenario_def, ans_model, parse_model)
+            for scenario_def in scenarios
+            for ans_model in config.answering_models
+            for parse_model in config.parsing_models
+        ]
+
+        combos.sort(
+            key=lambda c: (
+                model_sort_key(c[1]),
+                c[0].name,
+                model_sort_key(c[2]),
+            )
+        )
+
+        scenario_names = [c[0].name for c in combos]
+        assert scenario_names == ["alpha", "mu", "zeta"]
+
+    def test_generation_order_preserves_original_order(self) -> None:
+        """With generation_order, combos stay in the original list comprehension order."""
+        model_b = _make_model("model-b")
+        model_a = _make_model("model-a")
+
+        config = VerificationConfig(
+            answering_models=[model_b, model_a],
+            parsing_models=[model_a],
+            task_ordering="generation_order",
+        )
+
+        scenarios = []
+        for name in ["s1", "s2"]:
+            s = MagicMock()
+            s.name = name
+            scenarios.append(s)
+
+        combos = [
+            (scenario_def, ans_model, parse_model)
+            for scenario_def in scenarios
+            for ans_model in config.answering_models
+            for parse_model in config.parsing_models
+        ]
+
+        original_order = list(combos)
+
+        # generation_order is a no-op; do nothing
+        # (matches the benchmark.py code path)
+
+        assert combos == original_order

--- a/tests/unit/benchmark/verification/stages/core/test_context_transient.py
+++ b/tests/unit/benchmark/verification/stages/core/test_context_transient.py
@@ -1,0 +1,57 @@
+"""Tests for VerificationContext transient error flag."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import VerificationContext
+from karenina.schemas.config import ModelConfig
+
+
+def _make_context() -> VerificationContext:
+    """Create a minimal VerificationContext for testing."""
+    model = ModelConfig(id="test", model_name="test-model")
+    return VerificationContext(
+        question_id="q1",
+        question_text="What?",
+        raw_answer="Y",
+        template_code="class Answer: pass",
+        answering_model=model,
+        parsing_model=model,
+        template_id="tpl1",
+    )
+
+
+@pytest.mark.unit
+class TestVerificationContextTransientFlag:
+    def test_default_is_transient_false(self) -> None:
+        ctx = _make_context()
+        assert ctx.is_transient_error is False
+
+    def test_mark_error_default_not_transient(self) -> None:
+        ctx = _make_context()
+        ctx.mark_error("something broke")
+        assert ctx.is_transient_error is False
+        assert ctx.completed_without_errors is False
+
+    def test_mark_error_transient_true(self) -> None:
+        ctx = _make_context()
+        ctx.mark_error("timeout", transient=True)
+        assert ctx.is_transient_error is True
+        assert ctx.completed_without_errors is False
+
+    def test_mark_error_transient_sticky(self) -> None:
+        """Once is_transient_error is True, a subsequent non-transient mark_error keeps it True."""
+        ctx = _make_context()
+        ctx.mark_error("connection error", transient=True)
+        assert ctx.is_transient_error is True
+
+        ctx.mark_error("permanent error", transient=False)
+        assert ctx.is_transient_error is True
+
+    def test_mark_error_sets_error_and_completed(self) -> None:
+        """Existing behavior: mark_error sets error string and completed_without_errors=False."""
+        ctx = _make_context()
+        ctx.mark_error("test error")
+        assert ctx.error == "test error"
+        assert ctx.completed_without_errors is False

--- a/tests/unit/benchmark/verification/stages/core/test_orchestrator_transient.py
+++ b/tests/unit/benchmark/verification/stages/core/test_orchestrator_transient.py
@@ -1,0 +1,106 @@
+"""Tests for StageOrchestrator transient error classification."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import (
+    BaseVerificationStage,
+    VerificationContext,
+)
+from karenina.benchmark.verification.stages.core.orchestrator import StageOrchestrator
+from karenina.schemas.config import ModelConfig
+
+
+def _make_context() -> VerificationContext:
+    model = ModelConfig(id="test", model_name="test-model")
+    return VerificationContext(
+        question_id="q1",
+        question_text="What?",
+        raw_answer="Y",
+        template_code="class Answer: pass",
+        answering_model=model,
+        parsing_model=model,
+        template_id="tpl1",
+    )
+
+
+class _RaisingStage(BaseVerificationStage):
+    """Test stage that raises a given exception."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    @property
+    def name(self) -> str:
+        return "raising_stage"
+
+    def execute(self, context: VerificationContext) -> None:  # noqa: ARG002
+        raise self._exc
+
+
+class _FinalizeStub(BaseVerificationStage):
+    """Stub finalize stage that always runs and stores a minimal result."""
+
+    @property
+    def name(self) -> str:
+        return "FinalizeResultStage"
+
+    def should_run(self, context: VerificationContext) -> bool:  # noqa: ARG002
+        return True  # Always runs
+
+    def execute(self, context: VerificationContext) -> None:
+        from karenina.benchmark.verification.stages.core.base import ArtifactKeys
+        from karenina.schemas.verification import VerificationResult
+        from karenina.schemas.verification.model_identity import ModelIdentity
+        from karenina.schemas.verification.result_components import (
+            VerificationResultDeepJudgment,
+            VerificationResultDeepJudgmentRubric,
+            VerificationResultMetadata,
+            VerificationResultRubric,
+            VerificationResultTemplate,
+        )
+
+        identity = ModelIdentity(model_name="test", interface="openai")
+        metadata = VerificationResultMetadata(
+            question_id=context.question_id,
+            template_id=context.template_id,
+            completed_without_errors=context.completed_without_errors,
+            error=context.error,
+            is_transient_error=context.is_transient_error,
+            question_text=context.question_text,
+            answering=identity,
+            parsing=identity,
+            execution_time=0.0,
+            timestamp="2026-01-01T00:00:00Z",
+            result_id="abcdef1234567890",
+        )
+        vr = VerificationResult(
+            metadata=metadata,
+            template=VerificationResultTemplate(),
+            rubric=VerificationResultRubric(),
+            deep_judgment=VerificationResultDeepJudgment(),
+            deep_judgment_rubric=VerificationResultDeepJudgmentRubric(),
+        )
+        context.set_artifact(ArtifactKeys.FINAL_RESULT, vr)
+
+
+@pytest.mark.unit
+class TestOrchestratorTransientErrorClassification:
+    def test_connection_error_marks_transient(self) -> None:
+        ctx = _make_context()
+        orchestrator = StageOrchestrator(stages=[_RaisingStage(ConnectionError("connection refused")), _FinalizeStub()])
+        orchestrator.execute(ctx)
+        assert ctx.is_transient_error is True
+
+    def test_value_error_marks_non_transient(self) -> None:
+        ctx = _make_context()
+        orchestrator = StageOrchestrator(stages=[_RaisingStage(ValueError("bad value")), _FinalizeStub()])
+        orchestrator.execute(ctx)
+        assert ctx.is_transient_error is False
+
+    def test_timeout_error_marks_transient(self) -> None:
+        ctx = _make_context()
+        orchestrator = StageOrchestrator(stages=[_RaisingStage(TimeoutError("request timed out")), _FinalizeStub()])
+        orchestrator.execute(ctx)
+        assert ctx.is_transient_error is True

--- a/tests/unit/benchmark/verification/stages/test_finalize_transient.py
+++ b/tests/unit/benchmark/verification/stages/test_finalize_transient.py
@@ -1,0 +1,53 @@
+"""Tests for FinalizeResultStage transient flag propagation."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import VerificationContext
+from karenina.benchmark.verification.stages.pipeline.finalize_result import FinalizeResultStage
+from karenina.schemas.config import ModelConfig
+
+
+def _make_context(*, is_transient: bool = False) -> VerificationContext:
+    """Create a minimal VerificationContext with error and transient state."""
+    model = ModelConfig(id="test", model_name="test-model")
+    ctx = VerificationContext(
+        question_id="q1",
+        question_text="What?",
+        raw_answer="Y",
+        template_code="class Answer: pass",
+        answering_model=model,
+        parsing_model=model,
+        template_id="tpl1",
+    )
+    if is_transient:
+        ctx.mark_error("connection timeout", transient=True)
+    else:
+        ctx.mark_error("permanent failure")
+    return ctx
+
+
+@pytest.mark.unit
+class TestFinalizeResultTransientFlag:
+    def test_transient_flag_copied_to_metadata(self) -> None:
+        ctx = _make_context(is_transient=True)
+        stage = FinalizeResultStage()
+        stage.execute(ctx)
+
+        from karenina.benchmark.verification.stages.core.base import ArtifactKeys
+
+        vr = ctx.get_artifact(ArtifactKeys.FINAL_RESULT)
+        assert vr is not None
+        assert vr.metadata.is_transient_error is True
+
+    def test_non_transient_flag_copied_to_metadata(self) -> None:
+        ctx = _make_context(is_transient=False)
+        stage = FinalizeResultStage()
+        stage.execute(ctx)
+
+        from karenina.benchmark.verification.stages.core.base import ArtifactKeys
+
+        vr = ctx.get_artifact(ArtifactKeys.FINAL_RESULT)
+        assert vr is not None
+        assert vr.metadata.is_transient_error is False

--- a/tests/unit/benchmark/verification/stages/test_generate_answer_streaming.py
+++ b/tests/unit/benchmark/verification/stages/test_generate_answer_streaming.py
@@ -103,6 +103,11 @@ class TestStreamingLLMPath:
         # Raw response should still be captured
         assert "partial content here" in ctx.get_artifact(ArtifactKeys.RAW_LLM_RESPONSE)
 
+        # Partial timeout is an error (transient)
+        assert ctx.completed_without_errors is False
+        assert ctx.is_transient_error is True
+        assert "streaming timeout" in ctx.error.lower()
+
     def test_streaming_no_content_raises_timeout_error(self) -> None:
         """When stream_invoke returns partial with empty content, a TimeoutError
         should propagate and mark_error on the context."""
@@ -244,7 +249,8 @@ class TestAgentTimeoutPath:
 
     def test_agent_timeout_with_trace_sets_partial_and_usage_unavailable(self) -> None:
         """When agent times out but has a partial trace, RESPONSE_TIMEOUT_PARTIAL
-        and USAGE_UNAVAILABLE should be set, and the trace should be stored."""
+        and USAGE_UNAVAILABLE should be set, the trace stored, and the context
+        marked as an error (transient timeout)."""
         ctx = _make_context()
         result = _make_agent_result(
             timeout_reached=True,
@@ -264,8 +270,10 @@ class TestAgentTimeoutPath:
         raw = ctx.get_artifact(ArtifactKeys.RAW_LLM_RESPONSE)
         assert "Partial response from agent" in raw
 
-        # Pipeline should continue (no error)
-        assert ctx.error is None
+        # Partial timeout is an error (transient)
+        assert ctx.completed_without_errors is False
+        assert ctx.is_transient_error is True
+        assert "timed out" in ctx.error.lower()
 
     def test_agent_timeout_with_no_trace_marks_error(self) -> None:
         """When agent times out with no trace at all, the context should be

--- a/tests/unit/benchmark/verification/stages/test_generate_answer_transient.py
+++ b/tests/unit/benchmark/verification/stages/test_generate_answer_transient.py
@@ -1,0 +1,76 @@
+"""Tests for GenerateAnswerStage transient error classification."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import VerificationContext
+from karenina.benchmark.verification.stages.pipeline.generate_answer import GenerateAnswerStage
+from karenina.schemas.config import ModelConfig
+
+
+def _make_context() -> VerificationContext:
+    model = ModelConfig(
+        id="test",
+        model_name="test-model",
+        interface="openai_endpoint",
+        endpoint_base_url="http://localhost:8000",
+        endpoint_api_key="EMPTY",
+    )
+    ctx = VerificationContext(
+        question_id="q1",
+        question_text="What is 2+2?",
+        raw_answer="4",
+        template_code="class Answer: pass",
+        answering_model=model,
+        parsing_model=model,
+        template_id="tpl1",
+    )
+    return ctx
+
+
+@pytest.mark.unit
+class TestGenerateAnswerTransientClassification:
+    @patch("karenina.benchmark.verification.stages.pipeline.generate_answer.get_llm")
+    def test_adapter_init_connection_error_transient(self, mock_get_llm: MagicMock) -> None:
+        """When get_llm() raises ConnectionError, context.is_transient_error should be True."""
+        mock_get_llm.side_effect = ConnectionError("connection refused")
+
+        ctx = _make_context()
+        stage = GenerateAnswerStage()
+        stage.execute(ctx)
+
+        assert ctx.completed_without_errors is False
+        assert ctx.is_transient_error is True
+
+    @patch("karenina.benchmark.verification.stages.pipeline.generate_answer.get_llm")
+    def test_adapter_call_connection_error_transient(self, mock_get_llm: MagicMock) -> None:
+        """When llm.stream_invoke() raises ConnectionError, context.is_transient_error should be True."""
+        mock_llm = MagicMock()
+        mock_llm.capabilities = MagicMock(supports_streaming=True)
+        mock_llm.stream_invoke.side_effect = ConnectionError("connection reset")
+        mock_get_llm.return_value = mock_llm
+
+        ctx = _make_context()
+        stage = GenerateAnswerStage()
+        stage.execute(ctx)
+
+        assert ctx.completed_without_errors is False
+        assert ctx.is_transient_error is True
+
+    @patch("karenina.benchmark.verification.stages.pipeline.generate_answer.get_llm")
+    def test_adapter_call_value_error_not_transient(self, mock_get_llm: MagicMock) -> None:
+        """When llm.stream_invoke() raises ValueError, context.is_transient_error should be False."""
+        mock_llm = MagicMock()
+        mock_llm.capabilities = MagicMock(supports_streaming=True)
+        mock_llm.stream_invoke.side_effect = ValueError("invalid prompt")
+        mock_get_llm.return_value = mock_llm
+
+        ctx = _make_context()
+        stage = GenerateAnswerStage()
+        stage.execute(ctx)
+
+        assert ctx.completed_without_errors is False
+        assert ctx.is_transient_error is False

--- a/tests/unit/benchmark/verification/test_batch_runner.py
+++ b/tests/unit/benchmark/verification/test_batch_runner.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from karenina.benchmark.verification.batch_runner import generate_task_queue, run_verification_batch
+from karenina.benchmark.verification.batch_runner import (
+    _apply_retry_config,
+    generate_task_queue,
+    run_verification_batch,
+)
 from karenina.schemas.config import ModelConfig
 from karenina.schemas.verification import FinishedTemplate, VerificationConfig
 
@@ -116,3 +120,37 @@ class TestParsingOnlyGuard:
         # Should not raise (we don't run the full pipeline, just check no guard fires)
         tasks = generate_task_queue(templates, config)
         assert len(tasks) == 1
+
+
+# =============================================================================
+# _apply_retry_config
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestApplyRetryConfig:
+    """Tests for _apply_retry_config function."""
+
+    def test_stamps_when_model_has_no_value(self) -> None:
+        """Test that pipeline value is stamped when model has None."""
+        model = ModelConfig(id="test", model_name="test", model_provider="openai")
+        result = _apply_retry_config(model, max_transient_retries=2)
+        assert result.max_transient_retries == 2
+
+    def test_preserves_existing_model_value(self) -> None:
+        """Test that model-level value is not overwritten."""
+        model = ModelConfig(
+            id="test",
+            model_name="test",
+            model_provider="openai",
+            max_transient_retries=1,
+        )
+        result = _apply_retry_config(model, max_transient_retries=5)
+        assert result.max_transient_retries == 1
+
+    def test_noop_when_pipeline_value_is_none(self) -> None:
+        """Test that None pipeline value does not stamp."""
+        model = ModelConfig(id="test", model_name="test", model_provider="openai")
+        result = _apply_retry_config(model, max_transient_retries=None)
+        assert result.max_transient_retries is None
+        assert result is model  # Same object, no copy

--- a/tests/unit/benchmark/verification/test_executor.py
+++ b/tests/unit/benchmark/verification/test_executor.py
@@ -615,8 +615,5 @@ class TestPerWorkerPortals:
         # All 6 tasks completed
         assert len(results) == 6
 
-        # 6 distinct portals were created (one per task, not per worker)
-        distinct_portal_ids = set(portal_ids)
-        assert len(distinct_portal_ids) == 6, (
-            f"Expected 6 distinct portals (one per task), got {len(distinct_portal_ids)}: {len(portal_ids)} total calls"
-        )
+        # 6 portal creations (one per task, not per worker)
+        assert len(portal_ids) == 6, f"Expected 6 portal creations (one per task), got {len(portal_ids)}"

--- a/tests/unit/benchmark/verification/test_executor.py
+++ b/tests/unit/benchmark/verification/test_executor.py
@@ -504,3 +504,48 @@ class TestSequentialPortalManagement:
         executor.run_batch(tasks)
 
         assert async_results == ["ok"]
+
+
+# ============================================================================
+# Executor requeue bound (issue 188)
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestExecutorRequeueBound:
+    """Tests for max_requeue_count in ExecutorConfig."""
+
+    def test_executor_config_default_requeue_count(self) -> None:
+        """Test ExecutorConfig has max_requeue_count defaulting to 5."""
+        config = ExecutorConfig()
+        assert config.max_requeue_count == 5
+
+    def test_executor_config_custom_requeue_count(self) -> None:
+        """Test ExecutorConfig accepts custom max_requeue_count."""
+        config = ExecutorConfig(max_requeue_count=10)
+        assert config.max_requeue_count == 10
+
+
+@pytest.mark.unit
+class TestForceResetOnRequeueLimit:
+    """Tests for force_reset behavior when requeue limit is reached."""
+
+    def test_cache_force_reset_after_max_requeues(self) -> None:
+        """Test that exceeding max_requeue_count triggers force_reset."""
+        from karenina.utils.answer_cache import AnswerTraceCache
+
+        cache = AnswerTraceCache()
+        max_requeue = 3
+
+        # Simulate: key reserved by another worker
+        cache.get_or_reserve("key1")
+
+        # Simulate requeue loop hitting the limit
+        for _i in range(max_requeue):
+            status, _ = cache.get_or_reserve("key1")
+            assert status == "IN_PROGRESS"
+
+        # After limit: force_reset should make next access return MISS
+        cache.force_reset("key1")
+        status, _ = cache.get_or_reserve("key1")
+        assert status == "MISS"

--- a/tests/unit/benchmark/verification/test_executor.py
+++ b/tests/unit/benchmark/verification/test_executor.py
@@ -561,30 +561,29 @@ class TestForceResetOnRequeueLimit:
 
 @pytest.mark.unit
 class TestPerWorkerPortals:
-    """Each submitted task creates its own distinct BlockingPortal."""
+    """Each worker thread creates one portal, reused across tasks."""
 
-    def test_parallel_tasks_create_distinct_portals(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """With 6 tasks and 2 workers, 6 distinct portal ids are observed (one per task).
+    def test_parallel_workers_create_portals(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With 6 tasks and 2 workers, 2 portals are created (one per worker).
 
-        Uses different task and worker counts to distinguish portal-per-task
-        from portal-per-worker behavior.
+        Each worker lazily creates a portal on its first task and reuses it
+        for subsequent tasks. This preserves connection pools.
         """
-        portal_ids: list[int] = []
+        portal_count = [0]
         portal_lock = threading.Lock()
 
         from anyio.from_thread import start_blocking_portal as original_start_blocking_portal
 
         class PortalTracker:
-            """Context manager that wraps start_blocking_portal to track portal identity."""
+            """Context manager that wraps start_blocking_portal to count creations."""
 
             def __init__(self) -> None:
                 self._real_cm = original_start_blocking_portal(backend="asyncio")
+                with portal_lock:
+                    portal_count[0] += 1
 
             def __enter__(self):
-                portal = self._real_cm.__enter__()
-                with portal_lock:
-                    portal_ids.append(id(portal))
-                return portal
+                return self._real_cm.__enter__()
 
             def __exit__(self, *args):
                 return self._real_cm.__exit__(*args)
@@ -615,5 +614,5 @@ class TestPerWorkerPortals:
         # All 6 tasks completed
         assert len(results) == 6
 
-        # 6 portal creations (one per task, not per worker)
-        assert len(portal_ids) == 6, f"Expected 6 portal creations (one per task), got {len(portal_ids)}"
+        # 2 portal creations (one per worker, reused across tasks)
+        assert portal_count[0] == 2, f"Expected 2 portal creations (one per worker), got {portal_count[0]}"

--- a/tests/unit/benchmark/verification/test_executor.py
+++ b/tests/unit/benchmark/verification/test_executor.py
@@ -6,7 +6,10 @@ Tests verify:
 - Parallel mode: counts failures toward completion (no deadlock), raises aggregate error
 - Both modes raise the same error type with equivalent information (symmetry)
 - Timeout safety net prevents indefinite hangs
+- Per-worker portal creation (each worker gets its own BlockingPortal)
 """
+
+import threading
 
 import pytest
 
@@ -549,3 +552,70 @@ class TestForceResetOnRequeueLimit:
         cache.force_reset("key1")
         status, _ = cache.get_or_reserve("key1")
         assert status == "MISS"
+
+
+# ============================================================================
+# Per-worker portal creation (executor concurrency optimization)
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestPerWorkerPortals:
+    """Each parallel worker thread creates its own distinct BlockingPortal."""
+
+    def test_parallel_workers_create_distinct_portals(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With max_workers=4 and 8 tasks, 4 distinct portal ids are observed."""
+        portal_ids_by_thread: dict[int, int] = {}
+        portal_ids_lock = threading.Lock()
+
+        # Capture the real start_blocking_portal so we can wrap it
+        from anyio.from_thread import start_blocking_portal as original_start_blocking_portal
+
+        class PortalTracker:
+            """Context manager that wraps start_blocking_portal to track portal identity."""
+
+            def __init__(self) -> None:
+                self._real_cm = original_start_blocking_portal(backend="asyncio")
+
+            def __enter__(self):
+                portal = self._real_cm.__enter__()
+                thread_id = threading.current_thread().ident
+                with portal_ids_lock:
+                    portal_ids_by_thread[thread_id] = id(portal)
+                return portal
+
+            def __exit__(self, *args):
+                return self._real_cm.__exit__(*args)
+
+        def mock_start_blocking_portal(**kwargs):
+            return PortalTracker()
+
+        monkeypatch.setattr(
+            "karenina.benchmark.verification.executor.start_blocking_portal",
+            mock_start_blocking_portal,
+        )
+
+        def mock_execute_task(task, answer_cache=None, **kwargs):
+            return (f"key_{task['question_id']}", _make_result(task["question_id"]))
+
+        monkeypatch.setattr(
+            "karenina.benchmark.verification.batch_runner.execute_task",
+            mock_execute_task,
+        )
+
+        tasks = [_make_task(f"q{i}") for i in range(8)]
+        executor = VerificationExecutor(
+            parallel=True,
+            config=ExecutorConfig(max_workers=4, enable_cache=False),
+        )
+        results = executor.run_batch(tasks)
+
+        # All 8 tasks completed
+        assert len(results) == 8
+
+        # 4 distinct portals were created (one per worker thread)
+        distinct_portal_ids = set(portal_ids_by_thread.values())
+        assert len(distinct_portal_ids) == 4, (
+            "Expected 4 distinct portals (one per worker), "
+            f"got {len(distinct_portal_ids)}: workers are sharing a single portal"
+        )

--- a/tests/unit/benchmark/verification/test_executor.py
+++ b/tests/unit/benchmark/verification/test_executor.py
@@ -6,7 +6,7 @@ Tests verify:
 - Parallel mode: counts failures toward completion (no deadlock), raises aggregate error
 - Both modes raise the same error type with equivalent information (symmetry)
 - Timeout safety net prevents indefinite hangs
-- Per-worker portal creation (each worker gets its own BlockingPortal)
+- Per-task portal creation (each submitted task gets its own BlockingPortal)
 """
 
 import threading
@@ -555,20 +555,23 @@ class TestForceResetOnRequeueLimit:
 
 
 # ============================================================================
-# Per-worker portal creation (executor concurrency optimization)
+# Per-task portal creation (executor concurrency optimization)
 # ============================================================================
 
 
 @pytest.mark.unit
 class TestPerWorkerPortals:
-    """Each parallel worker thread creates its own distinct BlockingPortal."""
+    """Each submitted task creates its own distinct BlockingPortal."""
 
-    def test_parallel_workers_create_distinct_portals(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """With max_workers=4 and 8 tasks, 4 distinct portal ids are observed."""
-        portal_ids_by_thread: dict[int, int] = {}
-        portal_ids_lock = threading.Lock()
+    def test_parallel_tasks_create_distinct_portals(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With 6 tasks and 2 workers, 6 distinct portal ids are observed (one per task).
 
-        # Capture the real start_blocking_portal so we can wrap it
+        Uses different task and worker counts to distinguish portal-per-task
+        from portal-per-worker behavior.
+        """
+        portal_ids: list[int] = []
+        portal_lock = threading.Lock()
+
         from anyio.from_thread import start_blocking_portal as original_start_blocking_portal
 
         class PortalTracker:
@@ -579,9 +582,8 @@ class TestPerWorkerPortals:
 
             def __enter__(self):
                 portal = self._real_cm.__enter__()
-                thread_id = threading.current_thread().ident
-                with portal_ids_lock:
-                    portal_ids_by_thread[thread_id] = id(portal)
+                with portal_lock:
+                    portal_ids.append(id(portal))
                 return portal
 
             def __exit__(self, *args):
@@ -603,19 +605,18 @@ class TestPerWorkerPortals:
             mock_execute_task,
         )
 
-        tasks = [_make_task(f"q{i}") for i in range(8)]
+        tasks = [_make_task(f"q{i}") for i in range(6)]
         executor = VerificationExecutor(
             parallel=True,
-            config=ExecutorConfig(max_workers=4, enable_cache=False),
+            config=ExecutorConfig(max_workers=2, enable_cache=False),
         )
         results = executor.run_batch(tasks)
 
-        # All 8 tasks completed
-        assert len(results) == 8
+        # All 6 tasks completed
+        assert len(results) == 6
 
-        # 4 distinct portals were created (one per worker thread)
-        distinct_portal_ids = set(portal_ids_by_thread.values())
-        assert len(distinct_portal_ids) == 4, (
-            "Expected 4 distinct portals (one per worker), "
-            f"got {len(distinct_portal_ids)}: workers are sharing a single portal"
+        # 6 distinct portals were created (one per task, not per worker)
+        distinct_portal_ids = set(portal_ids)
+        assert len(distinct_portal_ids) == 6, (
+            f"Expected 6 distinct portals (one per task), got {len(distinct_portal_ids)}: {len(portal_ids)} total calls"
         )

--- a/tests/unit/benchmark/verification/test_executor_hang.py
+++ b/tests/unit/benchmark/verification/test_executor_hang.py
@@ -1,0 +1,376 @@
+"""Tests for VerificationExecutor hang prevention.
+
+These tests verify that the ThreadPoolExecutor-based parallel executor
+never hangs due to untracked worker deaths. Each test targets a specific
+failure mode that caused hangs with the previous raw-thread design.
+"""
+
+import threading
+
+import pytest
+
+from karenina.benchmark.verification.executor import ExecutorConfig, VerificationExecutor
+from karenina.exceptions import VerificationBatchError
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification import VerificationResult
+from karenina.schemas.verification.model_identity import ModelIdentity
+from karenina.schemas.verification.result_components import VerificationResultMetadata
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _make_identity(name: str = "test-model") -> ModelIdentity:
+    """Create a minimal ModelIdentity for test results."""
+    return ModelIdentity(
+        model_name=name,
+        interface="langchain",
+    )
+
+
+def _make_result(question_id: str = "q1") -> VerificationResult:
+    """Create a minimal VerificationResult for testing."""
+    return VerificationResult(
+        metadata=VerificationResultMetadata(
+            question_id=question_id,
+            template_id="test_template",
+            completed_without_errors=True,
+            question_text="Test question",
+            answering=_make_identity(),
+            parsing=_make_identity(),
+            execution_time=0.1,
+            timestamp="2026-01-01T00:00:00",
+            result_id="abcdef1234567890",
+        )
+    )
+
+
+def _make_task(question_id: str = "q1") -> dict:
+    """Create a minimal task dict for executor tests."""
+    model = ModelConfig(
+        id="test-model",
+        model_name="test-model",
+        model_provider="anthropic",
+        interface="langchain",
+        system_prompt="test",
+        temperature=0.0,
+    )
+    return {
+        "question_id": question_id,
+        "question_text": f"Question {question_id}",
+        "raw_answer": None,
+        "template_code": "class Answer(BaseAnswer): pass",
+        "answering_model": model,
+        "parsing_model": model,
+        "run_name": "test_run",
+        "replicate": None,
+        "rubric": None,
+        "dynamic_rubric": None,
+        "keywords": None,
+        "question_workspace_path": None,
+        "few_shot_examples": None,
+    }
+
+
+# ============================================================================
+# BaseException handling
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestVerificationBaseExceptionNoHang:
+    """BaseException from a task must not cause the batch to hang."""
+
+    def test_keyboard_interrupt_no_hang(self, monkeypatch) -> None:
+        """A task raising KeyboardInterrupt is collected as an error.
+
+        With the old raw-thread design, KeyboardInterrupt bypassed the
+        except Exception handler, leaving the task untracked.
+        """
+        tasks = [_make_task("q1"), _make_task("q2"), _make_task("q3")]
+
+        def mock_execute_task(task, answer_cache=None, **kwargs):
+            if task["question_id"] == "q2":
+                raise KeyboardInterrupt()
+            return (f"key_{task['question_id']}", _make_result(task["question_id"]))
+
+        monkeypatch.setattr(
+            "karenina.benchmark.verification.batch_runner.execute_task",
+            mock_execute_task,
+        )
+
+        executor = VerificationExecutor(
+            parallel=True,
+            config=ExecutorConfig(max_workers=2, enable_cache=False, timeout_seconds=10.0),
+        )
+
+        with pytest.raises(VerificationBatchError) as exc_info:
+            executor.run_batch(tasks)
+
+        err = exc_info.value
+        assert len(err.partial_results) == 2
+        assert len(err.errors) == 1
+        assert isinstance(err.errors[0][1], KeyboardInterrupt)
+
+    def test_system_exit_no_hang(self, monkeypatch) -> None:
+        """A task raising SystemExit is collected as an error without hanging."""
+        tasks = [_make_task("q1"), _make_task("q2")]
+
+        def mock_execute_task(task, answer_cache=None, **kwargs):
+            if task["question_id"] == "q2":
+                raise SystemExit(1)
+            return (f"key_{task['question_id']}", _make_result(task["question_id"]))
+
+        monkeypatch.setattr(
+            "karenina.benchmark.verification.batch_runner.execute_task",
+            mock_execute_task,
+        )
+
+        executor = VerificationExecutor(
+            parallel=True,
+            config=ExecutorConfig(max_workers=2, enable_cache=False, timeout_seconds=10.0),
+        )
+
+        with pytest.raises(VerificationBatchError) as exc_info:
+            executor.run_batch(tasks)
+
+        err = exc_info.value
+        assert len(err.partial_results) == 1
+        assert len(err.errors) == 1
+        assert isinstance(err.errors[0][1], SystemExit)
+
+    def test_all_raise_base_exception(self, monkeypatch) -> None:
+        """When every task raises BaseException, batch returns immediately
+        with all errors collected.
+        """
+        tasks = [_make_task("q1"), _make_task("q2")]
+
+        def mock_execute_task(task, answer_cache=None, **kwargs):
+            raise KeyboardInterrupt()
+
+        monkeypatch.setattr(
+            "karenina.benchmark.verification.batch_runner.execute_task",
+            mock_execute_task,
+        )
+
+        executor = VerificationExecutor(
+            parallel=True,
+            config=ExecutorConfig(max_workers=2, enable_cache=False, timeout_seconds=10.0),
+        )
+
+        with pytest.raises(VerificationBatchError) as exc_info:
+            executor.run_batch(tasks)
+
+        err = exc_info.value
+        assert len(err.partial_results) == 0
+        assert len(err.errors) == 2
+        assert all(isinstance(e, KeyboardInterrupt) for _, e in err.errors)
+
+    def test_mixed_success_and_base_exception(self, monkeypatch) -> None:
+        """Mix of successful tasks and BaseException produces partial results."""
+        tasks = [_make_task("q1"), _make_task("q2"), _make_task("q3"), _make_task("q4")]
+
+        def mock_execute_task(task, answer_cache=None, **kwargs):
+            if task["question_id"] == "q2":
+                raise KeyboardInterrupt()
+            return (f"key_{task['question_id']}", _make_result(task["question_id"]))
+
+        monkeypatch.setattr(
+            "karenina.benchmark.verification.batch_runner.execute_task",
+            mock_execute_task,
+        )
+
+        executor = VerificationExecutor(
+            parallel=True,
+            config=ExecutorConfig(max_workers=2, enable_cache=False, timeout_seconds=10.0),
+        )
+
+        with pytest.raises(VerificationBatchError) as exc_info:
+            executor.run_batch(tasks)
+
+        err = exc_info.value
+        assert len(err.partial_results) == 3
+        assert len(err.errors) == 1
+
+
+# ============================================================================
+# Portal creation failure
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestVerificationPortalCreationFailure:
+    """Portal creation failure for one task must not block others."""
+
+    def test_portal_failure_collected_as_error(self, monkeypatch) -> None:
+        """When start_blocking_portal raises for one task, the error is
+        captured by the Future and the other tasks complete normally.
+        """
+        tasks = [_make_task("q1"), _make_task("q2"), _make_task("q3")]
+
+        portal_call_count = [0]
+        portal_lock = threading.Lock()
+
+        from anyio.from_thread import start_blocking_portal as original_start_blocking_portal
+
+        class FailingPortalTracker:
+            """Wraps start_blocking_portal; the second call raises RuntimeError."""
+
+            def __init__(self) -> None:
+                with portal_lock:
+                    portal_call_count[0] += 1
+                    self._should_fail = portal_call_count[0] == 2
+
+                if self._should_fail:
+                    raise RuntimeError("portal creation failed")
+
+                self._real_cm = original_start_blocking_portal(backend="asyncio")
+
+            def __enter__(self):
+                return self._real_cm.__enter__()
+
+            def __exit__(self, *args):
+                return self._real_cm.__exit__(*args)
+
+        def mock_start_blocking_portal(**kwargs):
+            return FailingPortalTracker()
+
+        monkeypatch.setattr(
+            "karenina.benchmark.verification.executor.start_blocking_portal",
+            mock_start_blocking_portal,
+        )
+
+        def mock_execute_task(task, answer_cache=None, **kwargs):
+            return (f"key_{task['question_id']}", _make_result(task["question_id"]))
+
+        monkeypatch.setattr(
+            "karenina.benchmark.verification.batch_runner.execute_task",
+            mock_execute_task,
+        )
+
+        executor = VerificationExecutor(
+            parallel=True,
+            config=ExecutorConfig(max_workers=3, enable_cache=False, timeout_seconds=10.0),
+        )
+
+        with pytest.raises(VerificationBatchError) as exc_info:
+            executor.run_batch(tasks)
+
+        err = exc_info.value
+        assert len(err.partial_results) == 2
+        assert len(err.errors) == 1
+        assert isinstance(err.errors[0][1], RuntimeError)
+        assert "portal creation failed" in str(err.errors[0][1])
+
+
+# ============================================================================
+# Timeout with hanging workers
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestVerificationTimeoutWithHangingWorkers:
+    """Batch timeout returns promptly even when workers are stuck."""
+
+    def test_indefinitely_hanging_worker(self, monkeypatch) -> None:
+        """One task blocks forever; the other completes. Timeout fires and
+        the completed task's result is in partial_results.
+        """
+        tasks = [_make_task("q1"), _make_task("q2")]
+
+        block_forever = threading.Event()
+
+        def mock_execute_task(task, answer_cache=None, **kwargs):
+            if task["question_id"] == "q2":
+                block_forever.wait(timeout=30.0)
+                return (f"key_{task['question_id']}", _make_result(task["question_id"]))
+            return (f"key_{task['question_id']}", _make_result(task["question_id"]))
+
+        monkeypatch.setattr(
+            "karenina.benchmark.verification.batch_runner.execute_task",
+            mock_execute_task,
+        )
+
+        executor = VerificationExecutor(
+            parallel=True,
+            config=ExecutorConfig(
+                max_workers=2,
+                enable_cache=False,
+                timeout_seconds=1.0,
+            ),
+        )
+
+        with pytest.raises(VerificationBatchError) as exc_info:
+            executor.run_batch(tasks)
+
+        # Unblock the hanging worker
+        block_forever.set()
+
+        err = exc_info.value
+        assert len(err.partial_results) >= 1
+        assert "key_q1" in err.partial_results
+        assert "timed out" in str(err)
+
+
+# ============================================================================
+# Cache retry completes without hang
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestCacheRetryCompletes:
+    """Cache retry with internal loop completes without hanging."""
+
+    def test_cache_retry_both_tasks_complete(self, monkeypatch) -> None:
+        """Two tasks share the same cache key. The first generates the answer,
+        the second retries and gets the cached result. Both complete.
+        """
+        model = ModelConfig(
+            id="shared-model",
+            model_name="shared-model",
+            model_provider="anthropic",
+            interface="langchain",
+            system_prompt="test",
+            temperature=0.0,
+        )
+        # Same question + model = same cache key
+        task1 = {
+            **_make_task("q1"),
+            "answering_model": model,
+            "parsing_model": model,
+        }
+        task2 = {
+            **_make_task("q1"),  # Same question_id
+            "answering_model": model,
+            "parsing_model": model,
+        }
+        tasks = [task1, task2]
+
+        call_count = [0]
+        call_lock = threading.Lock()
+
+        def mock_execute_task(task, answer_cache=None, **kwargs):
+            with call_lock:
+                call_count[0] += 1
+            return (f"key_{task['question_id']}_{call_count[0]}", _make_result(task["question_id"]))
+
+        monkeypatch.setattr(
+            "karenina.benchmark.verification.batch_runner.execute_task",
+            mock_execute_task,
+        )
+
+        executor = VerificationExecutor(
+            parallel=True,
+            config=ExecutorConfig(
+                max_workers=2,
+                enable_cache=True,
+                retry_wait_seconds=0.5,
+                timeout_seconds=10.0,
+            ),
+        )
+
+        results = executor.run_batch(tasks)
+
+        # Both tasks should complete (no hang)
+        assert len(results) == 2

--- a/tests/unit/benchmark/verification/test_portal_health.py
+++ b/tests/unit/benchmark/verification/test_portal_health.py
@@ -1,0 +1,63 @@
+"""Tests for dead portal detection in get_async_portal()."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from karenina.benchmark.verification.executor import get_async_portal, set_async_portal
+
+
+@pytest.fixture(autouse=True)
+def _clean_portal():
+    """Ensure portal is cleared before and after each test."""
+    set_async_portal(None)
+    yield
+    set_async_portal(None)
+
+
+def _make_live_portal() -> MagicMock:
+    """Create a mock portal that appears alive."""
+    portal = MagicMock()
+    portal._event_loop_thread_id = 12345  # Non-None = alive
+    return portal
+
+
+def _make_dead_portal() -> MagicMock:
+    """Create a mock portal that appears dead (event loop thread ended)."""
+    portal = MagicMock()
+    portal._event_loop_thread_id = None  # None = dead
+    return portal
+
+
+@pytest.mark.unit
+class TestGetAsyncPortalHealthCheck:
+    def test_returns_live_portal(self) -> None:
+        portal = _make_live_portal()
+        set_async_portal(portal)
+        assert get_async_portal() is portal
+
+    def test_returns_none_for_dead_portal(self) -> None:
+        portal = _make_dead_portal()
+        set_async_portal(portal)
+        assert get_async_portal() is None
+
+    def test_clears_stale_reference_on_dead_portal(self) -> None:
+        """After detecting a dead portal, the stale reference is cleared."""
+        portal = _make_dead_portal()
+        set_async_portal(portal)
+
+        # First call detects and clears
+        assert get_async_portal() is None
+        # Second call returns None without needing to detect again
+        assert get_async_portal() is None
+
+    def test_returns_none_when_no_portal_set(self) -> None:
+        assert get_async_portal() is None
+
+    def test_portal_without_thread_id_attr_returned_as_is(self) -> None:
+        """Portal missing _event_loop_thread_id (not anyio) is returned as-is."""
+        portal = MagicMock(spec=[])  # No attributes at all
+        set_async_portal(portal)
+        assert get_async_portal() is portal

--- a/tests/unit/benchmark/verification/test_scenario_executor_hang.py
+++ b/tests/unit/benchmark/verification/test_scenario_executor_hang.py
@@ -162,7 +162,14 @@ class TestBaseExceptionNoHang:
 
 @pytest.mark.unit
 class TestPortalCreationFailure:
-    """Portal creation failure for one combo must not block others."""
+    """Portal creation failure in one worker must not block others.
+
+    Under the per-worker portal lifecycle, each worker thread lazily creates
+    one BlockingPortal on its first task and reuses it. Portal-creation
+    failures are therefore per-worker, not per-combo: the worker whose
+    portal creation raises loses whichever combo it was assigned, while
+    other workers (with healthy portals) continue running their combos.
+    """
 
     @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
     @patch("karenina.benchmark.verification.scenario_executor.start_blocking_portal")
@@ -171,15 +178,26 @@ class TestPortalCreationFailure:
         mock_start_portal: MagicMock,
         mock_manager_cls: MagicMock,
     ) -> None:
-        """When start_blocking_portal raises for one combo, the error is
-        captured by the Future and the other combos complete normally.
+        """When one worker's portal creation raises, its combo surfaces as
+        an error while combos on other workers complete normally.
+
+        A threading.Barrier forces all three workers to reach the portal
+        factory simultaneously, guaranteeing each worker calls the factory
+        exactly once. Without this synchronization a single worker could
+        drain every combo before the others start (mocked work is
+        instantaneous), leaving the failure-injection branch unreachable.
         """
         combos = [_make_combo("s1"), _make_combo("s2"), _make_combo("s3")]
 
+        # Force all three workers to create their portal at the same time.
+        worker_barrier = threading.Barrier(3, timeout=5.0)
         portal_call_count = [0]
         portal_lock = threading.Lock()
 
         def make_portal(*args, **kwargs):  # noqa: ARG001
+            # Block until all three workers have reached portal creation,
+            # ensuring each worker calls this factory exactly once.
+            worker_barrier.wait()
             with portal_lock:
                 portal_call_count[0] += 1
                 current = portal_call_count[0]
@@ -200,6 +218,8 @@ class TestPortalCreationFailure:
         )
         results, errors = executor.run_batch(combos, config)
 
+        # Exactly three portal creations (one per worker), the second raising.
+        assert portal_call_count[0] == 3
         assert len(results) == 2
         assert len(errors) == 1
         assert isinstance(errors[0][1], RuntimeError)

--- a/tests/unit/benchmark/verification/test_scenario_executor_hang.py
+++ b/tests/unit/benchmark/verification/test_scenario_executor_hang.py
@@ -1,0 +1,257 @@
+"""Tests for ScenarioExecutor hang prevention.
+
+These tests verify that the ThreadPoolExecutor-based parallel executor
+never hangs due to untracked worker deaths. Each test targets a specific
+failure mode that caused hangs with the previous raw-thread design.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karenina.benchmark.verification.scenario_executor import (
+    ScenarioExecutor,
+    ScenarioExecutorConfig,
+)
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _make_combo(scenario_name: str, model_name: str = "test-model") -> tuple:
+    """Create a mock (scenario_def, answering_model, parsing_model) combo."""
+    scenario_def = MagicMock()
+    scenario_def.name = scenario_name
+
+    ans_model = MagicMock()
+    ans_model.model_name = model_name
+    ans_model.id = f"{model_name}-ans"
+
+    parse_model = MagicMock()
+    parse_model.model_name = model_name
+    parse_model.id = f"{model_name}-parse"
+
+    return (scenario_def, ans_model, parse_model)
+
+
+def _make_exec_result(scenario_id: str = "s1") -> MagicMock:
+    """Create a mock ScenarioExecutionResult."""
+    result = MagicMock()
+    result.scenario_id = scenario_id
+    result.status = "completed"
+    result.turn_count = 3
+    return result
+
+
+# ============================================================================
+# BaseException handling (the original hang bug)
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestBaseExceptionNoHang:
+    """BaseException from a combo must not cause the batch to hang."""
+
+    @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
+    def test_keyboard_interrupt_no_hang(self, mock_manager_cls: MagicMock) -> None:
+        """A combo raising KeyboardInterrupt is collected as an error.
+
+        With the old raw-thread design, KeyboardInterrupt bypassed the
+        except Exception handler, leaving the combo untracked and the
+        completion event stuck.
+        """
+        combos = [_make_combo("ok"), _make_combo("interrupt"), _make_combo("ok2")]
+
+        def mock_run(**kwargs):
+            if kwargs["scenario"].name == "interrupt":
+                raise KeyboardInterrupt()
+            return _make_exec_result(kwargs["scenario"].name)
+
+        mock_manager_cls.return_value.run.side_effect = mock_run
+
+        config = MagicMock()
+        executor = ScenarioExecutor(
+            parallel=True,
+            config=ScenarioExecutorConfig(max_workers=2, enable_cache=False, timeout_seconds=10.0),
+        )
+        results, errors = executor.run_batch(combos, config)
+
+        assert len(results) == 2
+        assert len(errors) == 1
+        assert isinstance(errors[0][1], KeyboardInterrupt)
+
+    @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
+    def test_system_exit_no_hang(self, mock_manager_cls: MagicMock) -> None:
+        """A combo raising SystemExit is collected as an error without hanging."""
+        combos = [_make_combo("ok"), _make_combo("exit")]
+
+        def mock_run(**kwargs):
+            if kwargs["scenario"].name == "exit":
+                raise SystemExit(1)
+            return _make_exec_result(kwargs["scenario"].name)
+
+        mock_manager_cls.return_value.run.side_effect = mock_run
+
+        config = MagicMock()
+        executor = ScenarioExecutor(
+            parallel=True,
+            config=ScenarioExecutorConfig(max_workers=2, enable_cache=False, timeout_seconds=10.0),
+        )
+        results, errors = executor.run_batch(combos, config)
+
+        assert len(results) == 1
+        assert len(errors) == 1
+        assert isinstance(errors[0][1], SystemExit)
+
+    @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
+    def test_all_raise_base_exception(self, mock_manager_cls: MagicMock) -> None:
+        """When every combo raises BaseException, batch returns immediately
+        with all errors collected (no waiting for timeout).
+        """
+        combos = [_make_combo("s1"), _make_combo("s2"), _make_combo("s3")]
+
+        mock_manager_cls.return_value.run.side_effect = KeyboardInterrupt()
+
+        config = MagicMock()
+        executor = ScenarioExecutor(
+            parallel=True,
+            config=ScenarioExecutorConfig(max_workers=3, enable_cache=False, timeout_seconds=10.0),
+        )
+        results, errors = executor.run_batch(combos, config)
+
+        assert len(results) == 0
+        assert len(errors) == 3
+        assert all(isinstance(e, KeyboardInterrupt) for _, e in errors)
+
+    @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
+    def test_mixed_success_and_base_exception(self, mock_manager_cls: MagicMock) -> None:
+        """Mix of successful combos and BaseException produces partial results."""
+        combos = [
+            _make_combo("ok_1"),
+            _make_combo("interrupt"),
+            _make_combo("ok_2"),
+            _make_combo("ok_3"),
+        ]
+
+        def mock_run(**kwargs):
+            if kwargs["scenario"].name == "interrupt":
+                raise KeyboardInterrupt()
+            return _make_exec_result(kwargs["scenario"].name)
+
+        mock_manager_cls.return_value.run.side_effect = mock_run
+
+        config = MagicMock()
+        executor = ScenarioExecutor(
+            parallel=True,
+            config=ScenarioExecutorConfig(max_workers=2, enable_cache=False, timeout_seconds=10.0),
+        )
+        results, errors = executor.run_batch(combos, config)
+
+        assert len(results) == 3
+        assert len(errors) == 1
+        result_ids = {r.scenario_id for r in results}
+        assert result_ids == {"ok_1", "ok_2", "ok_3"}
+
+
+# ============================================================================
+# Portal creation failure
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestPortalCreationFailure:
+    """Portal creation failure for one combo must not block others."""
+
+    @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
+    @patch("karenina.benchmark.verification.scenario_executor.start_blocking_portal")
+    def test_portal_failure_collected_as_error(
+        self,
+        mock_start_portal: MagicMock,
+        mock_manager_cls: MagicMock,
+    ) -> None:
+        """When start_blocking_portal raises for one combo, the error is
+        captured by the Future and the other combos complete normally.
+        """
+        combos = [_make_combo("s1"), _make_combo("s2"), _make_combo("s3")]
+
+        portal_call_count = [0]
+        portal_lock = threading.Lock()
+
+        def make_portal(*args, **kwargs):  # noqa: ARG001
+            with portal_lock:
+                portal_call_count[0] += 1
+                current = portal_call_count[0]
+            if current == 2:
+                raise RuntimeError("portal creation failed")
+            ctx = MagicMock()
+            ctx.__enter__ = MagicMock(return_value=MagicMock())
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        mock_start_portal.side_effect = make_portal
+        mock_manager_cls.return_value.run.return_value = _make_exec_result("s")
+
+        config = MagicMock()
+        executor = ScenarioExecutor(
+            parallel=True,
+            config=ScenarioExecutorConfig(max_workers=3, enable_cache=False, timeout_seconds=10.0),
+        )
+        results, errors = executor.run_batch(combos, config)
+
+        assert len(results) == 2
+        assert len(errors) == 1
+        assert isinstance(errors[0][1], RuntimeError)
+        assert "portal creation failed" in str(errors[0][1])
+
+
+# ============================================================================
+# Timeout with hanging workers
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestTimeoutWithHangingWorkers:
+    """Batch timeout returns promptly even when workers are stuck."""
+
+    @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
+    def test_indefinitely_hanging_worker(self, mock_manager_cls: MagicMock) -> None:
+        """One combo blocks forever; the other completes. Timeout fires and
+        the completed combo's result is returned alongside a timeout error.
+        """
+        combos = [_make_combo("fast"), _make_combo("hang")]
+
+        block_forever = threading.Event()
+
+        def mock_run(**kwargs):
+            if kwargs["scenario"].name == "hang":
+                block_forever.wait(timeout=30.0)
+                return _make_exec_result("hang")
+            return _make_exec_result("fast")
+
+        mock_manager_cls.return_value.run.side_effect = mock_run
+
+        config = MagicMock()
+        executor = ScenarioExecutor(
+            parallel=True,
+            config=ScenarioExecutorConfig(
+                max_workers=2,
+                enable_cache=False,
+                timeout_seconds=1.0,
+            ),
+        )
+        results, errors = executor.run_batch(combos, config)
+
+        # Unblock the hanging worker so the test thread can exit cleanly
+        block_forever.set()
+
+        # The fast combo should have completed
+        assert len(results) >= 1
+        fast_results = [r for r in results if r.scenario_id == "fast"]
+        assert len(fast_results) == 1
+
+        # A timeout error should be present
+        timeout_errors = [(d, e) for d, e in errors if isinstance(e, TimeoutError)]
+        assert len(timeout_errors) >= 1
+        assert "timed out" in str(timeout_errors[0][1])

--- a/tests/unit/benchmark/verification/test_scenario_executor_parallel.py
+++ b/tests/unit/benchmark/verification/test_scenario_executor_parallel.py
@@ -430,24 +430,23 @@ class TestParallelPortalManagement:
 
 @pytest.mark.unit
 class TestScenarioPerWorkerPortals:
-    """Each worker thread creates its own distinct BlockingPortal."""
+    """Each submitted combo creates its own distinct BlockingPortal."""
 
     @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
     @patch("karenina.benchmark.verification.scenario_executor.start_blocking_portal")
-    def test_each_worker_gets_distinct_portal(
+    def test_each_combo_gets_distinct_portal(
         self,
         mock_start_portal: MagicMock,
         mock_manager_cls: MagicMock,
     ) -> None:
-        """With max_workers=4 and 4 combos, 4 distinct portals are created.
+        """With 6 combos and 2 workers, 6 distinct portals are created (one per combo).
 
-        Each worker should call start_blocking_portal independently,
-        producing a unique portal instance per worker thread.
+        Uses different combo and worker counts to distinguish portal-per-combo
+        from portal-per-worker behavior.
         """
         created_portals: list[MagicMock] = []
         lock = threading.Lock()
 
-        # Each call to start_blocking_portal returns a unique mock portal
         def make_portal(*args, **kwargs):  # noqa: ARG001
             portal = MagicMock()
             with lock:
@@ -461,19 +460,19 @@ class TestScenarioPerWorkerPortals:
 
         mock_manager_cls.return_value.run.return_value = _make_exec_result("s")
 
-        combos = [_make_combo(f"s{i}") for i in range(4)]
+        combos = [_make_combo(f"s{i}") for i in range(6)]
         config = MagicMock()
         executor = ScenarioExecutor(
             parallel=True,
-            config=ScenarioExecutorConfig(max_workers=4, enable_cache=False),
+            config=ScenarioExecutorConfig(max_workers=2, enable_cache=False),
         )
         executor.run_batch(combos, config)
 
-        # Each worker creates its own portal (one per worker thread)
-        assert mock_start_portal.call_count == 4
-        assert len(created_portals) == 4
+        # One portal per combo (not per worker)
+        assert mock_start_portal.call_count == 6
+        assert len(created_portals) == 6
         portal_ids = {id(p) for p in created_portals}
-        assert len(portal_ids) == 4, (
-            "Expected 4 distinct portal objects (one per worker), "
+        assert len(portal_ids) == 6, (
+            "Expected 6 distinct portal objects (one per combo), "
             f"got {len(portal_ids)} unique out of {len(created_portals)}"
         )

--- a/tests/unit/benchmark/verification/test_scenario_executor_parallel.py
+++ b/tests/unit/benchmark/verification/test_scenario_executor_parallel.py
@@ -430,19 +430,19 @@ class TestParallelPortalManagement:
 
 @pytest.mark.unit
 class TestScenarioPerWorkerPortals:
-    """Each submitted combo creates its own distinct BlockingPortal."""
+    """Each worker thread creates one portal, reused across combos."""
 
     @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
     @patch("karenina.benchmark.verification.scenario_executor.start_blocking_portal")
-    def test_each_combo_gets_distinct_portal(
+    def test_each_worker_gets_one_portal(
         self,
         mock_start_portal: MagicMock,
         mock_manager_cls: MagicMock,
     ) -> None:
-        """With 6 combos and 2 workers, 6 distinct portals are created (one per combo).
+        """With 6 combos and 2 workers, 2 portals are created (one per worker).
 
-        Uses different combo and worker counts to distinguish portal-per-combo
-        from portal-per-worker behavior.
+        Each worker lazily creates a portal on its first combo and reuses it
+        for subsequent combos. This preserves connection pools.
         """
         created_portals: list[MagicMock] = []
         lock = threading.Lock()
@@ -468,11 +468,6 @@ class TestScenarioPerWorkerPortals:
         )
         executor.run_batch(combos, config)
 
-        # One portal per combo (not per worker)
-        assert mock_start_portal.call_count == 6
-        assert len(created_portals) == 6
-        portal_ids = {id(p) for p in created_portals}
-        assert len(portal_ids) == 6, (
-            "Expected 6 distinct portal objects (one per combo), "
-            f"got {len(portal_ids)} unique out of {len(created_portals)}"
-        )
+        # One portal per worker (reused across combos)
+        assert mock_start_portal.call_count == 2
+        assert len(created_portals) == 2

--- a/tests/unit/benchmark/verification/test_scenario_executor_parallel.py
+++ b/tests/unit/benchmark/verification/test_scenario_executor_parallel.py
@@ -421,3 +421,59 @@ class TestParallelPortalManagement:
 
         # Portal is cleared after run_batch (on the main thread)
         assert get_async_portal() is None
+
+
+# ============================================================================
+# Parallel: per-worker portals
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestScenarioPerWorkerPortals:
+    """Each worker thread creates its own distinct BlockingPortal."""
+
+    @patch("karenina.benchmark.verification.scenario_executor.ScenarioManager")
+    @patch("karenina.benchmark.verification.scenario_executor.start_blocking_portal")
+    def test_each_worker_gets_distinct_portal(
+        self,
+        mock_start_portal: MagicMock,
+        mock_manager_cls: MagicMock,
+    ) -> None:
+        """With max_workers=4 and 4 combos, 4 distinct portals are created.
+
+        Each worker should call start_blocking_portal independently,
+        producing a unique portal instance per worker thread.
+        """
+        created_portals: list[MagicMock] = []
+        lock = threading.Lock()
+
+        # Each call to start_blocking_portal returns a unique mock portal
+        def make_portal(*args, **kwargs):  # noqa: ARG001
+            portal = MagicMock()
+            with lock:
+                created_portals.append(portal)
+            ctx = MagicMock()
+            ctx.__enter__ = MagicMock(return_value=portal)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        mock_start_portal.side_effect = make_portal
+
+        mock_manager_cls.return_value.run.return_value = _make_exec_result("s")
+
+        combos = [_make_combo(f"s{i}") for i in range(4)]
+        config = MagicMock()
+        executor = ScenarioExecutor(
+            parallel=True,
+            config=ScenarioExecutorConfig(max_workers=4, enable_cache=False),
+        )
+        executor.run_batch(combos, config)
+
+        # Each worker creates its own portal (one per worker thread)
+        assert mock_start_portal.call_count == 4
+        assert len(created_portals) == 4
+        portal_ids = {id(p) for p in created_portals}
+        assert len(portal_ids) == 4, (
+            "Expected 4 distinct portal objects (one per worker), "
+            f"got {len(portal_ids)} unique out of {len(created_portals)}"
+        )

--- a/tests/unit/benchmark/verification/test_task_helpers.py
+++ b/tests/unit/benchmark/verification/test_task_helpers.py
@@ -1,0 +1,162 @@
+"""Tests for task_helpers utility functions."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from karenina.benchmark.verification.utils.task_helpers import (
+    model_sort_key,
+    replicate_range,
+)
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification import FinishedTemplate, VerificationConfig
+
+
+@dataclass
+class _StubModel:
+    """Lightweight stand-in for ModelConfig in sort key tests.
+
+    Avoids ModelConfig validators that require manual_traces or non-None id
+    for certain interface values.
+    """
+
+    id: str | None = None
+    model_name: str | None = None
+
+
+def _make_model(model_id: str, model_name: str | None = None) -> ModelConfig:
+    return ModelConfig(
+        id=model_id,
+        model_name=model_name or model_id,
+        model_provider="anthropic",
+        interface="langchain",
+        system_prompt="test",
+        temperature=0.1,
+    )
+
+
+def _make_template(question_id: str = "q1") -> FinishedTemplate:
+    return FinishedTemplate(
+        question_id=question_id,
+        question_text="What is 2+2?",
+        question_preview="What is 2+2?",
+        template_code="class Answer(BaseAnswer): pass",
+        last_modified="2026-01-01T00:00:00",
+    )
+
+
+# =============================================================================
+# model_sort_key
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestModelSortKey:
+    """Tests for the model_sort_key helper."""
+
+    def test_prefers_id(self) -> None:
+        """When both id and model_name are set, id wins."""
+        model = _make_model("alpha", model_name="beta")
+        assert model_sort_key(model) == "alpha"
+
+    def test_falls_back_to_model_name(self) -> None:
+        """When id is None, falls back to model_name."""
+        model = _StubModel(id=None, model_name="fallback-name")
+        assert model_sort_key(model) == "fallback-name"
+
+    def test_empty_string_when_both_none(self) -> None:
+        """When both id and model_name are None, returns empty string."""
+        model = _StubModel(id=None, model_name=None)
+        assert model_sort_key(model) == ""
+
+
+# =============================================================================
+# replicate_range
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestReplicateRange:
+    """Tests for the replicate_range helper."""
+
+    def test_single_returns_none_list(self) -> None:
+        """count=1 returns [None] (no replicate numbering)."""
+        assert replicate_range(1) == [None]
+
+    def test_zero_returns_none_list(self) -> None:
+        """count=0 returns [None] (degenerate case, same as single)."""
+        assert replicate_range(0) == [None]
+
+    def test_multiple_returns_one_indexed_range(self) -> None:
+        """count=3 returns [1, 2, 3]."""
+        assert replicate_range(3) == [1, 2, 3]
+
+
+# =============================================================================
+# Task ordering (integration test for batch_runner sort logic)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestTaskOrdering:
+    """Tests for task queue ordering in batch_runner."""
+
+    def test_prefix_cache_groups_by_answering_model(self) -> None:
+        """prefix_cache mode sorts by (answering_model, question, parsing_model)."""
+        from karenina.benchmark.verification.batch_runner import generate_task_queue
+        from karenina.benchmark.verification.utils.task_helpers import model_sort_key
+
+        model_a = _make_model("model-a")
+        model_b = _make_model("model-b")
+
+        config = VerificationConfig(
+            answering_models=[model_b, model_a],
+            parsing_models=[model_a],
+            task_ordering="prefix_cache",
+        )
+
+        templates = [_make_template("q2"), _make_template("q0"), _make_template("q1")]
+
+        task_queue = generate_task_queue(templates, config)
+
+        # Apply the same sort that batch_runner applies after generation
+        task_queue.sort(
+            key=lambda t: (
+                model_sort_key(t["answering_model"]),
+                t["question_id"],
+                model_sort_key(t["parsing_model"]),
+                t.get("replicate") or 0,
+            )
+        )
+
+        answering_ids = [model_sort_key(t["answering_model"]) for t in task_queue]
+        question_ids = [t["question_id"] for t in task_queue]
+
+        # All model-a tasks come before all model-b tasks
+        assert answering_ids == ["model-a", "model-a", "model-a", "model-b", "model-b", "model-b"]
+        # Within each model group, questions are sorted
+        assert question_ids == ["q0", "q1", "q2", "q0", "q1", "q2"]
+
+    def test_generation_order_preserves_loop_order(self) -> None:
+        """generation_order keeps the original expansion order from generate_task_queue."""
+        from karenina.benchmark.verification.batch_runner import generate_task_queue
+
+        model_a = _make_model("model-a")
+        model_b = _make_model("model-b")
+
+        config = VerificationConfig(
+            answering_models=[model_b, model_a],
+            parsing_models=[model_a],
+            task_ordering="generation_order",
+        )
+
+        templates = [_make_template("q2"), _make_template("q0")]
+
+        task_queue = generate_task_queue(templates, config)
+        # generation_order is a no-op, so the loop order is: template x answering x parsing
+        # q2/model-b, q2/model-a, q0/model-b, q0/model-a
+        question_ids = [t["question_id"] for t in task_queue]
+        answering_ids = [model_sort_key(t["answering_model"]) for t in task_queue]
+
+        assert question_ids == ["q2", "q2", "q0", "q0"]
+        assert answering_ids == ["model-b", "model-a", "model-b", "model-a"]

--- a/tests/unit/scenario/test_manager_turn_retry.py
+++ b/tests/unit/scenario/test_manager_turn_retry.py
@@ -1,0 +1,301 @@
+"""Tests for ScenarioManager per-turn retry on transient errors."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karenina.scenario.manager import ScenarioManager
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.scenario.definition import ScenarioDefinition
+from karenina.schemas.scenario.types import END, ScenarioEdge, ScenarioNode
+from karenina.schemas.verification import VerificationConfig, VerificationResult
+from karenina.schemas.verification.model_identity import ModelIdentity
+from karenina.schemas.verification.result_components import (
+    VerificationResultDeepJudgment,
+    VerificationResultDeepJudgmentRubric,
+    VerificationResultMetadata,
+    VerificationResultRubric,
+    VerificationResultTemplate,
+)
+
+
+def _make_model(name: str = "test-model") -> ModelConfig:
+    return ModelConfig(id=name, model_name=name, model_provider="openai")
+
+
+def _make_vr(
+    *,
+    completed: bool = True,
+    transient: bool = False,
+    error: str | None = None,
+    verify_result: bool | None = True,
+) -> VerificationResult:
+    """Create a minimal VerificationResult with controllable error state."""
+    identity = ModelIdentity(model_name="test", interface="openai")
+    metadata = VerificationResultMetadata(
+        question_id="q1",
+        template_id="tpl1",
+        completed_without_errors=completed,
+        error=error,
+        is_transient_error=transient,
+        question_text="What?",
+        answering=identity,
+        parsing=identity,
+        execution_time=1.0,
+        timestamp="2026-01-01T00:00:00Z",
+        result_id="abcdef1234567890",
+    )
+    template = VerificationResultTemplate(verify_result=verify_result)
+    return VerificationResult(
+        metadata=metadata,
+        template=template,
+        rubric=VerificationResultRubric(),
+        deep_judgment=VerificationResultDeepJudgment(),
+        deep_judgment_rubric=VerificationResultDeepJudgmentRubric(),
+    )
+
+
+def _make_scenario() -> ScenarioDefinition:
+    """Single-node scenario: ask -> END."""
+    from karenina.schemas.entities import Question
+
+    q = Question(question="What?", raw_answer="Y", answer_template="class Answer: pass")
+    node = ScenarioNode(node_id="ask", question=q)
+    return ScenarioDefinition(
+        name="test_scenario",
+        description="test",
+        nodes={"ask": node},
+        edges=[ScenarioEdge(source="ask", target=END)],
+        entry_node="ask",
+        outcome_criteria=[],
+    )
+
+
+def _make_config(**overrides) -> VerificationConfig:
+    defaults = {
+        "answering_models": [_make_model()],
+        "parsing_models": [_make_model()],
+    }
+    defaults.update(overrides)
+    with patch("karenina.schemas.verification.config.os.getenv", return_value=None):
+        return VerificationConfig(**defaults)
+
+
+@pytest.mark.unit
+class TestScenarioManagerTurnRetry:
+    """Per-turn retry when _run_turn returns a transient error VR."""
+
+    @patch.object(ScenarioManager, "_run_turn")
+    def test_no_retry_on_success(self, mock_run_turn: MagicMock) -> None:
+        """Successful turn: _run_turn called once, scenario completes."""
+        vr_ok = _make_vr(completed=True)
+        mock_run_turn.return_value = (vr_ok, None, None, "answer")
+
+        manager = ScenarioManager()
+        result = manager.run(
+            scenario=_make_scenario(),
+            config=_make_config(),
+            base_answering_model=_make_model(),
+            base_parsing_model=_make_model(),
+        )
+        assert result.status == "completed"
+        assert mock_run_turn.call_count == 1
+
+    @patch("karenina.scenario.manager.time.sleep")
+    @patch.object(ScenarioManager, "_run_turn")
+    def test_retry_on_transient_error_then_success(self, mock_run_turn: MagicMock, _mock_sleep: MagicMock) -> None:
+        """Transient error on first attempt, success on second."""
+        vr_fail = _make_vr(completed=False, transient=True, error="Connection error")
+        vr_ok = _make_vr(completed=True)
+        mock_run_turn.side_effect = [
+            (vr_fail, None, None, ""),
+            (vr_ok, None, None, "answer"),
+        ]
+
+        manager = ScenarioManager()
+        config = _make_config(max_scenario_turn_retries=2)
+        result = manager.run(
+            scenario=_make_scenario(),
+            config=config,
+            base_answering_model=_make_model(),
+            base_parsing_model=_make_model(),
+        )
+        assert result.status == "completed"
+        assert mock_run_turn.call_count == 2
+
+    @patch.object(ScenarioManager, "_run_turn")
+    def test_no_retry_on_permanent_error(self, mock_run_turn: MagicMock) -> None:
+        """Non-transient error: no retry, status is 'error'."""
+        vr_fail = _make_vr(completed=False, transient=False, error="ValueError: bad")
+        mock_run_turn.return_value = (vr_fail, None, None, "")
+
+        manager = ScenarioManager()
+        config = _make_config(max_scenario_turn_retries=3)
+        result = manager.run(
+            scenario=_make_scenario(),
+            config=config,
+            base_answering_model=_make_model(),
+            base_parsing_model=_make_model(),
+        )
+        assert result.status == "error"
+        assert mock_run_turn.call_count == 1
+
+    @patch("karenina.scenario.manager.time.sleep")
+    @patch.object(ScenarioManager, "_run_turn")
+    def test_retries_exhaust_then_error(self, mock_run_turn: MagicMock, _mock_sleep: MagicMock) -> None:
+        """All retry attempts fail with transient errors."""
+        vr_fail = _make_vr(completed=False, transient=True, error="Connection error")
+        mock_run_turn.return_value = (vr_fail, None, None, "")
+
+        manager = ScenarioManager()
+        config = _make_config(max_scenario_turn_retries=3)
+        result = manager.run(
+            scenario=_make_scenario(),
+            config=config,
+            base_answering_model=_make_model(),
+            base_parsing_model=_make_model(),
+        )
+        assert result.status == "error"
+        assert mock_run_turn.call_count == 3
+
+    @patch("karenina.scenario.manager.time.sleep")
+    @patch.object(ScenarioManager, "_run_turn")
+    def test_retry_count_from_config(self, mock_run_turn: MagicMock, _mock_sleep: MagicMock) -> None:
+        """max_scenario_turn_retries controls total attempts."""
+        vr_fail = _make_vr(completed=False, transient=True, error="timeout")
+        mock_run_turn.return_value = (vr_fail, None, None, "")
+
+        manager = ScenarioManager()
+        config = _make_config(max_scenario_turn_retries=5)
+        manager.run(
+            scenario=_make_scenario(),
+            config=config,
+            base_answering_model=_make_model(),
+            base_parsing_model=_make_model(),
+        )
+        assert mock_run_turn.call_count == 5
+
+    @patch("karenina.scenario.manager.time.sleep")
+    @patch.object(ScenarioManager, "_run_turn")
+    def test_retry_sleeps_between_attempts(self, mock_run_turn: MagicMock, mock_sleep: MagicMock) -> None:
+        """time.sleep(1) called between retries but not after the last attempt."""
+        vr_fail = _make_vr(completed=False, transient=True, error="Connection error")
+        mock_run_turn.return_value = (vr_fail, None, None, "")
+
+        manager = ScenarioManager()
+        config = _make_config(max_scenario_turn_retries=3)
+        manager.run(
+            scenario=_make_scenario(),
+            config=config,
+            base_answering_model=_make_model(),
+            base_parsing_model=_make_model(),
+        )
+        # 3 attempts = 2 sleeps (between attempt 1-2 and 2-3, not after 3)
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(1)
+
+    @patch("karenina.scenario.manager.time.sleep")
+    @patch.object(ScenarioManager, "_run_turn")
+    def test_retry_logs_warning(
+        self, mock_run_turn: MagicMock, _mock_sleep: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warning logged for each retry with scenario name, node, attempt number."""
+        vr_fail = _make_vr(completed=False, transient=True, error="Connection error")
+        vr_ok = _make_vr(completed=True)
+        mock_run_turn.side_effect = [
+            (vr_fail, None, None, ""),
+            (vr_ok, None, None, "answer"),
+        ]
+
+        manager = ScenarioManager()
+        config = _make_config(max_scenario_turn_retries=2)
+        with caplog.at_level(logging.WARNING, logger="karenina.scenario.manager"):
+            manager.run(
+                scenario=_make_scenario(),
+                config=config,
+                base_answering_model=_make_model(),
+                base_parsing_model=_make_model(),
+            )
+
+        retry_warnings = [r for r in caplog.records if "transient" in r.message.lower()]
+        assert len(retry_warnings) == 1
+        assert "test_scenario" in retry_warnings[0].message
+        assert "ask" in retry_warnings[0].message
+        assert "1/2" in retry_warnings[0].message
+
+    @patch("karenina.scenario.manager.time.sleep")
+    @patch.object(ScenarioManager, "_run_turn")
+    def test_retry_preserves_conversation_history(self, mock_run_turn: MagicMock, _mock_sleep: MagicMock) -> None:
+        """Same conversation_history passed on each retry attempt."""
+        vr_fail = _make_vr(completed=False, transient=True, error="timeout")
+        vr_ok = _make_vr(completed=True)
+        mock_run_turn.side_effect = [
+            (vr_fail, None, None, ""),
+            (vr_ok, None, None, "answer"),
+        ]
+
+        manager = ScenarioManager()
+        config = _make_config(max_scenario_turn_retries=2)
+        manager.run(
+            scenario=_make_scenario(),
+            config=config,
+            base_answering_model=_make_model(),
+            base_parsing_model=_make_model(),
+        )
+
+        # Both calls should receive the same conversation_history kwarg
+        call1_kwargs = mock_run_turn.call_args_list[0].kwargs
+        call2_kwargs = mock_run_turn.call_args_list[1].kwargs
+        assert call1_kwargs["conversation_history"] == call2_kwargs["conversation_history"]
+
+    @patch("karenina.scenario.manager.time.sleep")
+    @patch.object(ScenarioManager, "_run_turn")
+    def test_cache_completed_only_after_final_attempt(self, mock_run_turn: MagicMock, _mock_sleep: MagicMock) -> None:
+        """Cache complete() called once after the retry loop, not between attempts."""
+        vr_fail = _make_vr(completed=False, transient=True, error="timeout")
+        vr_ok = _make_vr(completed=True)
+        mock_run_turn.side_effect = [
+            (vr_fail, None, None, ""),
+            (vr_ok, None, None, "answer"),
+        ]
+
+        mock_cache = MagicMock()
+        mock_cache.get_or_reserve.return_value = ("MISS", None)
+        mock_cache.wait_for_completion.return_value = True
+
+        manager = ScenarioManager()
+        config = _make_config(max_scenario_turn_retries=2)
+        manager.run(
+            scenario=_make_scenario(),
+            config=config,
+            base_answering_model=_make_model(),
+            base_parsing_model=_make_model(),
+            answer_cache=mock_cache,
+        )
+
+        # complete() called once (after retry loop), not twice
+        assert mock_cache.complete.call_count == 1
+
+    @patch.object(ScenarioManager, "_run_turn")
+    def test_cache_not_completed_on_hit(self, mock_run_turn: MagicMock) -> None:
+        """When cache returns HIT, complete() should not be called."""
+        vr_ok = _make_vr(completed=True)
+        mock_run_turn.return_value = (vr_ok, None, None, "cached answer")
+
+        mock_cache = MagicMock()
+        mock_cache.get_or_reserve.return_value = ("HIT", {"raw_response": "cached"})
+
+        manager = ScenarioManager()
+        config = _make_config()
+        manager.run(
+            scenario=_make_scenario(),
+            config=config,
+            base_answering_model=_make_model(),
+            base_parsing_model=_make_model(),
+            answer_cache=mock_cache,
+        )
+
+        mock_cache.complete.assert_not_called()

--- a/tests/unit/scenario/test_parallel_execution.py
+++ b/tests/unit/scenario/test_parallel_execution.py
@@ -215,12 +215,8 @@ class TestScenarioRunParallel:
 
         config = _make_config()
 
-        call_index = {"n": 0}
-
         def fake_run(_self, **kwargs: Any) -> ScenarioExecutionResult:
-            idx = call_index["n"]
-            call_index["n"] += 1
-            if idx == 0:
+            if kwargs["scenario"].name == "alpha":
                 raise RuntimeError("boom")
             return _make_exec_result()
 

--- a/tests/unit/schemas/test_verification_config.py
+++ b/tests/unit/schemas/test_verification_config.py
@@ -1528,3 +1528,66 @@ class TestRetryConfigMaxRetriesConstraint:
         """ToolRetryConfig accepts max_retries=3."""
         config = ToolRetryConfig(max_retries=3)
         assert config.max_retries == 3
+
+
+# =============================================================================
+# Retry Configuration Fields Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRetryConfigFields:
+    """Tests for max_transient_retries and max_requeue_count fields."""
+
+    def test_verification_config_defaults(self) -> None:
+        """Test default values for new retry fields."""
+        config = VerificationConfig(
+            parsing_models=[ModelConfig(id="test", model_name="test", model_provider="openai")],
+            parsing_only=True,
+        )
+        assert config.max_transient_retries == 3
+        assert config.max_requeue_count == 5
+
+    def test_verification_config_custom_values(self) -> None:
+        """Test custom values for retry fields."""
+        config = VerificationConfig(
+            parsing_models=[ModelConfig(id="test", model_name="test", model_provider="openai")],
+            parsing_only=True,
+            max_transient_retries=1,
+            max_requeue_count=10,
+        )
+        assert config.max_transient_retries == 1
+        assert config.max_requeue_count == 10
+
+    def test_verification_config_rejects_zero_retries(self) -> None:
+        """Test that max_transient_retries must be >= 1."""
+        with pytest.raises(ValidationError):
+            VerificationConfig(
+                parsing_models=[ModelConfig(id="test", model_name="test", model_provider="openai")],
+                parsing_only=True,
+                max_transient_retries=0,
+            )
+
+    def test_verification_config_rejects_zero_requeue(self) -> None:
+        """Test that max_requeue_count must be >= 1."""
+        with pytest.raises(ValidationError):
+            VerificationConfig(
+                parsing_models=[ModelConfig(id="test", model_name="test", model_provider="openai")],
+                parsing_only=True,
+                max_requeue_count=0,
+            )
+
+    def test_model_config_default_max_transient_retries(self) -> None:
+        """Test ModelConfig has max_transient_retries defaulting to None."""
+        config = ModelConfig(id="test", model_name="test", model_provider="openai")
+        assert config.max_transient_retries is None
+
+    def test_model_config_custom_max_transient_retries(self) -> None:
+        """Test ModelConfig accepts max_transient_retries."""
+        config = ModelConfig(
+            id="test",
+            model_name="test",
+            model_provider="openai",
+            max_transient_retries=2,
+        )
+        assert config.max_transient_retries == 2

--- a/tests/unit/schemas/test_verification_config.py
+++ b/tests/unit/schemas/test_verification_config.py
@@ -1591,3 +1591,48 @@ class TestRetryConfigFields:
             max_transient_retries=2,
         )
         assert config.max_transient_retries == 2
+
+
+# =============================================================================
+# Task Ordering Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestTaskOrdering:
+    """Tests for the task_ordering field on VerificationConfig."""
+
+    def test_default_is_prefix_cache(self) -> None:
+        """Test that task_ordering defaults to 'prefix_cache'."""
+        config = VerificationConfig(
+            parsing_models=[ModelConfig(id="test", model_name="test", model_provider="openai")],
+            parsing_only=True,
+        )
+        assert config.task_ordering == "prefix_cache"
+
+    def test_accepts_generation_order(self) -> None:
+        """Test that task_ordering accepts 'generation_order'."""
+        config = VerificationConfig(
+            parsing_models=[ModelConfig(id="test", model_name="test", model_provider="openai")],
+            parsing_only=True,
+            task_ordering="generation_order",
+        )
+        assert config.task_ordering == "generation_order"
+
+    def test_accepts_random(self) -> None:
+        """Test that task_ordering accepts 'random'."""
+        config = VerificationConfig(
+            parsing_models=[ModelConfig(id="test", model_name="test", model_provider="openai")],
+            parsing_only=True,
+            task_ordering="random",
+        )
+        assert config.task_ordering == "random"
+
+    def test_rejects_invalid_value(self) -> None:
+        """Test that task_ordering rejects values outside the allowed literal."""
+        with pytest.raises(ValidationError):
+            VerificationConfig(
+                parsing_models=[ModelConfig(id="test", model_name="test", model_provider="openai")],
+                parsing_only=True,
+                task_ordering="invalid",
+            )

--- a/tests/unit/schemas/test_verification_config_turn_retry.py
+++ b/tests/unit/schemas/test_verification_config_turn_retry.py
@@ -1,0 +1,37 @@
+"""Tests for max_scenario_turn_retries config field."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification import VerificationConfig
+
+
+def _make_config(**overrides) -> VerificationConfig:
+    """Create a minimal VerificationConfig."""
+    defaults = {
+        "answering_models": [ModelConfig(id="m", model_name="m", model_provider="openai")],
+        "parsing_models": [ModelConfig(id="m", model_name="m", model_provider="openai")],
+    }
+    defaults.update(overrides)
+    with patch("karenina.schemas.verification.config.os.getenv", return_value=None):
+        return VerificationConfig(**defaults)
+
+
+@pytest.mark.unit
+class TestMaxScenarioTurnRetries:
+    def test_default_is_2(self) -> None:
+        config = _make_config()
+        assert config.max_scenario_turn_retries == 2
+
+    def test_minimum_is_1(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_config(max_scenario_turn_retries=0)
+
+    def test_custom_value(self) -> None:
+        config = _make_config(max_scenario_turn_retries=5)
+        assert config.max_scenario_turn_retries == 5

--- a/tests/unit/schemas/verification/test_result_metadata_transient.py
+++ b/tests/unit/schemas/verification/test_result_metadata_transient.py
@@ -1,0 +1,43 @@
+"""Tests for VerificationResultMetadata transient error flag."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.schemas.verification.model_identity import ModelIdentity
+from karenina.schemas.verification.result_components import VerificationResultMetadata
+
+
+def _make_metadata(**overrides) -> VerificationResultMetadata:
+    """Create a minimal VerificationResultMetadata with required fields."""
+    defaults = {
+        "question_id": "q1",
+        "template_id": "tpl1",
+        "completed_without_errors": True,
+        "question_text": "What?",
+        "answering": ModelIdentity(model_name="test", interface="openai"),
+        "parsing": ModelIdentity(model_name="test", interface="openai"),
+        "execution_time": 1.0,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "result_id": "abcdef1234567890",
+    }
+    defaults.update(overrides)
+    return VerificationResultMetadata(**defaults)
+
+
+@pytest.mark.unit
+class TestVerificationResultMetadataTransientFlag:
+    def test_default_is_transient_false(self) -> None:
+        meta = _make_metadata()
+        assert meta.is_transient_error is False
+
+    def test_explicit_transient_true_roundtrip(self) -> None:
+        """Field set to True survives model_dump/model_validate."""
+        meta = _make_metadata(is_transient_error=True)
+        assert meta.is_transient_error is True
+
+        dumped = meta.model_dump()
+        assert dumped["is_transient_error"] is True
+
+        restored = VerificationResultMetadata.model_validate(dumped)
+        assert restored.is_transient_error is True

--- a/tests/unit/utils/test_answer_cache.py
+++ b/tests/unit/utils/test_answer_cache.py
@@ -331,6 +331,37 @@ class TestCacheEntryTimestamp:
         assert entry1.timestamp < entry2.timestamp
 
 
+class TestForceReset:
+    """Tests for force_reset method."""
+
+    def test_force_reset_removes_entry(self) -> None:
+        """Test that force_reset removes an existing cache entry."""
+        cache = AnswerTraceCache()
+        cache.get_or_reserve("key1")  # Creates IN_PROGRESS entry
+        cache.force_reset("key1")
+
+        # Next get_or_reserve should return MISS (not IN_PROGRESS)
+        status, data = cache.get_or_reserve("key1")
+        assert status == "MISS"
+        assert data is None
+
+    def test_force_reset_nonexistent_key_is_noop(self) -> None:
+        """Test that force_reset on missing key does not raise."""
+        cache = AnswerTraceCache()
+        cache.force_reset("nonexistent")  # Should not raise
+
+    def test_force_reset_completed_entry(self) -> None:
+        """Test that force_reset can remove a completed entry."""
+        cache = AnswerTraceCache()
+        cache.get_or_reserve("key1")
+        cache.complete("key1", {"answer": "test"})
+        cache.force_reset("key1")
+
+        status, data = cache.get_or_reserve("key1")
+        assert status == "MISS"
+        assert data is None
+
+
 class TestEdgeCases:
     """Tests for edge cases and error conditions."""
 

--- a/tests/unit/utils/test_errors.py
+++ b/tests/unit/utils/test_errors.py
@@ -1,0 +1,43 @@
+"""Tests for error detection utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.utils.errors import is_retryable_error
+
+
+@pytest.mark.unit
+class TestIsRetryableErrorEventLoop:
+    """Event loop errors should be classified as retryable (transient)."""
+
+    def test_event_loop_closed_is_retryable(self) -> None:
+        assert is_retryable_error(RuntimeError("Event loop is closed")) is True
+
+    def test_event_loop_different_message_retryable(self) -> None:
+        assert is_retryable_error(RuntimeError("Event loop is running")) is True
+
+
+@pytest.mark.unit
+class TestIsRetryableErrorPortal:
+    """Portal errors should be classified as retryable (transient)."""
+
+    def test_portal_not_running_is_retryable(self) -> None:
+        assert is_retryable_error(RuntimeError("This portal is not running")) is True
+
+
+@pytest.mark.unit
+class TestIsRetryableErrorExisting:
+    """Existing behavior preserved."""
+
+    def test_connection_error_is_retryable(self) -> None:
+        assert is_retryable_error(ConnectionError("connection reset")) is True
+
+    def test_value_error_is_not_retryable(self) -> None:
+        assert is_retryable_error(ValueError("invalid input")) is False
+
+    def test_timeout_error_is_retryable(self) -> None:
+        assert is_retryable_error(TimeoutError("timed out")) is True
+
+    def test_rate_limit_message_retryable(self) -> None:
+        assert is_retryable_error(Exception("rate limit exceeded")) is True


### PR DESCRIPTION
## Summary

Fixes the retry-multiplication bug where nested retries at the SDK, pipeline, and executor layers could compound into hundreds of real requests per failing question. Introduces a bounded retry model (`max_transient_retries`, `max_requeue_count`), classifies errors as transient at the context/orchestrator/stage level, restructures the executors to use per-worker `BlockingPortals` and `ThreadPoolExecutor`, and replaces the previous random task shuffle with KV-cache-aware task ordering that groups tasks to maximize prompt-prefix reuse on the inference backend.

## Changes Made

### Config foundation (bounded retry surface)
- New `max_transient_retries` and `max_requeue_count` fields on `VerificationConfig` and `ModelConfig` (`schemas/verification/config.py`, `schemas/config/models.py`)
- `batch_runner` stamps `max_transient_retries` onto each `ModelConfig` at task-dispatch time so every worker sees the same pipeline-level budget
- `AnswerTraceCache.force_reset()` added to support safe requeue (`utils/answer_cache.py`)
- SDK adapters (`adapters/langchain/llm.py`, `adapters/langchain/parser.py`) now pass `max_retries=0` and rely on the new `TRANSIENT_RETRY` constant; parser no longer swallows transient errors, it propagates them up the stack
- Executor requeue loop bounded by `max_requeue_count` to prevent runaway requeue (`benchmark/verification/executor.py`)

### KV-cache-aware task queue ordering
The previous executor called `random.shuffle` on the task queue before dispatch, which actively defeated the inference server's prompt-prefix KV cache: consecutive tasks sharing the same model and system prompt would hit cold caches on the backend even though their prefixes were identical.

- New `task_ordering` field on `VerificationConfig` with three modes:
  - `prefix_cache` (default): sort by `(answering_model, question, parsing_model, replicate)`, grouping tasks so identical prompt prefixes hit the inference server consecutively and the KV cache stays warm
  - `generation_order`: preserve the order the benchmark generated tasks in
  - `random`: the old shuffle behavior, available for users who need it
- New `model_sort_key` helper (`benchmark/verification/utils/task_helpers.py`) that returns a stable string key from a model identity so `ModelConfig` and `ModelIdentity` objects sort deterministically
- Same ordering applied to `ScenarioExecutor` combos, not just flat verification tasks
- Wired through the benchmark facade (`benchmark/benchmark.py`) and the batch runner

The hardcoded `random.shuffle` is gone. Users who benchmark against the same model across many questions should see significantly better inference-side throughput on backends that cache prompt prefixes.

### Executor concurrency
- Per-worker `BlockingPortal` lifecycle in both `VerificationExecutor` and `ScenarioExecutor`, replacing shared portals (`benchmark/verification/executor.py`, `benchmark/verification/scenario_executor.py`)
- Raw threads replaced by `ThreadPoolExecutor` in both executors with portal-per-task / portal-per-combo semantics

### Transient error classification and retry
- `retry zero-content streaming timeouts` in `generate_answer` stage so single-shot empty streaming responses get a retry budget
- `VerificationBatchError.errors` widened to `BaseException` so the batch error type can hold cancel-scope exceptions
- New transient-error tracking fields on verification schemas (`schemas/verification/result_components.py`)
- `VerificationContext` and the stage orchestrator now classify errors as transient; individual pipeline stages inherit the classification and surface it in stage results
- `ScenarioExecutor` retries scenario turns on transient pipeline errors within the bounded budget

## Testing

New test modules:
- `tests/unit/benchmark/verification/test_executor.py`, `tests/unit/benchmark/verification/test_scenario_executor_parallel.py`: portal-per-task and portal-per-combo assertions, hang-prevention under failure, bounded requeue behavior
- `tests/unit/benchmark/verification/test_batch_runner.py`: `max_transient_retries` propagation to per-task `ModelConfig`
- `tests/unit/benchmark/verification/test_task_helpers.py`: `model_sort_key` ordering under mixed models and identity types
- `tests/unit/benchmark/test_benchmark_scenario_ordering.py`: `task_ordering` wiring from benchmark facade end-to-end
- `tests/unit/schemas/test_verification_config.py`: config field validation for the new retry and ordering knobs (including `task_ordering` mode values)
- `tests/unit/utils/test_answer_cache.py`: `force_reset` semantics
- `tests/unit/adapters/langchain/test_llm_adapter.py`, `tests/unit/adapters/langchain/test_parser_adapter.py`: SDK `max_retries=0` and transient-error propagation

## Additional Context

- **No breaking public API changes**. All new config fields have safe defaults that preserve current behavior where possible. The one default change: `task_ordering` defaults to `prefix_cache`, which replaces the previous random shuffle. Users who need the old behavior can set `task_ordering='random'`.
- **Behavior change for nested retries**: the SDK layer no longer retries internally (`max_retries=0`). Transient errors now surface to the pipeline layer, which retries according to `max_transient_retries`. Users who relied on the old compounding behavior to mask transient failures will see errors earlier. This is the intended fix.
- **Behavior change for task order**: with the default `prefix_cache` mode, tasks sharing a model are grouped together. Per-task timing statistics may look different because cache hits cluster; total throughput should improve on inference backends that cache prompt prefixes (vLLM, TGI, SGLang, etc.).
- **Scale**: 41 files changed, +2,780 / -344 lines; 21 commits.