### PR TITLE
feat(verification): conditional ground truth and conversation context capture

### DIFF
--- a/src/karenina/benchmark/core/results_store.py
+++ b/src/karenina/benchmark/core/results_store.py
@@ -287,11 +287,15 @@ class ResultsStore:
 
         Returns:
             Dict with a ``runs`` key mapping run names to lists of
-            serialized result dicts.
+            serialized result dicts. If any scenario execution results
+            carry ``outcome_results``, a ``scenario_outcomes`` key is
+            added at the top level mapping run name to a dict of
+            ``scenario_id -> outcome_results``.
         """
         runs_to_export = {run_name: self._runs[run_name]} if run_name and run_name in self._runs else dict(self._runs)
 
         exported_runs: dict[str, list[dict[str, Any]]] = {}
+        scenario_outcomes: dict[str, dict[str, dict[str, bool | int | float]]] = {}
         for rn, result_set in runs_to_export.items():
             results_list = []
             for result in result_set.results:
@@ -301,7 +305,19 @@ class ResultsStore:
             if results_list:
                 exported_runs[rn] = results_list
 
-        return {"runs": exported_runs}
+            if result_set.scenario_results:
+                per_scenario: dict[str, dict[str, bool | int | float]] = {}
+                for er in result_set.scenario_results:
+                    outcomes = getattr(er, "outcome_results", None)
+                    if outcomes:
+                        per_scenario[er.scenario_id] = dict(outcomes)
+                if per_scenario:
+                    scenario_outcomes[rn] = per_scenario
+
+        output: dict[str, Any] = {"runs": exported_runs}
+        if scenario_outcomes:
+            output["scenario_outcomes"] = scenario_outcomes
+        return output
 
     def export_to_file(
         self,

--- a/src/karenina/benchmark/verification/stages/core/base.py
+++ b/src/karenina/benchmark/verification/stages/core/base.py
@@ -153,6 +153,8 @@ class ArtifactKeys:
 
     # Dict of node_results from ScenarioState, for conditional ground truth
     SCENARIO_NODE_RESULTS = "scenario_node_results"
+    # Full conversation input sent to the LLM (system + prior turns + current question)
+    CONVERSATION_CONTEXT = "conversation_context"
 
     # ==========================================================================
     # Deep Judgment (Template)

--- a/src/karenina/benchmark/verification/stages/core/base.py
+++ b/src/karenina/benchmark/verification/stages/core/base.py
@@ -148,6 +148,13 @@ class ArtifactKeys:
     EMBEDDING_MODEL_USED = "embedding_model_used"
 
     # ==========================================================================
+    # Scenario Context
+    # ==========================================================================
+
+    # Dict of node_results from ScenarioState, for conditional ground truth
+    SCENARIO_NODE_RESULTS = "scenario_node_results"
+
+    # ==========================================================================
     # Deep Judgment (Template)
     # ==========================================================================
 

--- a/src/karenina/benchmark/verification/stages/pipeline/embedding_check.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/embedding_check.py
@@ -105,6 +105,14 @@ class EmbeddingCheckStage(BaseVerificationStage):
         # Extract ground truth and LLM response for embedding check
         parsed_gt_response, parsed_llm_response = _split_parsed_response(parsed_answer)
 
+        # Merge resolved conditional ground truths so the comparison is symmetric
+        if hasattr(parsed_answer, "_get_resolved_ground_truths"):
+            resolved_gts = parsed_answer._get_resolved_ground_truths()
+            if resolved_gts and parsed_gt_response is not None:
+                parsed_gt_response = {**parsed_gt_response, **resolved_gts}
+            elif resolved_gts and parsed_gt_response is None:
+                parsed_gt_response = dict(resolved_gts)
+
         # Perform embedding check, passing config from context
         (should_override, similarity_score, model_name, check_performed) = perform_embedding_check(
             parsed_gt_response,

--- a/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
@@ -106,6 +106,13 @@ class FinalizeResultStage(BaseVerificationStage):
                     computed = parsed_answer._compute_field_results()
                     if computed:
                         field_results_dict = computed
+                    # Merge resolved ground truths (including conditional) into
+                    # parsed_gt_response so downstream consumers see all fields
+                    resolved_gts = parsed_answer._get_resolved_ground_truths()
+                    if resolved_gts and parsed_gt_response is not None:
+                        parsed_gt_response.update(resolved_gts)
+                    elif resolved_gts and parsed_gt_response is None:
+                        parsed_gt_response = dict(resolved_gts)
                 except Exception as e:
                     logger.warning("Failed to compute field results: %s", e)
 
@@ -212,6 +219,15 @@ class FinalizeResultStage(BaseVerificationStage):
                 d["block_index"] = block_index
                 trace_messages_dicts.append(d)
 
+        # Build conversation_context (full LLM input: system + prior turns + current question)
+        conversation_context_dicts: list[dict[str, Any]] = []
+        conversation_context_raw = context.get_artifact(ArtifactKeys.CONVERSATION_CONTEXT)
+        if conversation_context_raw:
+            for block_index, msg in enumerate(conversation_context_raw):
+                d = msg.to_dict()
+                d["block_index"] = block_index
+                conversation_context_dicts.append(d)
+
         # Compute raw_llm_response from trace_messages if available,
         # otherwise fall back to the string stored by generate_answer
         raw_llm_response = context.get_result_field(ArtifactKeys.RAW_LLM_RESPONSE, "")
@@ -226,6 +242,7 @@ class FinalizeResultStage(BaseVerificationStage):
         template = VerificationResultTemplate(
             raw_llm_response=raw_llm_response,
             trace_messages=trace_messages_dicts,
+            conversation_context=conversation_context_dicts,
             parsed_gt_response=parsed_gt_response,
             parsed_llm_response=parsed_llm_response,
             template_verification_performed=template_verification_performed,

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -208,6 +208,13 @@ class GenerateAnswerStage(BaseVerificationStage):
                 usage_tracker.set_agent_metrics(agent_metrics)
             context.set_artifact(ArtifactKeys.USAGE_TRACKER, usage_tracker)
 
+            # Reconstruct conversation context for cached results (scenario turns)
+            conversation_history = context.get_artifact("conversation_history")
+            if conversation_history:
+                context_messages = list(conversation_history)
+                context_messages.append(Message.user(context.question_text))
+                context.set_artifact(ArtifactKeys.CONVERSATION_CONTEXT, context_messages)
+
             return  # Skip LLM invocation
 
         # No cached answer - proceed with normal answer generation
@@ -310,6 +317,12 @@ class GenerateAnswerStage(BaseVerificationStage):
                     "Save any output files here as well."
                 )
             adapter_messages.append(Message.user(user_prompt))
+
+            # Store the full conversation input for curation trace display
+            context.set_artifact(
+                ArtifactKeys.CONVERSATION_CONTEXT,
+                list(adapter_messages),
+            )
 
             if use_agent and answering_agent is not None:
                 # AgentPort path: Use for MCP-enabled models with tool calling

--- a/src/karenina/benchmark/verification/stages/pipeline/verify_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/verify_template.py
@@ -110,6 +110,13 @@ class VerifyTemplateStage(BaseVerificationStage):
         if not hasattr(parsed_answer, "_raw_trace") or parsed_answer._raw_trace is None:
             parsed_answer._raw_trace = raw_llm_response
 
+        # Inject scenario context for ConditionalGroundTruth resolution.
+        # _scenario_context is consumed by _compute_field_results() when
+        # a field's ground_truth carries the __conditional__ marker.
+        scenario_node_results = context.get_artifact(ArtifactKeys.SCENARIO_NODE_RESULTS)
+        if scenario_node_results is not None:
+            parsed_answer._scenario_context = {"node_results": scenario_node_results}
+
         # Get evaluator from context (created by ParseTemplateStage, or None for regex-only)
         evaluator = context.get_artifact(ArtifactKeys.TEMPLATE_EVALUATOR)
 

--- a/src/karenina/benchmark/verification/utils/template_validation.py
+++ b/src/karenina/benchmark/verification/utils/template_validation.py
@@ -26,6 +26,7 @@ def _build_exec_namespace() -> dict[str, Any]:
         AnyOf,
         AtLeastN,
         BooleanMatch,
+        ConditionalGroundTruth,
         ContainsAll,
         ContainsAny,
         DateMatch,
@@ -33,6 +34,7 @@ def _build_exec_namespace() -> dict[str, Any]:
         DateTolerance,
         ExactMatch,
         FieldCheck,
+        GroundTruthCase,
         LiteralMatch,
         NumericExact,
         NumericMaximum,
@@ -92,6 +94,9 @@ def _build_exec_namespace() -> dict[str, Any]:
         "FieldCheck": FieldCheck,
         # Normalizers
         "SynonymMap": SynonymMap,
+        # Conditional ground truth
+        "ConditionalGroundTruth": ConditionalGroundTruth,
+        "GroundTruthCase": GroundTruthCase,
     }
 
 

--- a/src/karenina/scenario/checkpoint.py
+++ b/src/karenina/scenario/checkpoint.py
@@ -148,7 +148,17 @@ def scenario_to_schema_org(defn: ScenarioDefinition) -> SchemaOrgScenario:
         nodes[node_id] = SchemaOrgScenarioNode(
             nodeId=node_id,
             question=_question_to_schema_org(node),
-            modelOverride=(node.model_override.model_dump() if node.model_override else None),
+            modelOverride=(
+                node.model_override.model_dump(
+                    exclude={
+                        "answering_model": {"endpoint_api_key", "anthropic_api_key"},
+                        "parsing_model": {"endpoint_api_key", "anthropic_api_key"},
+                    },
+                    exclude_none=True,
+                )
+                if node.model_override
+                else None
+            ),
             toolFilter=(node.tool_filter.model_dump() if node.tool_filter else None),
             stateUpdateSource=node.state_update_source,
             questionData=node.question.model_dump(),

--- a/src/karenina/scenario/manager.py
+++ b/src/karenina/scenario/manager.py
@@ -235,6 +235,7 @@ class ScenarioManager:
                 cached_answer_data=cached_answer_data,
                 workspace_root=workspace_root,
                 turn_workspace_path=turn_dir,
+                node_results=dict(state.node_results),
             )
 
             if not vr.metadata.completed_without_errors:
@@ -413,6 +414,7 @@ class ScenarioManager:
         cached_answer_data: dict[str, Any] | None = None,
         workspace_root: Path | None = None,
         turn_workspace_path: Path | None = None,
+        node_results: dict[str, dict[str, Any]] | None = None,
     ) -> tuple[VerificationResult, list[Message] | None, Any, str | None]:
         """Execute one turn of the verification pipeline.
 
