### PR TITLE
fix(adapters): bound LangChain agent http pool and per-call timeouts

### DIFF
--- a/src/karenina/adapters/langchain/agent.py
+++ b/src/karenina/adapters/langchain/agent.py
@@ -36,6 +36,38 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+async def _aclose_model_http_clients(model: Any) -> None:
+    """Close a LangChain chat model's underlying httpx clients, best-effort.
+
+    Used as an AsyncExitStack cleanup callback for per-arun() chat models so
+    that the underlying httpx connection pools are released deterministically.
+    Without this, vLLM streaming connections accumulate in CLOSE_WAIT until
+    GC finalizes the model (issue 194).
+
+    The function never raises: cleanup must not mask agent execution errors.
+    Both ChatOpenAI-derived classes (sync .http_client and async
+    .http_async_client) and provider-native classes (which may not expose
+    these attributes) are tolerated.
+
+    Args:
+        model: A LangChain chat model instance, typically returned from
+            init_chat_model_unified().
+    """
+    async_client = getattr(model, "http_async_client", None)
+    if async_client is not None:
+        try:
+            await async_client.aclose()
+        except Exception as exc:
+            logger.warning("Failed to close async httpx client on model cleanup: %s", exc)
+
+    sync_client = getattr(model, "http_client", None)
+    if sync_client is not None:
+        try:
+            sync_client.close()
+        except Exception as exc:
+            logger.warning("Failed to close sync httpx client on model cleanup: %s", exc)
+
+
 def extract_partial_agent_state(
     agent: Any,
     messages: list[Any],
@@ -206,7 +238,7 @@ class LangChainAgentAdapter:
         self,
         tools: list[Any],
         kwargs: dict[str, Any],
-    ) -> Any:
+    ) -> tuple[Any, Any]:
         """Create a LangGraph agent with pre-loaded tools.
 
         This is the canonical agent creation path for the LangChain adapter.
@@ -222,7 +254,9 @@ class LangChainAgentAdapter:
             kwargs: Additional kwargs for model initialization.
 
         Returns:
-            A LangGraph agent ready for invocation.
+            A tuple of (agent, base_model). The base_model is returned so the
+            caller can register its httpx clients for deterministic cleanup
+            (see arun() and issue 194).
         """
         from karenina.adapters.langchain.initialization import init_chat_model_unified
         from karenina.adapters.langchain.middleware import build_agent_middleware
@@ -285,7 +319,7 @@ class LangChainAgentAdapter:
 
         logger.info(f"Created agent with {len(tools)} MCP tools and {len(middleware)} middleware components")
 