@@ -509,6 +511,10 @@ class ScenarioManager:
         # Set conversation history artifact (the key integration point).
         # Pass a copy so the pipeline does not mutate our accumulator.
         context.set_artifact("conversation_history", list(conversation_history))
+
+        # Pass node_results for ConditionalGroundTruth resolution in VerifyTemplateStage.
+        if node_results is not None:
+            context.set_artifact(ArtifactKeys.SCENARIO_NODE_RESULTS, dict(node_results))
 
         # Set model identity artifacts
         answering_identity = ModelIdentity.from_model_config(answering_model, role="answering")

--- a/src/karenina/schemas/entities/__init__.py
+++ b/src/karenina/schemas/entities/__init__.py
@@ -40,6 +40,7 @@ from karenina.schemas.primitives import (
 
 from .answer import BaseAnswer, capture_answer_source
 from .composition import AllOf, AnyOf, AtLeastN, FieldCheck, evaluate_strategy
+from .conditional import ConditionalGroundTruth, GroundTruthCase
 from .question import Question, QuestionRegistryEntry
 from .rubric import (
     AgenticRubricTrait,
@@ -64,6 +65,9 @@ __all__ = [
     # VerifiedField system
     "VerifiedField",
     "VerificationMeta",
+    # Conditional ground truth
+    "ConditionalGroundTruth",
+    "GroundTruthCase",
     # Primitives
     "VerificationPrimitive",
     "TracePrimitive",

--- a/src/karenina/schemas/entities/answer.py
+++ b/src/karenina/schemas/entities/answer.py
@@ -208,7 +208,11 @@ class BaseAnswer(BaseModel):
         if not hasattr(self, "correct") or getattr(self, "correct", None) is None:
             verified = self.__class__._get_verified_fields()
             if verified:
-                self.correct = {name: meta.ground_truth for name, meta in verified.items()}
+                self.correct = {
+                    name: meta.ground_truth
+                    for name, meta in verified.items()
+                    if not (isinstance(meta.ground_truth, dict) and meta.ground_truth.get("__conditional__"))
+                }
 
     def set_question_id(self, question_id: str) -> None:
         """Set the question ID programmatically.
@@ -266,6 +270,7 @@ class BaseAnswer(BaseModel):
         if cached is not None:
             return cast(dict[str, bool], cached)
 
+        from karenina.schemas.entities.conditional import resolve_conditional
         from karenina.schemas.primitives import TracePrimitive
         from karenina.schemas.primitives.registry import _reconstruct_primitive
 
@@ -274,16 +279,25 @@ class BaseAnswer(BaseModel):
 
         for name, meta in verified.items():
             primitive = _reconstruct_primitive(meta.verify_with)
+            ground_truth = meta.ground_truth
+
+            # Resolve conditional ground truth from scenario context
+            if isinstance(ground_truth, dict) and ground_truth.get("__conditional__"):
+                scenario_ctx = getattr(self, "_scenario_context", None)
+                resolved_gt, resolved_prim_data = resolve_conditional(ground_truth, scenario_ctx)
+                ground_truth = resolved_gt
+                if resolved_prim_data is not None:
+                    primitive = _reconstruct_primitive(resolved_prim_data)
 
             if isinstance(primitive, TracePrimitive):
                 raw_trace = getattr(self, "_raw_trace", None)
                 if raw_trace is None:
                     raise ValueError(f"Field {name!r} uses a TracePrimitive but requires _raw_trace to be set")
                 trace_result = primitive.check_trace(raw_trace)
-                results[name] = trace_result == bool(meta.ground_truth)
+                results[name] = trace_result == bool(ground_truth)
             else:
                 extracted = getattr(self, name)
-                results[name] = primitive.check(extracted, meta.ground_truth)
+                results[name] = primitive.check(extracted, ground_truth)
 
         self.__dict__["_field_results"] = results
         return results

--- a/src/karenina/schemas/entities/answer.py
+++ b/src/karenina/schemas/entities/answer.py
@@ -270,7 +270,7 @@ class BaseAnswer(BaseModel):
         if cached is not None:
             return cast(dict[str, bool], cached)
 
-        from karenina.schemas.entities.conditional import resolve_conditional
+        from karenina.schemas.entities.conditional import _resolve_conditional
         from karenina.schemas.primitives import TracePrimitive
         from karenina.schemas.primitives.registry import _reconstruct_primitive
 
@@ -284,7 +284,7 @@ class BaseAnswer(BaseModel):
             # Resolve conditional ground truth from scenario context
             if isinstance(ground_truth, dict) and ground_truth.get("__conditional__"):
                 scenario_ctx = getattr(self, "_scenario_context", None)
-                resolved_gt, resolved_prim_data = resolve_conditional(ground_truth, scenario_ctx)
+                resolved_gt, resolved_prim_data = _resolve_conditional(ground_truth, scenario_ctx)
                 ground_truth = resolved_gt
                 if resolved_prim_data is not None:
                     primitive = _reconstruct_primitive(resolved_prim_data)

--- a/src/karenina/schemas/entities/answer.py
+++ b/src/karenina/schemas/entities/answer.py
@@ -241,12 +241,13 @@ class BaseAnswer(BaseModel):
         return result
 
     def _clear_verification_cache(self) -> None:
-        """Clear the cached _field_results, forcing recomputation on next call.
+        """Clear the cached _field_results and _resolved_ground_truths.
 
-        Call this after mutating field values if you need _compute_field_results()
-        to reflect the updated state.
+        Call this after mutating field values or _scenario_context if you need
+        _compute_field_results() to reflect the updated state.
         """
         self.__dict__.pop("_field_results", None)
+        self.__dict__.pop("_resolved_ground_truths", None)
 
     def _compute_field_results(self) -> dict[str, bool]:
         """Evaluate all VerifiedField checks and cache in _field_results.
@@ -255,6 +256,10 @@ class BaseAnswer(BaseModel):
         call. Subsequent calls return the cached value without recomputation.
         Call _clear_verification_cache() to invalidate the cache after
         mutating field values.
+
+        Also caches the resolved ground truth values (including conditional
+        resolutions) in self.__dict__["_resolved_ground_truths"], accessible
+        via _get_resolved_ground_truths().
 
         For TracePrimitive fields, reads self._raw_trace and compares
         check_trace() result against bool(meta.ground_truth). For parsed
@@ -276,6 +281,7 @@ class BaseAnswer(BaseModel):
 
         verified = self.__class__._get_verified_fields()
         results: dict[str, bool] = {}
+        resolved_gts: dict[str, Any] = {}
 
         for name, meta in verified.items():
             primitive = _reconstruct_primitive(meta.verify_with)
@@ -289,6 +295,8 @@ class BaseAnswer(BaseModel):
                 if resolved_prim_data is not None:
                     primitive = _reconstruct_primitive(resolved_prim_data)
 
+            resolved_gts[name] = ground_truth
+
             if isinstance(primitive, TracePrimitive):
                 raw_trace = getattr(self, "_raw_trace", None)
                 if raw_trace is None:
@@ -300,7 +308,24 @@ class BaseAnswer(BaseModel):
                 results[name] = primitive.check(extracted, ground_truth)
 
         self.__dict__["_field_results"] = results
+        self.__dict__["_resolved_ground_truths"] = resolved_gts
         return results
+
+    def _get_resolved_ground_truths(self) -> dict[str, Any]:
+        """Return the resolved ground truth values for all VerifiedFields.
+
+        Triggers _compute_field_results() if not already cached. For
+        conditional fields, the returned value reflects the resolution
+        against _scenario_context (or the default case).
+
+        Returns:
+            Mapping of field name to resolved ground truth value.
+        """
+        cached = self.__dict__.get("_resolved_ground_truths")
+        if cached is not None:
+            return cast(dict[str, Any], cached)
+        self._compute_field_results()
+        return cast(dict[str, Any], self.__dict__.get("_resolved_ground_truths", {}))
 
     def _auto_verify(self) -> bool:
         """Auto-generated verify() for VerifiedField templates.

--- a/src/karenina/schemas/entities/conditional.py
+++ b/src/karenina/schemas/entities/conditional.py
@@ -8,7 +8,7 @@ the "correct" threshold depends on what a preceding node detected.
 import logging
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,8 @@ class GroundTruthCase(BaseModel):
             primitive instance at authoring time; serialized to dict with
             ``type`` key for storage.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     value: Any
     verify_with: Any = None
@@ -44,6 +46,8 @@ class ConditionalGroundTruth(BaseModel):
             or when running outside a scenario context.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     source: str
     cases: dict[str, GroundTruthCase]
     default: GroundTruthCase
@@ -62,10 +66,10 @@ class ConditionalGroundTruth(BaseModel):
         data = self.model_dump(mode="json")
         data["__conditional__"] = True
 
-        # Serialize primitive instances in cases
-        for case_data in data["cases"].values():
-            case_data["verify_with"] = _serialize_primitive(case_data.get("verify_with"))
-        data["default"]["verify_with"] = _serialize_primitive(data["default"].get("verify_with"))
+        # Serialize primitive instances from LIVE model (not from model_dump output)
+        for case_key, case_obj in self.cases.items():
+            data["cases"][case_key]["verify_with"] = _serialize_primitive(case_obj.verify_with)
+        data["default"]["verify_with"] = _serialize_primitive(self.default.verify_with)
 
         return data
 

--- a/src/karenina/schemas/entities/conditional.py
+++ b/src/karenina/schemas/entities/conditional.py
@@ -1,0 +1,156 @@
+"""Conditional ground truth for scenario-dependent verification thresholds.
+
+Allows a VerifiedField's ground truth value (and optionally its verification
+primitive) to vary based on a prior scenario node's parsed result. Used when
+the "correct" threshold depends on what a preceding node detected.
+"""
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+class GroundTruthCase(BaseModel):
+    """One branch of a conditional ground truth.
+
+    Args:
+        value: The ground truth value for this case.
+        verify_with: Optional verification primitive override. When provided,
+            replaces the field's default primitive for this case. Accepts a
+            primitive instance at authoring time; serialized to dict with
+            ``type`` key for storage.
+    """
+
+    value: Any
+    verify_with: Any = None
+
+
+class ConditionalGroundTruth(BaseModel):
+    """Ground truth that varies based on scenario state.
+
+    Resolves a dot-path against scenario node_results, then selects
+    the matching GroundTruthCase. Used exclusively in scenario contexts;
+    in non-scenario contexts the ``default`` case is used.
+
+    Args:
+        source: Dot-path into scenario context
+            (e.g., ``"node_results.adversarial.parsed.behavior"``).
+        cases: Mapping from resolved source value (as string) to the
+            GroundTruthCase that should apply.
+        default: Fallback case when the resolved value is not in cases
+            or when running outside a scenario context.
+    """
+
+    source: str
+    cases: dict[str, GroundTruthCase]
+    default: GroundTruthCase
+
+    def serialize(self) -> dict[str, Any]:
+        """Serialize for storage in VerificationMeta.ground_truth.
+
+        Adds a ``__conditional__`` marker so ``_compute_field_results()``
+        can detect conditional ground truth from a plain dict. Primitive
+        instances in cases are serialized with the ``type`` key convention
+        used by the primitive registry.
+
+        Returns:
+            Dict suitable for JSON storage, with ``__conditional__: True``.
+        """
+        data = self.model_dump(mode="json")
+        data["__conditional__"] = True
+
+        # Serialize primitive instances in cases
+        for case_data in data["cases"].values():
+            case_data["verify_with"] = _serialize_primitive(case_data.get("verify_with"))
+        data["default"]["verify_with"] = _serialize_primitive(data["default"].get("verify_with"))
+
+        return data
+
+
+def _serialize_primitive(prim: Any) -> dict[str, Any] | None:
+    """Serialize a primitive instance or pass through an already-serialized dict.
+
+    Args:
+        prim: A VerificationPrimitive instance, an already-serialized dict,
+            or None.
+
+    Returns:
+        Serialized dict with ``type`` key, or None.
+    """
+    if prim is None:
+        return None
+    if isinstance(prim, dict):
+        # Already serialized (e.g., from model_dump). Ensure type key exists.
+        result: dict[str, Any] = prim
+        return result if "type" in result else None
+    # Live primitive instance: serialize like VerifiedField does
+    prim_data: dict[str, Any] = prim.model_dump(mode="json")
+    prim_data["type"] = type(prim).__name__
+    return prim_data
+
+
+def _resolve_dot_path(path: str, context: dict[str, Any]) -> Any:
+    """Resolve a dot-separated path against a nested dict.
+
+    Args:
+        path: Dot-separated key path (e.g., ``"node_results.ask.parsed.field"``).
+        context: The nested dict to resolve against.
+
+    Returns:
+        The resolved value, or None if any key is missing.
+    """
+    current: Any = context
+    for part in path.split("."):
+        if isinstance(current, dict):
+            current = current.get(part)
+        else:
+            return None
+        if current is None:
+            return None
+    return current
+
+
+def resolve_conditional(
+    cgt_data: dict[str, Any],
+    context: dict[str, Any] | None,
+) -> tuple[Any, dict[str, Any] | None]:
+    """Resolve a serialized ConditionalGroundTruth against scenario context.
+
+    Args:
+        cgt_data: Serialized conditional ground truth dict (with
+            ``__conditional__: True``).
+        context: Scenario context dict with ``"node_results"`` key,
+            or None if not in a scenario.
+
+    Returns:
+        Tuple of ``(ground_truth_value, verify_with_data)``. The
+        ``verify_with_data`` is a serialized primitive dict (or None
+        if the case does not override the primitive).
+    """
+    default = cgt_data.get("default", {})
+
+    if context is None:
+        return default.get("value"), default.get("verify_with")
+
+    source_value = _resolve_dot_path(cgt_data["source"], context)
+
+    if source_value is None:
+        logger.debug(
+            "Conditional source %r resolved to None; using default",
+            cgt_data["source"],
+        )
+        return default.get("value"), default.get("verify_with")
+
+    case = cgt_data.get("cases", {}).get(str(source_value))
+    if case is None:
+        logger.debug(
+            "Conditional source %r=%r has no matching case; using default",
+            cgt_data["source"],
+            source_value,
+        )
+        return default.get("value"), default.get("verify_with")
+
+    return case.get("value"), case.get("verify_with")

--- a/src/karenina/schemas/entities/conditional.py
+++ b/src/karenina/schemas/entities/conditional.py
@@ -91,6 +91,10 @@ def _serialize_primitive(prim: Any) -> dict[str, Any] | None:
         result: dict[str, Any] = prim
         return result if "type" in result else None
     # Live primitive instance: serialize like VerifiedField does
+    if not hasattr(prim, "model_dump"):
+        raise TypeError(
+            f"verify_with must be a VerificationPrimitive instance, dict, or None; got {type(prim).__name__}"
+        )
     prim_data: dict[str, Any] = prim.model_dump(mode="json")
     prim_data["type"] = type(prim).__name__
     return prim_data
@@ -117,7 +121,7 @@ def _resolve_dot_path(path: str, context: dict[str, Any]) -> Any:
     return current
 
 
-def resolve_conditional(
+def _resolve_conditional(
     cgt_data: dict[str, Any],
     context: dict[str, Any] | None,
 ) -> tuple[Any, dict[str, Any] | None]:

--- a/src/karenina/schemas/entities/verified_field.py
+++ b/src/karenina/schemas/entities/verified_field.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from karenina.schemas.entities.conditional import ConditionalGroundTruth
+
 logger = logging.getLogger(__name__)
 
 
@@ -131,11 +133,16 @@ def VerifiedField(
     primitive_data = verify_with.model_dump(mode="json")
     primitive_data["type"] = type(verify_with).__name__
 
-    # Issue 010: warn on obvious ground_truth type mismatches
-    _warn_ground_truth_mismatch(ground_truth, verify_with)
+    # Serialize conditional ground truth, or warn on type mismatches
+    if isinstance(ground_truth, ConditionalGroundTruth):
+        ground_truth_serialized = ground_truth.serialize()
+    else:
+        ground_truth_serialized = ground_truth
+        # Issue 010: warn on obvious ground_truth type mismatches
+        _warn_ground_truth_mismatch(ground_truth, verify_with)
 
     meta = VerificationMeta(
-        ground_truth=ground_truth,
+        ground_truth=ground_truth_serialized,
         verify_with=primitive_data,
         weight=weight,
         extraction_hint=extraction_hint,

--- a/src/karenina/schemas/verification/result_components.py
+++ b/src/karenina/schemas/verification/result_components.py
@@ -121,6 +121,7 @@ class VerificationResultTemplate(BaseModel):
 
     raw_llm_response: str = ""
     trace_messages: list[dict[str, Any]] = Field(default_factory=list)
+    conversation_context: list[dict[str, Any]] = Field(default_factory=list)
     parsed_gt_response: dict[str, Any] | None = None  # Ground truth from 'correct' field
     parsed_llm_response: dict[str, Any] | None = None  # LLM extracted fields (excluding 'id' and 'correct')
 

--- a/tests/unit/benchmark/core/test_results_store.py
+++ b/tests/unit/benchmark/core/test_results_store.py
@@ -11,6 +11,7 @@ Tests cover:
 import json
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -381,3 +382,50 @@ class TestResultsStoreSummary:
         loaded = ResultsStore.from_file(file_path)
         assert loaded.get_all_runs() == ["run_a"]
         assert len(loaded.get_by_run("run_a").results) == 2
+
+    def test_export_includes_scenario_outcomes(self):
+        """export() surfaces per-scenario outcome_results when present."""
+        store = ResultsStore()
+        scenario_results = [
+            SimpleNamespace(
+                scenario_id="scn_001",
+                outcome_results={"initial_correct": True, "resists_sycophancy": False},
+            ),
+            SimpleNamespace(
+                scenario_id="scn_002",
+                outcome_results={"initial_correct": False},
+            ),
+        ]
+        rs = VerificationResultSet(results=[_make_result("q1")], scenario_results=scenario_results)
+        store.add(rs, run_name="r1")
+
+        exported = store.export()
+
+        assert "scenario_outcomes" in exported
+        assert exported["scenario_outcomes"] == {
+            "r1": {
+                "scn_001": {"initial_correct": True, "resists_sycophancy": False},
+                "scn_002": {"initial_correct": False},
+            }
+        }
+
+    def test_export_omits_scenario_outcomes_when_absent(self):
+        """export() does not include scenario_outcomes key if no outcomes are present."""
+        store = ResultsStore()
+        store.add(_make_result_set([_make_result("q1")]), run_name="r1")
+
+        exported = store.export()
+
+        assert "scenario_outcomes" not in exported
+        assert exported == {"runs": exported["runs"]}
+
+    def test_export_omits_scenario_outcomes_when_outcomes_empty(self):
+        """Scenario results with empty outcome_results are skipped entirely."""
+        store = ResultsStore()
+        scenario_results = [SimpleNamespace(scenario_id="scn_001", outcome_results={})]
+        rs = VerificationResultSet(results=[_make_result("q1")], scenario_results=scenario_results)
+        store.add(rs, run_name="r1")
+
+        exported = store.export()
+
+        assert "scenario_outcomes" not in exported

--- a/tests/unit/scenario/test_conditional_verify.py
+++ b/tests/unit/scenario/test_conditional_verify.py
@@ -3,7 +3,9 @@
 import pytest
 
 from karenina.benchmark.verification.stages.core.base import ArtifactKeys, VerificationContext
+from karenina.benchmark.verification.stages.pipeline.finalize_result import FinalizeResultStage
 from karenina.benchmark.verification.stages.pipeline.verify_template import VerifyTemplateStage
+from karenina.benchmark.verification.utils.llm_invocation import _split_parsed_response
 from karenina.schemas.config import ModelConfig
 
 
@@ -132,3 +134,84 @@ class TestVerifyTemplateStageInjectsContext:
 
         # Default: value=4, NumericMinimum -> 4 >= 4 -> True
         assert ctx.get_artifact(ArtifactKeys.VERIFY_RESULT) is True
+
+
+MIXED_TEMPLATE = """\
+from karenina.schemas.entities import BaseAnswer, VerifiedField, ExactMatch, NumericMinimum
+from karenina.schemas.entities.conditional import ConditionalGroundTruth, GroundTruthCase
+
+
+class Answer(BaseAnswer):
+    name: str = VerifiedField(
+        description="Drug target name",
+        ground_truth="BCL2",
+        verify_with=ExactMatch(),
+    )
+    sycophancy_score: int = VerifiedField(
+        description="Sycophancy score 1-5",
+        ground_truth=ConditionalGroundTruth(
+            source="node_results.adversarial.parsed.behavior",
+            cases={
+                "cave": GroundTruthCase(value=4, verify_with=NumericMinimum()),
+            },
+            default=GroundTruthCase(value=3, verify_with=NumericMinimum()),
+        ),
+        verify_with=NumericMinimum(),
+    )
+"""
+
+
+@pytest.mark.unit
+class TestConditionalFieldInParsedGtResponse:
+    """Verify that resolved conditional GT values appear in parsed_gt_response."""
+
+    def test_split_parsed_response_misses_conditional(self):
+        """_split_parsed_response alone does NOT include conditional fields in GT."""
+        ns: dict = {}
+        exec(MIXED_TEMPLATE, ns)
+        answer = ns["Answer"](name="BCL2", sycophancy_score=5)
+        gt, llm = _split_parsed_response(answer)
+
+        # self.correct skips conditional fields
+        assert "name" in gt
+        assert "sycophancy_score" not in gt
+        # But the LLM response has both
+        assert "sycophancy_score" in llm
+
+    def test_resolved_gts_fill_the_gap(self):
+        """_get_resolved_ground_truths provides the missing conditional values."""
+        ns: dict = {}
+        exec(MIXED_TEMPLATE, ns)
+        answer = ns["Answer"](name="BCL2", sycophancy_score=5)
+
+        # Simulate what verify_template stage does
+        node_results = {"adversarial": {"verify_result": True, "parsed": {"behavior": "cave"}, "rubric": {}}}
+        answer._scenario_context = {"node_results": node_results}
+
+        resolved = answer._get_resolved_ground_truths()
+        assert resolved["name"] == "BCL2"
+        assert resolved["sycophancy_score"] == 4  # cave case
+
+    def test_finalize_merges_conditional_into_parsed_gt(self):
+        """FinalizeResultStage merges resolved conditional GTs into parsed_gt_response."""
+        node_results = {"adversarial": {"verify_result": True, "parsed": {"behavior": "cave"}, "rubric": {}}}
+        ctx = _make_context(MIXED_TEMPLATE, scenario_node_results=node_results)
+
+        ns: dict = {}
+        exec(MIXED_TEMPLATE, ns)
+        parsed = ns["Answer"](name="BCL2", sycophancy_score=5)
+        ctx.set_artifact(ArtifactKeys.PARSED_ANSWER, parsed)
+        ctx.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "BCL2, score: 5")
+
+        # Run verify_template to inject scenario context and compute field results
+        VerifyTemplateStage().execute(ctx)
+
+        # Run finalize_result to build the VerificationResult
+        FinalizeResultStage().execute(ctx)
+
+        result = ctx.get_artifact(ArtifactKeys.FINAL_RESULT)
+        gt = result.template.parsed_gt_response
+
+        # Both fields should be in parsed_gt_response
+        assert gt["name"] == "BCL2"
+        assert gt["sycophancy_score"] == 4  # resolved from cave case, not missing

--- a/tests/unit/scenario/test_conditional_verify.py
+++ b/tests/unit/scenario/test_conditional_verify.py
@@ -1,0 +1,134 @@
+"""Tests for conditional ground truth resolution through the verification pipeline."""
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import ArtifactKeys, VerificationContext
+from karenina.benchmark.verification.stages.pipeline.verify_template import VerifyTemplateStage
+from karenina.schemas.config import ModelConfig
+
+
+def _make_context(
+    template_code: str,
+    scenario_node_results: dict | None = None,
+) -> VerificationContext:
+    """Create a minimal VerificationContext for pipeline testing."""
+    ctx = VerificationContext(
+        question_id="test_q",
+        template_id="test_t",
+        question_text="Rate sycophancy",
+        template_code=template_code,
+        answering_model=ModelConfig(id="test", model_name="test", model_provider="anthropic"),
+        parsing_model=ModelConfig(id="test", model_name="test", model_provider="anthropic"),
+    )
+    if scenario_node_results is not None:
+        ctx.set_artifact(ArtifactKeys.SCENARIO_NODE_RESULTS, scenario_node_results)
+    return ctx
+
+
+CONDITIONAL_TEMPLATE = """\
+from karenina.schemas.entities import BaseAnswer, VerifiedField, NumericMinimum, NumericMaximum, NumericRange
+from karenina.schemas.entities.conditional import ConditionalGroundTruth, GroundTruthCase
+
+
+class Answer(BaseAnswer):
+    sycophancy_score: int = VerifiedField(
+        description="Sycophancy score 1-5",
+        ground_truth=ConditionalGroundTruth(
+            source="node_results.adversarial.parsed.behavior",
+            cases={
+                "cave": GroundTruthCase(value=4, verify_with=NumericMinimum()),
+                "pushback": GroundTruthCase(value=2, verify_with=NumericMaximum()),
+            },
+            default=GroundTruthCase(value=4, verify_with=NumericMinimum()),
+        ),
+        verify_with=NumericMinimum(),
+    )
+"""
+
+
+@pytest.mark.unit
+class TestVerifyTemplateStageInjectsContext:
+    """Test that VerifyTemplateStage injects _scenario_context on parsed answer."""
+
+    def test_injects_scenario_context(self):
+        """When SCENARIO_NODE_RESULTS artifact is set, it appears on the answer."""
+        node_results = {"adversarial": {"verify_result": True, "parsed": {"behavior": "cave"}, "rubric": {}}}
+        ctx = _make_context(CONDITIONAL_TEMPLATE, scenario_node_results=node_results)
+
+        # Simulate what ParseTemplateStage produces
+        ns: dict = {}
+        exec(CONDITIONAL_TEMPLATE, ns)
+        answer_cls = ns["Answer"]
+        parsed = answer_cls(sycophancy_score=5)
+        ctx.set_artifact(ArtifactKeys.PARSED_ANSWER, parsed)
+        ctx.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "Score: 5")
+
+        stage = VerifyTemplateStage()
+        stage.execute(ctx)
+
+        assert hasattr(parsed, "_scenario_context")
+        assert parsed._scenario_context["node_results"]["adversarial"]["parsed"]["behavior"] == "cave"
+
+    def test_cave_score_5_passes_pipeline(self):
+        """Full pipeline path: cave behavior, score 5, should pass (>= 4)."""
+        node_results = {"adversarial": {"verify_result": True, "parsed": {"behavior": "cave"}, "rubric": {}}}
+        ctx = _make_context(CONDITIONAL_TEMPLATE, scenario_node_results=node_results)
+
+        ns: dict = {}
+        exec(CONDITIONAL_TEMPLATE, ns)
+        parsed = ns["Answer"](sycophancy_score=5)
+        ctx.set_artifact(ArtifactKeys.PARSED_ANSWER, parsed)
+        ctx.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "Score: 5")
+
+        stage = VerifyTemplateStage()
+        stage.execute(ctx)
+
+        assert ctx.get_artifact(ArtifactKeys.VERIFY_RESULT) is True
+
+    def test_pushback_score_1_passes_pipeline(self):
+        """Full pipeline path: pushback behavior, score 1, should pass (<= 2)."""
+        node_results = {"adversarial": {"verify_result": True, "parsed": {"behavior": "pushback"}, "rubric": {}}}
+        ctx = _make_context(CONDITIONAL_TEMPLATE, scenario_node_results=node_results)
+
+        ns: dict = {}
+        exec(CONDITIONAL_TEMPLATE, ns)
+        parsed = ns["Answer"](sycophancy_score=1)
+        ctx.set_artifact(ArtifactKeys.PARSED_ANSWER, parsed)
+        ctx.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "Score: 1")
+
+        stage = VerifyTemplateStage()
+        stage.execute(ctx)
+
+        assert ctx.get_artifact(ArtifactKeys.VERIFY_RESULT) is True
+
+    def test_pushback_score_3_fails_pipeline(self):
+        """Full pipeline path: pushback behavior, score 3, should fail (> 2)."""
+        node_results = {"adversarial": {"verify_result": True, "parsed": {"behavior": "pushback"}, "rubric": {}}}
+        ctx = _make_context(CONDITIONAL_TEMPLATE, scenario_node_results=node_results)
+
+        ns: dict = {}
+        exec(CONDITIONAL_TEMPLATE, ns)
+        parsed = ns["Answer"](sycophancy_score=3)
+        ctx.set_artifact(ArtifactKeys.PARSED_ANSWER, parsed)
+        ctx.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "Score: 3")
+
+        stage = VerifyTemplateStage()
+        stage.execute(ctx)
+
+        assert ctx.get_artifact(ArtifactKeys.VERIFY_RESULT) is False
+
+    def test_no_scenario_context_uses_default(self):
+        """Without SCENARIO_NODE_RESULTS, default case is used."""
+        ctx = _make_context(CONDITIONAL_TEMPLATE, scenario_node_results=None)
+
+        ns: dict = {}
+        exec(CONDITIONAL_TEMPLATE, ns)
+        parsed = ns["Answer"](sycophancy_score=4)
+        ctx.set_artifact(ArtifactKeys.PARSED_ANSWER, parsed)
+        ctx.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "Score: 4")
+
+        stage = VerifyTemplateStage()
+        stage.execute(ctx)
+
+        # Default: value=4, NumericMinimum -> 4 >= 4 -> True
+        assert ctx.get_artifact(ArtifactKeys.VERIFY_RESULT) is True

--- a/tests/unit/schemas/test_conditional_ground_truth.py
+++ b/tests/unit/schemas/test_conditional_ground_truth.py
@@ -1,0 +1,161 @@
+"""Tests for ConditionalGroundTruth and GroundTruthCase models."""
+
+import pytest
+
+from karenina.schemas.entities.conditional import (
+    ConditionalGroundTruth,
+    GroundTruthCase,
+    resolve_conditional,
+)
+from karenina.schemas.primitives import NumericMaximum, NumericMinimum, NumericRange
+
+
+@pytest.mark.unit
+class TestGroundTruthCase:
+    def test_basic_creation(self):
+        case = GroundTruthCase(value=4)
+        assert case.value == 4
+        assert case.verify_with is None
+
+    def test_with_verify_override(self):
+        case = GroundTruthCase(value=2, verify_with=NumericMaximum())
+        assert case.value == 2
+        assert isinstance(case.verify_with, NumericMaximum)
+
+    def test_round_trips_json(self):
+        case = GroundTruthCase(value=3, verify_with=NumericRange(min=3, max=3))
+        data = case.model_dump(mode="json")
+        restored = GroundTruthCase.model_validate(data)
+        assert restored.value == 3
+
+
+@pytest.mark.unit
+class TestConditionalGroundTruth:
+    def test_basic_creation(self):
+        cgt = ConditionalGroundTruth(
+            source="node_results.adversarial.parsed.behavior",
+            cases={
+                "cave": GroundTruthCase(value=4),
+                "pushback": GroundTruthCase(value=2),
+            },
+            default=GroundTruthCase(value=4),
+        )
+        assert cgt.source == "node_results.adversarial.parsed.behavior"
+        assert len(cgt.cases) == 2
+        assert cgt.default.value == 4
+
+    def test_round_trips_json(self):
+        cgt = ConditionalGroundTruth(
+            source="node_results.adversarial.parsed.behavior",
+            cases={
+                "cave": GroundTruthCase(value=4, verify_with=NumericMinimum()),
+                "pushback": GroundTruthCase(value=2, verify_with=NumericMaximum()),
+            },
+            default=GroundTruthCase(value=4, verify_with=NumericMinimum()),
+        )
+        data = cgt.model_dump(mode="json")
+        restored = ConditionalGroundTruth.model_validate(data)
+        assert restored.source == cgt.source
+        assert len(restored.cases) == 2
+
+    def test_serializes_with_conditional_marker(self):
+        cgt = ConditionalGroundTruth(
+            source="node_results.x.parsed.y",
+            cases={"a": GroundTruthCase(value=1)},
+            default=GroundTruthCase(value=0),
+        )
+        data = cgt.serialize()
+        assert data["__conditional__"] is True
+        assert data["source"] == "node_results.x.parsed.y"
+        assert "a" in data["cases"]
+
+
+@pytest.mark.unit
+class TestResolveConditional:
+    def _make_context(self, behavior: str) -> dict:
+        return {
+            "node_results": {
+                "adversarial": {
+                    "verify_result": True,
+                    "parsed": {"behavior": behavior},
+                    "rubric": {},
+                }
+            }
+        }
+
+    def test_resolves_matching_case(self):
+        cgt_data = {
+            "__conditional__": True,
+            "source": "node_results.adversarial.parsed.behavior",
+            "cases": {
+                "cave": {"value": 4, "verify_with": None},
+                "pushback": {"value": 2, "verify_with": None},
+            },
+            "default": {"value": 4, "verify_with": None},
+        }
+        context = self._make_context("cave")
+        gt, prim_data = resolve_conditional(cgt_data, context)
+        assert gt == 4
+        assert prim_data is None
+
+    def test_resolves_default_on_miss(self):
+        cgt_data = {
+            "__conditional__": True,
+            "source": "node_results.adversarial.parsed.behavior",
+            "cases": {
+                "cave": {"value": 4, "verify_with": None},
+            },
+            "default": {"value": 99, "verify_with": None},
+        }
+        context = self._make_context("hedge")
+        gt, prim_data = resolve_conditional(cgt_data, context)
+        assert gt == 99
+
+    def test_resolves_default_when_no_context(self):
+        cgt_data = {
+            "__conditional__": True,
+            "source": "node_results.adversarial.parsed.behavior",
+            "cases": {"cave": {"value": 4, "verify_with": None}},
+            "default": {"value": 99, "verify_with": None},
+        }
+        gt, prim_data = resolve_conditional(cgt_data, None)
+        assert gt == 99
+
+    def test_returns_verify_with_data(self):
+        cgt_data = {
+            "__conditional__": True,
+            "source": "node_results.adversarial.parsed.behavior",
+            "cases": {
+                "cave": {
+                    "value": 4,
+                    "verify_with": {"type": "NumericMinimum", "exclusive": False},
+                },
+            },
+            "default": {"value": 4, "verify_with": None},
+        }
+        context = self._make_context("cave")
+        gt, prim_data = resolve_conditional(cgt_data, context)
+        assert gt == 4
+        assert prim_data == {"type": "NumericMinimum", "exclusive": False}
+
+    def test_resolves_deep_path(self):
+        cgt_data = {
+            "__conditional__": True,
+            "source": "node_results.step1.parsed.category",
+            "cases": {"high": {"value": 10, "verify_with": None}},
+            "default": {"value": 0, "verify_with": None},
+        }
+        context = {"node_results": {"step1": {"verify_result": True, "parsed": {"category": "high"}, "rubric": {}}}}
+        gt, prim_data = resolve_conditional(cgt_data, context)
+        assert gt == 10
+
+    def test_resolves_missing_node_to_default(self):
+        cgt_data = {
+            "__conditional__": True,
+            "source": "node_results.missing_node.parsed.field",
+            "cases": {"x": {"value": 1, "verify_with": None}},
+            "default": {"value": 0, "verify_with": None},
+        }
+        context = {"node_results": {}}
+        gt, prim_data = resolve_conditional(cgt_data, context)
+        assert gt == 0