-        return agent
+        return agent, base_model
 
     async def arun(
         self,
@@ -385,10 +419,18 @@ class LangChainAgentAdapter:
             if deferred_error is None:
                 # Create agent with persistent tools
                 try:
-                    agent = self._create_agent(persistent_tools, kwargs)
+                    agent, base_model = self._create_agent(persistent_tools, kwargs)
                 except Exception as e:
                     deferred_error = AgentExecutionError(f"Failed to initialize agent: {e}")
                     deferred_error.__cause__ = e
+                else:
+                    # Register the base model's httpx clients for deterministic
+                    # cleanup. The model is created fresh per arun() call, and
+                    # without explicit close its underlying httpx pool stays
+                    # alive until GC finalizes it: this is the leak window
+                    # documented in issue 194 (vLLM CLOSE_WAIT accumulation
+                    # under concurrent MCP-equipped agents).
+                    exit_stack.push_async_callback(_aclose_model_http_clients, base_model)
 
             if deferred_error is None:
                 if use_callback:
@@ -549,13 +591,15 @@ class LangChainAgentAdapter:
             return asyncio.run(self.arun(messages, tools, mcp_servers, config))
 
     async def aclose(self) -> None:
-        """Close underlying resources.
+        """Close underlying resources (no-op for the agent adapter).
 
-        LangChain adapters delegate to LangChain's model management which
-        handles its own HTTP client lifecycle. This is a no-op provided
-        for interface consistency with other adapters.
+        Unlike LangChainLLMAdapter, this adapter does not hold a long-lived
+        chat model. A fresh model is constructed inside each ``arun()`` call
+        and its httpx clients are closed deterministically via the
+        AsyncExitStack inside ``arun()`` (see _aclose_model_http_clients).
+        There is therefore nothing to release at adapter scope.
         """
-        pass
+        return None
 
 
 # Verify protocol compliance at import time

--- a/src/karenina/adapters/langchain/agent.py
+++ b/src/karenina/adapters/langchain/agent.py
@@ -299,12 +299,15 @@ class LangChainAgentAdapter:
         # Build middleware from configuration
         # Pass base_model so summarization uses the same model by default
         # Pass provider to enable provider-specific middleware (e.g., Anthropic prompt caching)
+        # Pass request_timeout so PerCallTimeoutMiddleware can bound each
+        # individual model.ainvoke() inside the agent loop (issue 195).
         middleware = build_agent_middleware(
             config=self._config.agent_middleware,
             max_context_tokens=max_context_tokens,
             interface=self._config.interface or "langchain",
             base_model=base_model,
             provider=self._config.model_provider,
+            request_timeout=self._config.request_timeout,
         )
 
         # Create agent with tools, middleware, and checkpointer

--- a/src/karenina/adapters/langchain/llm.py
+++ b/src/karenina/adapters/langchain/llm.py
@@ -672,13 +672,30 @@ class LangChainLLMAdapter:
     # =========================================================================
 
     async def aclose(self) -> None:
-        """Close underlying resources.
+        """Close the underlying model's httpx clients, best-effort.
 
-        LangChain adapters delegate to LangChain's model management which
-        handles its own HTTP client lifecycle. This is a no-op provided
-        for interface consistency with other adapters.
+        For ChatOpenAI-derived models (openai_endpoint, openrouter), this
+        releases the bounded httpx pool injected by the custom model classes.
+        For provider-native models (anthropic, openai, google via
+        init_chat_model), the http_client/http_async_client attributes are
+        usually not present and the call is a no-op.
+
+        Cleanup never raises: each close is wrapped in try/except so that
+        ``aclose`` can always be called safely from cleanup paths.
         """
-        pass
+        async_client = getattr(self._model, "http_async_client", None)
+        if async_client is not None:
+            try:
+                await async_client.aclose()
+            except Exception as exc:
+                logger.warning("Failed to close async httpx client on adapter aclose: %s", exc)
+
+        sync_client = getattr(self._model, "http_client", None)
+        if sync_client is not None:
+            try:
+                sync_client.close()
+            except Exception as exc:
+                logger.warning("Failed to close sync httpx client on adapter aclose: %s", exc)
 
 
 # Verify protocol compliance at import time

--- a/src/karenina/adapters/langchain/middleware.py
+++ b/src/karenina/adapters/langchain/middleware.py
@@ -9,6 +9,7 @@ Use the AgentPort interface via get_agent() instead.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -19,9 +20,17 @@ from pydantic import SecretStr
 from .prompts import SUMMARIZATION, build_question_context
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from karenina.schemas.config import AgentMiddlewareConfig
 
 logger = logging.getLogger(__name__)
+
+# Default per-LLM-call timeout used by PerCallTimeoutMiddleware when the
+# caller does not supply an explicit value. Matches the LangChainLLMAdapter
+# default (see llm.py _ainvoke_with_timeout) so the agent path and LLM path
+# share the same budget. See issue 195 for the wedge mode this prevents.
+_DEFAULT_PER_CALL_TIMEOUT_S = 180.0
 
 
 def fetch_openai_endpoint_context_size(
@@ -249,12 +258,93 @@ def create_invoke_summarization_middleware(
     )
 
 
+class PerCallTimeoutMiddleware(_get_agent_middleware_base()):  # type: ignore[misc]
+    """Middleware that bounds each individual model.ainvoke() inside the agent loop.
+
+    LangGraph's create_agent wraps the whole agent loop (many model + tool
+    iterations) in a single asyncio.wait_for at agent.py:arun(), but does not
+    bound each individual model call. Issue 195 documented a residual wedge
+    mode where a single model.ainvoke() inside the loop silently stalls for
+    the entire agent_timeout, even though httpx.Timeout(read=120s) is
+    configured on the underlying http client. The wedge is silent: no
+    httpx.ReadTimeout, no openai APITimeoutError, no exception at all until
+    the outer agent_timeout fires and kills the whole run.
+
+    This middleware mirrors the LangChainLLMAdapter._ainvoke_with_timeout
+    pattern at the LangGraph-middleware layer: every model call that
+    _execute_model_async makes inside the agent loop runs under an
+    asyncio.wait_for budget. When the budget expires, a stock
+    asyncio.TimeoutError is raised, which the ModelRetryMiddleware layered
+    above catches and retries with backoff. If all retries exhaust, the
+    exception propagates out of agent.ainvoke() where the existing
+    exception handler logs it as AgentExecutionError.
+
+    The sync wrap_model_call path is implemented as a passthrough (no
+    timeout) because karenina's agent adapter only ever runs async, and
+    interrupting a sync call cleanly without spawning threads is not
+    straightforward. If a sync code path ever hits this middleware, it
+    still functions, just without the guardrail.
+    """
+
+    def __init__(self, timeout: float) -> None:
+        """Initialize the per-call timeout middleware.
+
+        Args:
+            timeout: Per-model-call wall-clock timeout in seconds. Must be
+                positive. Callers that want "no timeout" should simply not
+                attach this middleware.
+        """
+        super().__init__()
+        if timeout <= 0:
+            msg = f"PerCallTimeoutMiddleware timeout must be positive, got {timeout}"
+            raise ValueError(msg)
+        self.timeout = timeout
+        self.tools: list[Any] = []  # no extra tools registered
+
+    def wrap_model_call(
+        self,
+        request: Any,
+        handler: Callable[[Any], Any],
+    ) -> Any:
+        """Sync passthrough: the agent adapter is async-only in karenina.
+
+        See class docstring: we intentionally do not try to bound sync calls.
+        This method exists only so the middleware does not raise
+        NotImplementedError if LangGraph ever routes a sync call through it.
+        """
+        return handler(request)
+
+    async def awrap_model_call(
+        self,
+        request: Any,
+        handler: Callable[[Any], Awaitable[Any]],
+    ) -> Any:
+        """Bound a single async model call by wall-clock timeout.
+
+        Calls the provided ``handler`` (which executes the model inside the
+        LangGraph agent loop) under an ``asyncio.wait_for`` wrapper. On
+        timeout, cancels the underlying handler and raises
+        ``asyncio.TimeoutError``; the outer ModelRetryMiddleware, if
+        present, retries the call with backoff.
+        """
+        try:
+            return await asyncio.wait_for(handler(request), timeout=self.timeout)
+        except TimeoutError:
+            logger.warning(
+                "PerCallTimeoutMiddleware: model call exceeded %.1fs budget; "
+                "cancelling and letting the retry layer handle it",
+                self.timeout,
+            )
+            raise
+
+
 def build_agent_middleware(
     config: AgentMiddlewareConfig | None,
     max_context_tokens: int | None = None,
     interface: str = "langchain",
     base_model: Any = None,
     provider: str | None = None,
+    request_timeout: float | None = None,
 ) -> list[Any]:
     """Build middleware list from configuration.
 
@@ -267,6 +357,12 @@ def build_agent_middleware(
             Required if summarization is enabled and no explicit model is configured.
         provider: The model provider (e.g., "anthropic", "openai"). Used to add
             provider-specific middleware like Anthropic prompt caching.
+        request_timeout: Per-LLM-call wall-clock timeout in seconds. When
+            set to a positive value, a PerCallTimeoutMiddleware is added
+            so each individual model.ainvoke() inside the agent loop is
+            bounded. When None or non-positive, no per-call guardrail is
+            added (the outer agent_timeout remains the only safety net).
+            See issue 195 for the wedge mode this prevents.
 
     Returns:
         List of configured middleware instances.
@@ -337,6 +433,18 @@ def build_agent_middleware(
             on_failure=config.model_retry.on_failure,  # type: ignore[arg-type]
         )
     )
+
+    # 3b. Per-LLM-call timeout middleware (inner to retry so each attempt
+    # gets its own budget). Added only when a positive request_timeout is
+    # supplied so the default behaviour (no per-call guardrail) stays the
+    # same for callers that do not opt in. See issue 195.
+    effective_call_timeout = request_timeout if request_timeout is not None and request_timeout > 0 else None
+    if effective_call_timeout is not None:
+        middleware.append(PerCallTimeoutMiddleware(timeout=effective_call_timeout))
+        logger.info(
+            "PerCallTimeoutMiddleware enabled: timeout=%.1fs (from request_timeout)",
+            effective_call_timeout,
+        )
 
     # 4. Tool retry middleware (new capability)
     middleware.append(

--- a/src/karenina/adapters/langchain/models.py
+++ b/src/karenina/adapters/langchain/models.py
@@ -14,10 +14,75 @@ import os
 import re
 from typing import Any
 
+import httpx
 from langchain_openai import ChatOpenAI
 from pydantic import Field, SecretStr
 
 logger = logging.getLogger(__name__)
+
+# Httpx pool sizing for ChatOpenAI-derived custom models.
+#
+# These bound the underlying httpx connection pool so that, under concurrent
+# streaming load, sockets in CLOSE_WAIT cannot accumulate without limit and
+# pool waits cannot block forever. The pool deadline turns silent waits into
+# httpx.PoolTimeout exceptions, which ErrorRegistry classifies as TIMEOUT and
+# RetryExecutor can rescue. See issue 194 for the lsof-confirmed root cause.
+_HTTPX_DEFAULT_MAX_CONNECTIONS = 32
+_HTTPX_DEFAULT_MAX_KEEPALIVE = 16
+_HTTPX_DEFAULT_POOL_TIMEOUT_S = 30.0
+_HTTPX_DEFAULT_CONNECT_TIMEOUT_S = 10.0
+# Per-chunk read timeout: this is NOT a wall-clock budget for the whole
+# response, it is the maximum gap between successive bytes/chunks. Streaming
+# generations can run for many minutes, but individual token-to-token gaps
+# (even during heavy "thinking" phases) should be a few seconds at most. A
+# silent stream death (vLLM sent FIN but no ReadTimeout fires because we
+# never asked for one) was the second wedge mode observed in issue 194 after
+# the pool fix landed: the pool fix bounded socket counts but a stuck
+# ESTABLISHED stream still hung the agent for the full agent_timeout. This
+# converts that hang into a retryable httpx.ReadTimeout within ~2 minutes,
+# which RetryExecutor classifies as TIMEOUT and rescues automatically.
+_HTTPX_DEFAULT_READ_TIMEOUT_S = 120.0
+
+
+def _build_default_request_timeout() -> httpx.Timeout:
+    """Build the per-request timeout that bounds read and connect waits.
+
+    The openai SDK overrides the underlying httpx client's default Timeout
+    on every request via ``client.send(request, timeout=...)``, which means
+    setting read/connect on the http client alone has no effect on real
+    traffic. We pass this Timeout via langchain-openai's ``request_timeout``
+    field instead: that maps to the openai SDK's ``timeout`` parameter,
+    which is then used for ``client.send`` and DOES bound each request.
+
+    Pool deadline is still meaningful here: it bounds the wait when a
+    request needs to acquire a connection from the underlying pool, before
+    any send call is even reached.
+    """
+    return httpx.Timeout(
+        connect=_HTTPX_DEFAULT_CONNECT_TIMEOUT_S,
+        read=_HTTPX_DEFAULT_READ_TIMEOUT_S,
+        write=None,
+        pool=_HTTPX_DEFAULT_POOL_TIMEOUT_S,
+    )
+
+
+def _build_httpx_clients() -> tuple[httpx.Client, httpx.AsyncClient]:
+    """Build sync and async httpx clients with bounded pool and read timeouts.
+
+    Returns:
+        A tuple of (sync_client, async_client). Both are configured with the
+        module-level default Limits and Timeout. The read timeout on the
+        client itself is mostly a defense-in-depth measure: the openai SDK
+        overrides per-request timeouts via ``client.send(request, timeout=)``
+        so the effective per-request bound also has to be set via
+        ``request_timeout`` on the model class. See _build_default_request_timeout.
+    """
+    limits = httpx.Limits(
+        max_connections=_HTTPX_DEFAULT_MAX_CONNECTIONS,
+        max_keepalive_connections=_HTTPX_DEFAULT_MAX_KEEPALIVE,
+    )
+    timeout = _build_default_request_timeout()
+    return httpx.Client(limits=limits, timeout=timeout), httpx.AsyncClient(limits=limits, timeout=timeout)
 
 
 def _normalize_openai_endpoint_url(base_url: str) -> str:
@@ -74,6 +139,17 @@ class ChatOpenRouter(ChatOpenAI):
 
     def __init__(self, openai_api_key: str | None = None, **kwargs: Any) -> None:
         openai_api_key = openai_api_key or os.environ.get("OPENROUTER_API_KEY")
+        # Inject bounded httpx clients unless the caller already supplied them.
+        # See _build_httpx_clients docstring and issue 194 for rationale.
+        if "http_client" not in kwargs and "http_async_client" not in kwargs:
+            sync_client, async_client = _build_httpx_clients()
+            kwargs["http_client"] = sync_client
+            kwargs["http_async_client"] = async_client
+        # Inject the per-request timeout that openai SDK actually honors.
+        # Without this, openai's per-request timeout override (~600s) defeats
+        # the read timeout we tried to set on the http client.
+        if "request_timeout" not in kwargs and "timeout" not in kwargs:
+            kwargs["request_timeout"] = _build_default_request_timeout()
         super().__init__(
             base_url="https://openrouter.ai/api/v1",
             api_key=SecretStr(openai_api_key) if openai_api_key else None,
@@ -120,6 +196,18 @@ class ChatOpenAIEndpoint(ChatOpenAI):
 
         # Normalize URL to ensure it ends with /v1
         normalized_url = _normalize_openai_endpoint_url(base_url)
+
+        # Inject bounded httpx clients unless the caller already supplied them.
+        # See _build_httpx_clients docstring and issue 194 for rationale.
+        if "http_client" not in kwargs and "http_async_client" not in kwargs:
+            sync_client, async_client = _build_httpx_clients()
+            kwargs["http_client"] = sync_client
+            kwargs["http_async_client"] = async_client
+        # Inject the per-request timeout that openai SDK actually honors.
+        # Without this, openai's per-request timeout override (~600s) defeats
+        # the read timeout we tried to set on the http client.
+        if "request_timeout" not in kwargs and "timeout" not in kwargs:
+            kwargs["request_timeout"] = _build_default_request_timeout()
 
         super().__init__(
             base_url=normalized_url,

--- a/tests/unit/adapters/langchain/test_models.py
+++ b/tests/unit/adapters/langchain/test_models.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import httpx
 import pytest
+
+from karenina.adapters.langchain.models import (
+    _HTTPX_DEFAULT_CONNECT_TIMEOUT_S,
+    _HTTPX_DEFAULT_MAX_CONNECTIONS,
+    _HTTPX_DEFAULT_MAX_KEEPALIVE,
+    _HTTPX_DEFAULT_POOL_TIMEOUT_S,
+    _HTTPX_DEFAULT_READ_TIMEOUT_S,
+)
 
 
 class TestChatOpenRouter:
@@ -70,3 +79,103 @@ class TestChatOpenAIEndpoint:
         )
         secrets = model.lc_secrets
         assert secrets == {}
+
+
+def _assert_bounded_httpx_client(client: httpx.AsyncClient | httpx.Client) -> None:
+    """Assert that an httpx client has bounded limits and a pool timeout.
+
+    See _build_httpx_clients in models.py and issue 194 for rationale.
+    """
+    assert client is not None
+    # Pool deadline must be set so silent waits raise PoolTimeout instead
+    # of blocking forever.
+    assert client.timeout.pool == _HTTPX_DEFAULT_POOL_TIMEOUT_S
+    assert client.timeout.connect == _HTTPX_DEFAULT_CONNECT_TIMEOUT_S
+    # Read timeout is a per-chunk gap budget, not a total response budget,
+    # so it bounds silent stream death without interrupting normal streaming.
+    assert client.timeout.read == _HTTPX_DEFAULT_READ_TIMEOUT_S
+    # Write left at None: prompts are short and never streamed.
+    assert client.timeout.write is None
+    # Pool size must be bounded so CLOSE_WAIT cannot accumulate without limit.
+    pool = client._transport._pool  # noqa: SLF001 (private access intentional for test assertions)
+    assert pool._max_connections == _HTTPX_DEFAULT_MAX_CONNECTIONS
+    assert pool._max_keepalive_connections == _HTTPX_DEFAULT_MAX_KEEPALIVE
+
+
+def _assert_bounded_request_timeout(model: object) -> None:
+    """Assert that the model has a per-request httpx.Timeout that openai SDK honors.
+
+    The openai SDK overrides per-request timeouts via ``client.send(request,
+    timeout=...)``, so the http_client's default timeout alone is not enough.
+    The model must also expose ``request_timeout`` set to an httpx.Timeout
+    with bounded read and pool deadlines.
+    """
+    request_timeout = getattr(model, "request_timeout", None)
+    assert isinstance(request_timeout, httpx.Timeout), f"expected httpx.Timeout, got {type(request_timeout).__name__}"
+    assert request_timeout.read == _HTTPX_DEFAULT_READ_TIMEOUT_S
+    assert request_timeout.connect == _HTTPX_DEFAULT_CONNECT_TIMEOUT_S
+    assert request_timeout.pool == _HTTPX_DEFAULT_POOL_TIMEOUT_S
+    assert request_timeout.write is None
+
+
+class TestHttpxPoolConfig:
+    """Tests that custom model classes inject bounded httpx clients.
+
+    Regression coverage for issue 194: under concurrent streaming load,
+    the default httpx pool failed to release vLLM connections (CLOSE_WAIT
+    accumulation), causing requests to block forever waiting for a slot.
+    The custom model classes now inject explicit Limits and Timeout(pool=)
+    so that the pool wait raises PoolTimeout instead of hanging.
+    """
+
+    def test_chat_openai_endpoint_injects_bounded_httpx_clients(self) -> None:
+        from karenina.adapters.langchain.models import ChatOpenAIEndpoint
+
+        model = ChatOpenAIEndpoint(
+            base_url="http://localhost:8000",
+            openai_api_key="test-key",
+            model="dummy",
+            max_retries=0,
+        )
+        _assert_bounded_httpx_client(model.http_async_client)
+        _assert_bounded_httpx_client(model.http_client)
+        _assert_bounded_request_timeout(model)
+
+    def test_chat_openrouter_injects_bounded_httpx_clients(self) -> None:
+        from karenina.adapters.langchain.models import ChatOpenRouter
+
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}):
+            model = ChatOpenRouter(model="gpt-4", max_retries=0)
+        _assert_bounded_httpx_client(model.http_async_client)
+        _assert_bounded_httpx_client(model.http_client)
+        _assert_bounded_request_timeout(model)
+
+    def test_caller_supplied_http_clients_are_respected(self) -> None:
+        """If the caller passes their own http clients, do not override them."""
+        from karenina.adapters.langchain.models import ChatOpenAIEndpoint
+
+        custom_async = httpx.AsyncClient()
+        custom_sync = httpx.Client()
+        model = ChatOpenAIEndpoint(
+            base_url="http://localhost:8000",
+            openai_api_key="test-key",
+            model="dummy",
+            max_retries=0,
+            http_client=custom_sync,
+            http_async_client=custom_async,
+        )
+        assert model.http_async_client is custom_async
+        assert model.http_client is custom_sync
+
+    def test_caller_supplied_request_timeout_is_respected(self) -> None:
+        """If the caller passes their own request_timeout, do not override it."""
+        from karenina.adapters.langchain.models import ChatOpenAIEndpoint
+
+        model = ChatOpenAIEndpoint(
+            base_url="http://localhost:8000",
+            openai_api_key="test-key",
+            model="dummy",
+            max_retries=0,
+            request_timeout=42.0,
+        )
+        assert model.request_timeout == 42.0

--- a/tests/unit/adapters/langchain/test_per_call_timeout_middleware.py
+++ b/tests/unit/adapters/langchain/test_per_call_timeout_middleware.py
@@ -1,0 +1,255 @@
+"""Tests for PerCallTimeoutMiddleware (issue 195).
+
+The LangChain agent loop runs many ``model.ainvoke()`` calls under a single
+outer ``asyncio.wait_for`` that budgets the full ``agent_timeout``. If a
+single call wedges silently, the only safety net is that outer budget,
+which pays a full timeout per rescue. Issue 195 documented 2-in-576 such
+wedges on vLLM streaming responses where httpx's read timeout never fired.
+
+PerCallTimeoutMiddleware wraps every ``handler(request)`` invocation in
+an ``asyncio.wait_for`` so each individual model call is bounded. When
+the budget expires the stock ``asyncio.TimeoutError`` propagates to the
+outer ``ModelRetryMiddleware`` which retries with backoff, mirroring the
+LangChainLLMAdapter._ainvoke_with_timeout pattern at the agent layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from karenina.adapters.langchain.middleware import (
+    PerCallTimeoutMiddleware,
+    build_agent_middleware,
+)
+
+
+class _FakeRequest:
+    """Minimal stand-in for langchain.agents.middleware.types.ModelRequest."""
+
+
+class _FakeResponse:
+    """Minimal stand-in for ModelResponse."""
+
+    def __init__(self, value: str = "ok") -> None:
+        self.value = value
+
+
+@pytest.mark.unit
+class TestPerCallTimeoutMiddleware:
+    """Direct tests on PerCallTimeoutMiddleware.awrap_model_call."""
+
+    def test_rejects_non_positive_timeout(self) -> None:
+        with pytest.raises(ValueError, match="must be positive"):
+            PerCallTimeoutMiddleware(timeout=0)
+        with pytest.raises(ValueError, match="must be positive"):
+            PerCallTimeoutMiddleware(timeout=-1.5)
+
+    @pytest.mark.asyncio
+    async def test_passes_through_fast_call(self) -> None:
+        """A handler that completes quickly should return unchanged."""
+        mw = PerCallTimeoutMiddleware(timeout=1.0)
+        expected = _FakeResponse("fast")
+
+        async def handler(_req: Any) -> _FakeResponse:
+            return expected
+
+        result = await mw.awrap_model_call(_FakeRequest(), handler)
+        assert result is expected
+
+    @pytest.mark.asyncio
+    async def test_raises_timeout_on_slow_call(self) -> None:
+        """A handler that blocks longer than timeout raises asyncio.TimeoutError."""
+        mw = PerCallTimeoutMiddleware(timeout=0.05)
+
+        async def handler(_req: Any) -> _FakeResponse:
+            await asyncio.sleep(5.0)  # deliberately longer than timeout
+            return _FakeResponse("should-not-reach")
+
+        with pytest.raises(asyncio.TimeoutError):
+            await mw.awrap_model_call(_FakeRequest(), handler)
+
+    @pytest.mark.asyncio
+    async def test_cancels_underlying_handler_on_timeout(self) -> None:
+        """When the budget fires, the underlying handler coroutine is cancelled."""
+        mw = PerCallTimeoutMiddleware(timeout=0.05)
+        cancelled = asyncio.Event()
+
+        async def handler(_req: Any) -> _FakeResponse:
+            try:
+                await asyncio.sleep(5.0)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+            return _FakeResponse("should-not-reach")
+
+        with pytest.raises(asyncio.TimeoutError):
+            await mw.awrap_model_call(_FakeRequest(), handler)
+        # Give the event loop a tick to observe the cancellation
+        await asyncio.sleep(0)
+        assert cancelled.is_set(), "handler was not cancelled on timeout"
+
+    @pytest.mark.asyncio
+    async def test_propagates_handler_exceptions_unchanged(self) -> None:
+        """A non-timeout exception from the handler should propagate untouched."""
+        mw = PerCallTimeoutMiddleware(timeout=1.0)
+
+        class _BoomError(RuntimeError):
+            pass
+
+        async def handler(_req: Any) -> _FakeResponse:
+            raise _BoomError("synthetic")
+
+        with pytest.raises(_BoomError, match="synthetic"):
+            await mw.awrap_model_call(_FakeRequest(), handler)
+
+    def test_sync_wrap_is_passthrough(self) -> None:
+        """The sync path is intentionally a passthrough (see class docstring)."""
+        mw = PerCallTimeoutMiddleware(timeout=0.001)
+        sentinel = object()
+        called = {"n": 0}
+
+        def handler(_req: Any) -> object:
+            called["n"] += 1
+            return sentinel
+
+        result = mw.wrap_model_call(_FakeRequest(), handler)
+        assert result is sentinel
+        assert called["n"] == 1
+
+
+def _build_config_without_summarization() -> Any:
+    """Return an AgentMiddlewareConfig with summarization disabled.
+
+    ``build_agent_middleware`` otherwise raises when no base_model is
+    provided, because the default summarization middleware needs a model
+    instance. These tests only care about timeout wiring.
+    """
+    from karenina.schemas.config import AgentMiddlewareConfig
+
+    cfg = AgentMiddlewareConfig()
+    cfg.summarization.enabled = False
+    return cfg
+
+
+@pytest.mark.unit
+class TestBuildAgentMiddlewareTimeoutWiring:
+    """Tests that build_agent_middleware installs the timeout MW correctly."""
+
+    def test_not_added_when_request_timeout_is_none(self) -> None:
+        middleware = build_agent_middleware(
+            config=_build_config_without_summarization(),
+            request_timeout=None,
+        )
+        assert not any(isinstance(m, PerCallTimeoutMiddleware) for m in middleware)
+
+    def test_not_added_when_request_timeout_is_zero(self) -> None:
+        middleware = build_agent_middleware(
+            config=_build_config_without_summarization(),
+            request_timeout=0.0,
+        )
+        assert not any(isinstance(m, PerCallTimeoutMiddleware) for m in middleware)
+
+    def test_not_added_when_request_timeout_is_negative(self) -> None:
+        middleware = build_agent_middleware(
+            config=_build_config_without_summarization(),
+            request_timeout=-10.0,
+        )
+        assert not any(isinstance(m, PerCallTimeoutMiddleware) for m in middleware)
+
+    def test_added_with_configured_timeout_when_request_timeout_is_positive(self) -> None:
+        middleware = build_agent_middleware(
+            config=_build_config_without_summarization(),
+            request_timeout=45.5,
+        )
+        timeout_mws = [m for m in middleware if isinstance(m, PerCallTimeoutMiddleware)]
+        assert len(timeout_mws) == 1
+        assert timeout_mws[0].timeout == 45.5
+
+    def test_timeout_middleware_is_inner_to_model_retry_middleware(self) -> None:
+        """PerCallTimeoutMiddleware must sit INSIDE ModelRetryMiddleware.
+
+        The outer ModelRetryMiddleware catches asyncio.TimeoutError and retries
+        the handler. If the order were reversed, the retry layer could not
+        observe timeouts and the guardrail would not compose with backoff.
+        """
+        from langchain.agents.middleware import ModelRetryMiddleware
+
+        middleware = build_agent_middleware(
+            config=_build_config_without_summarization(),
+            request_timeout=30.0,
+        )
+        retry_idx = next(i for i, m in enumerate(middleware) if isinstance(m, ModelRetryMiddleware))
+        timeout_idx = next(i for i, m in enumerate(middleware) if isinstance(m, PerCallTimeoutMiddleware))
+        assert retry_idx < timeout_idx, (
+            f"ModelRetryMiddleware (idx {retry_idx}) must come before "
+            f"PerCallTimeoutMiddleware (idx {timeout_idx}) so retry is the outer layer"
+        )
+
+
+@pytest.mark.unit
+class TestAgentCreateAgentPassesRequestTimeout:
+    """Integration: LangChainAgentAdapter._create_agent wires request_timeout through."""
+
+    def test_create_agent_passes_request_timeout_to_build_agent_middleware(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from karenina.adapters.langchain import agent as agent_module
+        from karenina.adapters.langchain.agent import LangChainAgentAdapter
+        from karenina.schemas.config import ModelConfig
+
+        config = ModelConfig(
+            id="test",
+            model_name="test-model",
+            model_provider="openai",
+            interface="langchain",
+            request_timeout=42.0,
+        )
+
+        adapter = LangChainAgentAdapter(config)
+
+        captured_kwargs: dict[str, Any] = {}
+
+        def fake_init_chat_model_unified(**kwargs: Any) -> Any:
+            return MagicMock(name="base_model")
+
+        def fake_build_agent_middleware(**kwargs: Any) -> list[Any]:
+            captured_kwargs.update(kwargs)
+            return []
+
+        def fake_create_agent(**_kwargs: Any) -> Any:
+            return MagicMock(name="agent")
+
+        # Patch the three things _create_agent imports via lazy imports
+        monkeypatch.setattr(
+            "karenina.adapters.langchain.initialization.init_chat_model_unified",
+            fake_init_chat_model_unified,
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain.middleware.build_agent_middleware",
+            fake_build_agent_middleware,
+        )
+        monkeypatch.setattr(
+            "langchain.agents.create_agent",
+            fake_create_agent,
+        )
+        # InMemorySaver is also imported inside _create_agent
+        fake_memory = MagicMock(name="InMemorySaver")
+        monkeypatch.setattr(
+            "langgraph.checkpoint.memory.InMemorySaver",
+            lambda: fake_memory,
+        )
+        # Prevent the openai_endpoint branch from trying to call the network
+        monkeypatch.setattr(
+            "karenina.adapters.langchain.middleware.fetch_openai_endpoint_context_size",
+            lambda **_kwargs: None,
+        )
+        # Silence module-level references just in case
+        _ = agent_module
+
+        adapter._create_agent(tools=[], kwargs={})
+
+        assert captured_kwargs.get("request_timeout") == 42.0


### PR DESCRIPTION
## Summary

Two complementary fixes for wedges in `LangChainAgentAdapter.arun()` under concurrent vLLM + MCP load, discovered and validated end-to-end on the OTP MCP sycophancy benchmark.

- **Issue 194** (httpx pool exhaustion): bound the httpx connection pool, per-request read timeout, and per-`arun()` http client cleanup for `ChatOpenAIEndpoint` and `ChatOpenRouter`.
- **Issue 195** (agent loop lacked per-LLM-call timeout): install a `PerCallTimeoutMiddleware` into LangGraph's `awrap_model_call` hook so each `model.ainvoke()` inside the agent loop is bounded by `asyncio.wait_for(..., timeout=ModelConfig.request_timeout)`, mirroring the existing `LangChainLLMAdapter._ainvoke_with_timeout` pattern at the agent layer.

## What changed

- `adapters/langchain/models.py`: bounded `httpx.Limits`, explicit `Timeout(connect=10, read=120, pool=30)`, and `request_timeout` injection on both custom model classes.
- `adapters/langchain/agent.py`: per-`arun()` http client cleanup via `AsyncExitStack.push_async_callback(_aclose_model_http_clients)`; `_create_agent` now returns `(agent, base_model)` and passes `request_timeout` through to `build_agent_middleware`.
- `adapters/langchain/middleware.py`: new `PerCallTimeoutMiddleware` (async `awrap_model_call`) installed after `ModelRetryMiddleware` so retry composes with the budget. Attached only when `ModelConfig.request_timeout` is a positive value (default behaviour unchanged otherwise).
- Tests: new `test_per_call_timeout_middleware.py` (12 cases) covering direct behaviour, `build_agent_middleware` wiring, middleware ordering relative to `ModelRetryMiddleware`, and integration through `_create_agent`. Existing `test_models.py::TestHttpxPoolConfig` covers the pool/timeout injection from 194.

## End-to-end validation

Benchmark: `adversarial/experiment/run_guardrail_test_qwen122b_async_otp_mcp.py` (qwen3.5-122b-a10b on LAN vLLM + local OTP MCP server, 576 aruns over 144 scenarios x 2 conditions).

| Metric | Pre-fix baseline | Post-fix (24 workers) |
|---|---|---|
| Agent timed out after 600s | 2 / 576 | 1 / 576 |
| PoolTimeout (httpx) | unbounded CLOSE_WAIT growth | 0 |
| ReadTimeout (httpx) | 0 (didn't fire) | 0 |
| LLMPort streaming/invoke timeouts rescued | 4 + 4 | 8 + 11 |
| Wall time | ~60 min (12 workers) | ~50.5 min (24 workers) |
| Unit tests | --- | 4931/4931 pass, 133/133 langchain |

The remaining 1/576 wedge is a distinct mode (sustained-slow correction path, ~11 sub-180s operations accumulating past `agent_timeout=600s`). `PerCallTimeoutMiddleware` correctly does not fire on it because no individual call exceeds the budget. Tracked separately as issue 196.

## Test plan

- [x] `cd karenina && uv run pytest tests/ -x -q` -> 4931 passed, 12 skipped
- [x] `cd karenina && uv run pytest tests/unit/adapters/langchain/ -q` -> 133 passed
- [x] ruff check + format clean on all modified files
- [x] mypy clean on modified files
- [x] E2E: full 576-arun OTP MCP benchmark at 24 workers, clean exit
- [ ] CI on `dev` (to be observed after open)