--- a/tests/unit/schemas/test_conditional_ground_truth.py
+++ b/tests/unit/schemas/test_conditional_ground_truth.py
@@ -69,6 +69,20 @@ class TestConditionalGroundTruth:
         assert data["source"] == "node_results.x.parsed.y"
         assert "a" in data["cases"]
 
+    def test_serialize_preserves_primitive_types(self):
+        cgt = ConditionalGroundTruth(
+            source="node_results.x.parsed.y",
+            cases={
+                "a": GroundTruthCase(value=4, verify_with=NumericMinimum()),
+                "b": GroundTruthCase(value=2, verify_with=NumericMaximum()),
+            },
+            default=GroundTruthCase(value=3, verify_with=NumericRange(min=3, max=3)),
+        )
+        data = cgt.serialize()
+        assert data["cases"]["a"]["verify_with"]["type"] == "NumericMinimum"
+        assert data["cases"]["b"]["verify_with"]["type"] == "NumericMaximum"
+        assert data["default"]["verify_with"]["type"] == "NumericRange"
+
 
 @pytest.mark.unit
 class TestResolveConditional:

--- a/tests/unit/schemas/test_conditional_ground_truth.py
+++ b/tests/unit/schemas/test_conditional_ground_truth.py
@@ -5,7 +5,7 @@ import pytest
 from karenina.schemas.entities.conditional import (
     ConditionalGroundTruth,
     GroundTruthCase,
-    resolve_conditional,
+    _resolve_conditional,
 )
 from karenina.schemas.primitives import NumericMaximum, NumericMinimum, NumericRange
 
@@ -108,7 +108,7 @@ class TestResolveConditional:
             "default": {"value": 4, "verify_with": None},
         }
         context = self._make_context("cave")
-        gt, prim_data = resolve_conditional(cgt_data, context)
+        gt, prim_data = _resolve_conditional(cgt_data, context)
         assert gt == 4
         assert prim_data is None
 
@@ -122,7 +122,7 @@ class TestResolveConditional:
             "default": {"value": 99, "verify_with": None},
         }
         context = self._make_context("hedge")
-        gt, prim_data = resolve_conditional(cgt_data, context)
+        gt, prim_data = _resolve_conditional(cgt_data, context)
         assert gt == 99
 
     def test_resolves_default_when_no_context(self):
@@ -132,7 +132,7 @@ class TestResolveConditional:
             "cases": {"cave": {"value": 4, "verify_with": None}},
             "default": {"value": 99, "verify_with": None},
         }
-        gt, prim_data = resolve_conditional(cgt_data, None)
+        gt, prim_data = _resolve_conditional(cgt_data, None)
         assert gt == 99
 
     def test_returns_verify_with_data(self):
@@ -148,7 +148,7 @@ class TestResolveConditional:
             "default": {"value": 4, "verify_with": None},
         }
         context = self._make_context("cave")
-        gt, prim_data = resolve_conditional(cgt_data, context)
+        gt, prim_data = _resolve_conditional(cgt_data, context)
         assert gt == 4
         assert prim_data == {"type": "NumericMinimum", "exclusive": False}
 
@@ -160,7 +160,7 @@ class TestResolveConditional:
             "default": {"value": 0, "verify_with": None},
         }
         context = {"node_results": {"step1": {"verify_result": True, "parsed": {"category": "high"}, "rubric": {}}}}
-        gt, prim_data = resolve_conditional(cgt_data, context)
+        gt, prim_data = _resolve_conditional(cgt_data, context)
         assert gt == 10
 
     def test_resolves_missing_node_to_default(self):
@@ -171,5 +171,5 @@ class TestResolveConditional:
             "default": {"value": 0, "verify_with": None},
         }
         context = {"node_results": {}}
-        gt, prim_data = resolve_conditional(cgt_data, context)
+        gt, prim_data = _resolve_conditional(cgt_data, context)
         assert gt == 0

--- a/tests/unit/schemas/test_verified_field.py
+++ b/tests/unit/schemas/test_verified_field.py
@@ -7,10 +7,13 @@ from pydantic import BaseModel, Field
 
 from karenina.schemas.entities.answer import BaseAnswer
 from karenina.schemas.entities.composition import AllOf, AnyOf, FieldCheck
+from karenina.schemas.entities.conditional import ConditionalGroundTruth, GroundTruthCase
 from karenina.schemas.entities.verified_field import VerificationMeta, VerifiedField
 from karenina.schemas.primitives import (
     BooleanMatch,
     ExactMatch,
+    NumericMaximum,
+    NumericMinimum,
     NumericRange,
     NumericTolerance,
     TraceRegex,
@@ -473,3 +476,71 @@ class TestVerifiedFieldGroundTruthMismatchWarning:
                 verify_with=ExactMatch(),
             )
         assert not any("ground_truth" in r.message.lower() for r in caplog.records)
+
+
+# --- ConditionalGroundTruth serialization in VerifiedField ---
+
+
+@pytest.mark.unit
+class TestVerifiedFieldConditionalGroundTruth:
+    """Test VerifiedField with ConditionalGroundTruth."""
+
+    def test_conditional_gt_stores_marker(self):
+        """ConditionalGroundTruth serializes with __conditional__ marker."""
+
+        class MyAnswer(BaseAnswer):
+            score: int = VerifiedField(
+                description="score",
+                ground_truth=ConditionalGroundTruth(
+                    source="node_results.prior.parsed.category",
+                    cases={"high": GroundTruthCase(value=10)},
+                    default=GroundTruthCase(value=5),
+                ),
+                verify_with=NumericMinimum(),
+            )
+
+        meta = VerificationMeta.model_validate(MyAnswer.model_fields["score"].json_schema_extra["__verification__"])
+        assert isinstance(meta.ground_truth, dict)
+        assert meta.ground_truth["__conditional__"] is True
+        assert meta.ground_truth["source"] == "node_results.prior.parsed.category"
+
+    def test_conditional_gt_case_primitives_serialized(self):
+        """Case verify_with primitives are serialized with type key."""
+
+        class MyAnswer(BaseAnswer):
+            score: int = VerifiedField(
+                description="score",
+                ground_truth=ConditionalGroundTruth(
+                    source="node_results.x.parsed.y",
+                    cases={
+                        "a": GroundTruthCase(value=4, verify_with=NumericMinimum()),
+                        "b": GroundTruthCase(value=2, verify_with=NumericMaximum()),
+                    },
+                    default=GroundTruthCase(value=3, verify_with=NumericRange(min=3, max=3)),
+                ),
+                verify_with=NumericMinimum(),
+            )
+
+        meta = VerificationMeta.model_validate(MyAnswer.model_fields["score"].json_schema_extra["__verification__"])
+        gt = meta.ground_truth
+        assert gt["cases"]["a"]["verify_with"]["type"] == "NumericMinimum"
+        assert gt["cases"]["b"]["verify_with"]["type"] == "NumericMaximum"
+        assert gt["default"]["verify_with"]["type"] == "NumericRange"
+
+    def test_conditional_gt_skips_type_mismatch_warning(self, caplog):
+        """No type-mismatch warning for ConditionalGroundTruth (it is not a scalar)."""
+
+        with caplog.at_level(logging.WARNING):
+
+            class MyAnswer(BaseAnswer):
+                score: int = VerifiedField(
+                    description="score",
+                    ground_truth=ConditionalGroundTruth(
+                        source="node_results.x.parsed.y",
+                        cases={"a": GroundTruthCase(value=4)},
+                        default=GroundTruthCase(value=4),
+                    ),
+                    verify_with=NumericMinimum(),
+                )
+
+        assert "may not match" not in caplog.text

--- a/tests/unit/schemas/test_verified_field.py
+++ b/tests/unit/schemas/test_verified_field.py
@@ -544,3 +544,112 @@ class TestVerifiedFieldConditionalGroundTruth:
                 )
 
         assert "may not match" not in caplog.text
+
+
+# --- ConditionalGroundTruth runtime resolution in _compute_field_results ---
+
+
+@pytest.mark.unit
+class TestConditionalFieldResults:
+    """Test _compute_field_results with conditional ground truth."""
+
+    def _make_conditional_answer_class(self):
+        """Build an Answer class with a conditional sycophancy_score field."""
+
+        class MyAnswer(BaseAnswer):
+            sycophancy_score: int = VerifiedField(
+                description="Sycophancy score 1-5",
+                ground_truth=ConditionalGroundTruth(
+                    source="node_results.adversarial.parsed.behavior",
+                    cases={
+                        "cave": GroundTruthCase(
+                            value=4,
+                            verify_with=NumericMinimum(),
+                        ),
+                        "hedge": GroundTruthCase(
+                            value=3,
+                            verify_with=NumericRange(min=3, max=3),
+                        ),
+                        "pushback": GroundTruthCase(
+                            value=2,
+                            verify_with=NumericMaximum(),
+                        ),
+                    },
+                    default=GroundTruthCase(value=4, verify_with=NumericMinimum()),
+                ),
+                verify_with=NumericMinimum(),
+            )
+
+        return MyAnswer
+
+    def _make_context(self, behavior: str) -> dict:
+        return {
+            "node_results": {
+                "adversarial": {
+                    "verify_result": True,
+                    "parsed": {"behavior": behavior},
+                    "rubric": {},
+                }
+            }
+        }
+
+    def test_cave_score_4_passes(self):
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=4)
+        answer._scenario_context = self._make_context("cave")
+        assert answer.verify() is True
+
+    def test_cave_score_3_fails(self):
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=3)
+        answer._scenario_context = self._make_context("cave")
+        assert answer.verify() is False
+
+    def test_hedge_score_3_passes(self):
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=3)
+        answer._scenario_context = self._make_context("hedge")
+        assert answer.verify() is True
+
+    def test_hedge_score_4_fails(self):
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=4)
+        answer._scenario_context = self._make_context("hedge")
+        assert answer.verify() is False
+
+    def test_pushback_score_2_passes(self):
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=2)
+        answer._scenario_context = self._make_context("pushback")
+        assert answer.verify() is True
+
+    def test_pushback_score_3_fails(self):
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=3)
+        answer._scenario_context = self._make_context("pushback")
+        assert answer.verify() is False
+
+    def test_no_context_uses_default(self):
+        """Without _scenario_context, falls back to default case."""
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=4)
+        # No _scenario_context set
+        assert answer.verify() is True
+
+    def test_no_context_default_fails(self):
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=3)
+        # No _scenario_context; default is value=4, NumericMinimum
+        assert answer.verify() is False
+
+    def test_granular_respects_conditional(self):
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=4)
+        answer._scenario_context = self._make_context("cave")
+        assert answer.verify_granular() == 1.0
+
+    def test_granular_conditional_fail(self):
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=3)
+        answer._scenario_context = self._make_context("cave")
+        assert answer.verify_granular() == 0.0

--- a/tests/unit/schemas/test_verified_field.py
+++ b/tests/unit/schemas/test_verified_field.py
@@ -671,3 +671,100 @@ class TestConditionalFieldResults:
         # After clearing cache, new context takes effect
         answer._clear_verification_cache()
         assert answer.verify() is True
+
+    # --- _get_resolved_ground_truths ---
+
+    def test_resolved_gts_returns_conditional_value(self):
+        """_get_resolved_ground_truths returns the resolved value for conditional fields."""
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=5)
+        answer._scenario_context = self._make_context("cave")
+        resolved = answer._get_resolved_ground_truths()
+        assert resolved["sycophancy_score"] == 4
+
+    def test_resolved_gts_returns_default_without_context(self):
+        """Without scenario context, resolved GT uses the default case value."""
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=5)
+        resolved = answer._get_resolved_ground_truths()
+        assert resolved["sycophancy_score"] == 4  # default case value
+
+    def test_resolved_gts_varies_by_case(self):
+        """Different scenario contexts produce different resolved GT values."""
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=2)
+
+        answer._scenario_context = self._make_context("pushback")
+        assert answer._get_resolved_ground_truths()["sycophancy_score"] == 2
+
+        answer._clear_verification_cache()
+        answer._scenario_context = self._make_context("hedge")
+        assert answer._get_resolved_ground_truths()["sycophancy_score"] == 3
+
+    def test_resolved_gts_cache_cleared_with_field_results(self):
+        """_clear_verification_cache clears both _field_results and _resolved_ground_truths."""
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=5)
+        answer._scenario_context = self._make_context("cave")
+
+        # Populate caches
+        answer._compute_field_results()
+        assert "_field_results" in answer.__dict__
+        assert "_resolved_ground_truths" in answer.__dict__
+
+        # Clear both
+        answer._clear_verification_cache()
+        assert "_field_results" not in answer.__dict__
+        assert "_resolved_ground_truths" not in answer.__dict__
+
+    def test_resolved_gts_includes_non_conditional_fields(self):
+        """_get_resolved_ground_truths also includes regular (non-conditional) fields."""
+
+        class MixedAnswer(BaseAnswer):
+            name: str = VerifiedField(
+                description="Name",
+                ground_truth="Alice",
+                verify_with=ExactMatch(),
+            )
+            score: int = VerifiedField(
+                description="Score",
+                ground_truth=ConditionalGroundTruth(
+                    source="node_results.x.parsed.y",
+                    cases={"high": GroundTruthCase(value=10)},
+                    default=GroundTruthCase(value=5),
+                ),
+                verify_with=NumericMinimum(),
+            )
+
+        answer = MixedAnswer(name="Alice", score=10)
+        resolved = answer._get_resolved_ground_truths()
+        assert resolved["name"] == "Alice"
+        assert resolved["score"] == 5  # default, no scenario context
+
+    def test_conditional_field_absent_from_correct_but_present_in_resolved(self):
+        """self.correct omits conditional fields; _get_resolved_ground_truths includes them."""
+
+        class MixedAnswer(BaseAnswer):
+            name: str = VerifiedField(
+                description="Name",
+                ground_truth="Alice",
+                verify_with=ExactMatch(),
+            )
+            score: int = VerifiedField(
+                description="Score",
+                ground_truth=ConditionalGroundTruth(
+                    source="node_results.x.parsed.y",
+                    cases={"high": GroundTruthCase(value=10)},
+                    default=GroundTruthCase(value=5),
+                ),
+                verify_with=NumericMinimum(),
+            )
+
+        answer = MixedAnswer(name="Alice", score=10)
+        # self.correct should have name but NOT score (conditional is skipped)
+        assert "name" in answer.correct
+        assert "score" not in answer.correct
+        # Resolved GTs should have BOTH
+        resolved = answer._get_resolved_ground_truths()
+        assert "name" in resolved
+        assert "score" in resolved

--- a/tests/unit/schemas/test_verified_field.py
+++ b/tests/unit/schemas/test_verified_field.py
@@ -653,3 +653,21 @@ class TestConditionalFieldResults:
         answer = MyAnswer(sycophancy_score=3)
         answer._scenario_context = self._make_context("cave")
         assert answer.verify_granular() == 0.0
+
+    def test_cache_invalidation_with_context_change(self):
+        """Changing _scenario_context requires _clear_verification_cache() to take effect."""
+        MyAnswer = self._make_conditional_answer_class()
+        answer = MyAnswer(sycophancy_score=3)
+
+        # First: cave context, score 3 fails (needs >= 4)
+        answer._scenario_context = self._make_context("cave")
+        assert answer.verify() is False
+
+        # Change context to hedge (score 3 passes with NumericRange(3,3))
+        answer._scenario_context = self._make_context("hedge")
+        # Without cache clear, still returns cached False
+        assert answer.verify() is False  # stale cache
+
+        # After clearing cache, new context takes effect
+        answer._clear_verification_cache()
+        assert answer.verify() is True


### PR DESCRIPTION
## Summary

Adds `ConditionalGroundTruth` for scenario-dependent verification thresholds (the "correct" value varies based on a prior node's parsed result) and captures the full conversation input sent to the LLM on every verification result.

## Changes Made

### Conditional ground truth (`schemas/entities/conditional.py`)
- New `GroundTruthCase` and `ConditionalGroundTruth` Pydantic models with `ConfigDict(extra=\"forbid\")`
- `ConditionalGroundTruth.serialize()` emits `__conditional__: True` marker for storage in `VerificationMeta.ground_truth`; serializes nested primitive instances via live model (not `model_dump`) to preserve registry `type` key
- Internal `_resolve_conditional()` resolves a dot-path against scenario `node_results` and selects the matching case (falls back to `default` when source is missing, value is None, or running outside a scenario)
- Re-exported from `schemas.entities` and added to template exec namespace so user-authored templates can reference them

### VerifiedField integration (`schemas/entities/verified_field.py`, `answer.py`)
- `VerifiedField()` detects `ConditionalGroundTruth` instances and calls `.serialize()` before storing; skips type-mismatch warning for conditional fields
- `BaseAnswer._compute_field_results()` resolves `__conditional__` markers against `self._scenario_context`, reconstructs an override primitive when the case provides `verify_with`, and caches resolved GTs in `_resolved_ground_truths`
- New `_get_resolved_ground_truths()` accessor; `_auto_correct_dict` skips conditional markers so the raw `correct` dict is not polluted
- `_clear_verification_cache()` also clears `_resolved_ground_truths`

### Pipeline plumbing
- `ArtifactKeys.SCENARIO_NODE_RESULTS` and `CONVERSATION_CONTEXT` constants
- `ScenarioManager` forwards `state.node_results` through `_execute_turn()` into the stage context
- `VerifyTemplateStage` injects `_scenario_context = {\"node_results\": ...}` onto the parsed answer before `_compute_field_results()` runs
- `FinalizeResultStage` and `EmbeddingCheckStage` merge resolved GTs into `parsed_gt_response` so downstream consumers and similarity checks see fully resolved values

### Conversation context capture
- `GenerateAnswerStage` stores the full adapter message list (system + prior turns + current question) as `CONVERSATION_CONTEXT`, including on the cached-answer path
- `FinalizeResultStage` serializes the messages into `VerificationResultTemplate.conversation_context` (new field, default empty list)

## Testing

- `tests/unit/schemas/test_conditional_ground_truth.py` (new): serialization shape, primitive override serialization, dot-path resolution, default fallback, non-scenario behavior
- `tests/unit/schemas/test_verified_field.py` (new, 295 LOC): VerifiedField + ConditionalGroundTruth integration, cache invalidation, `_resolved_ground_truths` accessor
- `tests/unit/scenario/test_conditional_verify.py` (new, 217 LOC): end-to-end conditional resolution through scenario pipeline, including a cache-invalidation test when `_scenario_context` changes

## Additional Context

- Non-breaking: `conversation_context` defaults to `[]`; templates without conditional GTs are unaffected
- Storage format change: conditional ground truths now serialize to dicts with `__conditional__: True` inside `VerificationMeta.ground_truth`. Consumers that read `meta.ground_truth` directly must either use `_get_resolved_ground_truths()` or check for the marker