### PR TITLE
feat(error-analysis): materialize verification failures into review cases + claude-code launcher

### DIFF
--- a/docs/advanced-pipeline/error-handling.md
+++ b/docs/advanced-pipeline/error-handling.md
@@ -478,3 +478,5 @@ The harmonization deletes several previously-supported retry surfaces.
 - [Stages in Detail](stages.md): which stages call the executor and which guards record streaming-timeout partial content.
 - [Adapters Overview](../advanced-adapters/index.md): where individual adapters install their `RetryExecutor`.
 - [Writing Adapters](../advanced-adapters/writing-adapters.md): how to wire `RetryExecutor` into a new adapter.
+
+For end-to-end analysis of a finished run, see [Error Analysis](../workflows/analyzing-results/error-analysis.md).

--- a/docs/core_concepts/results-and-scoring.md
+++ b/docs/core_concepts/results-and-scoring.md
@@ -653,3 +653,4 @@ This stage handles both success and error cases. If the pipeline errors at stage
 - [Evaluation Modes](../evaluation-modes/): How modes affect which result sub-objects are populated
 - [Rubrics](../../../core_concepts/rubrics/): Defining the traits that populate rubric results
 - [Answer Templates](../answer-templates/): Writing the `verify()` logic that produces `verify_result`
+- [Error Analysis](../../../workflows/analyzing-results/error-analysis/): Downstream consumer of `VerificationResultSet` that renders passes and failures as navigable markdown files for agent-assisted review

--- a/docs/core_concepts/scenarios/index.md
+++ b/docs/core_concepts/scenarios/index.md
@@ -59,3 +59,5 @@ Outcome criteria are declarative assertions evaluated after the scenario complet
 - [Outcome Criteria](../../notebooks/core_concepts/scenarios/outcome-criteria.ipynb): check nodes, sugar functions
 - [State and Routing](../../notebooks/core_concepts/scenarios/state-and-routing.ipynb): runtime state, edge resolution
 - [Sycophancy Tutorial](../../notebooks/scenarios/sycophancy-tutorial.ipynb): end-to-end walkthrough
+
+Scenario runs render as single files with per-turn sections in [Error Analysis](../../workflows/analyzing-results/error-analysis.md).

--- a/docs/workflows/analyzing-results/error-analysis.md
+++ b/docs/workflows/analyzing-results/error-analysis.md
@@ -1,0 +1,129 @@
+# Error Analysis
+
+## What it does
+
+Takes a finished verification run (`VerificationResultSet` plus the corresponding `Benchmark` checkpoint) and materializes it into a navigable directory. Passes and failures are split into per-category buckets; every case gets a markdown file with YAML frontmatter, a rendered trace, parsed fields, rubric scores, and the full failure record when applicable. A `PROMPT.md` is written alongside to orient an analyst agent. Running the agent is optional: the default `prepare-only` launcher just verifies `REPORT.md` exists afterwards, and an opt-in `claude-code` launcher shells out to the Claude Code CLI. Custom launchers can be registered against a small Protocol.
+
+This is a post-run diagnostic, not part of the [verification pipeline](../../core_concepts/verification-pipeline.md).
+
+## When to use it
+
+- Debugging a new benchmark where the pass rate is lower than expected.
+- Comparing two runs qualitatively (pattern detection over individual cases).
+- Iterating on a rubric or template and looking for recurring failure modes.
+
+When aggregate statistics are enough, use [DataFrame analysis](dataframe-analysis.md) instead.
+
+## Quick start
+
+Prepare the directory without running any agent:
+
+```bash
+karenina analyze-errors \
+    --results runs/2026-04-16_claude.json \
+    --checkpoint benchmarks/legal_qa.json \
+    --out-dir ./analysis/
+```
+
+Python equivalent:
+
+```python
+from pathlib import Path
+
+from karenina.benchmark.error_analysis import analyze_errors
+
+analyze_errors(
+    results=Path("runs/2026-04-16_claude.json"),
+    checkpoint=Path("benchmarks/legal_qa.json"),
+    out_dir=Path("./analysis/"),
+)
+```
+
+By default the command exits with status 3 because no agent has produced `REPORT.md` yet. Open the directory in Claude Code, Codex, or any other coding agent; point it at `PROMPT.md`; write `REPORT.md`; re-run with `--force` if desired.
+
+## Directory layout
+
+```
+analysis/
+├── INDEX.md             # stats, breakdown tables, directory map
+├── PROMPT.md            # analyst prompt (default or user-provided)
+├── REPORT.md            # agent output
+├── benchmark/
+│   ├── metadata.md
+│   ├── questions.jsonl
+│   ├── rubric.json
+│   └── templates/
+├── passes/              # one file per passing case
+├── failures/
+│   └── <category>/      # one file per failure, bucketed by FailureCategory
+└── case_assets/
+    └── <case_id>/
+        └── traces/artifacts/
+```
+
+Links for further reading: [answer templates](../../core_concepts/answer-templates.md), [rubrics](../../core_concepts/rubrics/index.md), [failure categories](../../advanced-pipeline/error-handling.md), [scenarios](../../core_concepts/scenarios/index.md).
+
+## How bucketing works
+
+Each `VerificationResult.failure.category` leaf becomes a folder name (`content`, `parsing`, `recursion_limit`, `trace_validation`, `deep_judgment`, `deep_judgment_rubric`, `abstention`, `sufficiency`, `template_validation`, `timeout`, `connection`, `rate_limit`, `server_error`, `unexpected_error`). Passes go into `passes/`. Scenarios land in the bucket of their first failing turn; the `failed_turn` frontmatter field pinpoints the turn. The `FailureGroup` is surfaced in the INDEX tables, never as a folder.
+
+Everything the agent needs is inside the analysis directory. The agent does not reach the SQLAlchemy database, other runs, or anything outside `out_dir`.
+
+## Running an agent against the directory
+
+Two supported paths.
+
+**Prepare only (default).** `karenina analyze-errors ...` writes the directory and exits. Open it in your agent of choice, feed it `PROMPT.md`, and let it write `REPORT.md`. Good for agents without a CLI entry point.
+
+**Built-in `claude-code` launcher (opt-in).** Requires `claude` on `PATH`.
+
+```bash
+karenina analyze-errors ... --launcher claude-code --timeout 1800
+```
+
+The launcher runs `claude -p @PROMPT.md --permission-mode acceptEdits` with `cwd=<out-dir>`. A missing `claude` binary raises `LauncherUnavailableError`.
+
+## Customizing the prompt
+
+The default prompt ships inside the package. Substituted placeholders:
+
+- `$BENCHMARK_NAME`
+- `$ANSWERING_MODEL` (comma-joined when multiple)
+- `$TOTAL`, `$PASSED`, `$FAILED`
+- `$FAILURE_CATEGORIES`
+
+Override by passing `--prompt path/to/custom.md` on the CLI (or `prompt_path=...` in Python). A user prompt that contains no placeholders is copied unchanged.
+
+## Writing a custom launcher
+
+```python
+from pathlib import Path
+import subprocess
+
+from karenina.benchmark.error_analysis import ErrorAnalystLauncher, register_launcher
+
+
+class CodexLauncher:
+    def run(self, analysis_dir: Path, **kwargs) -> Path:
+        subprocess.run(
+            ["codex", "run", "--file", "PROMPT.md"],
+            cwd=analysis_dir,
+            check=True,
+        )
+        return analysis_dir / "REPORT.md"
+
+
+register_launcher("codex", CodexLauncher)
+```
+
+Contract the launcher must honor: read the materialized files under `analysis_dir`, write `analysis_dir / REPORT.md`, and do not mutate anything outside the directory.
+
+## Trace size handling
+
+Long trace content is offloaded to per-case artifact files via the same mechanism the scenario handover uses. Offloaded chunks land in `case_assets/<case_id>/traces/artifacts/`; the inline trace carries a `[Content offloaded: N chars] File: <absolute path>` pointer. Threshold: `KARENINA_TRACE_TRUNCATION_THRESHOLD` environment variable (default 2000 characters). Override per analysis with `--max-trace-chars N`.
+
+## Limits
+
+- No live re-execution of failing cases. The directory is a snapshot.
+- One run per analysis directory. Cross-run comparison is out of scope.
+- Report quality is the agent's responsibility. karenina only checks that `REPORT.md` exists.

--- a/docs/workflows/analyzing-results/index.md
+++ b/docs/workflows/analyzing-results/index.md
@@ -106,6 +106,8 @@ df_rubric.groupby("question_id")["trait_score"].mean()
 
 [Analyze results with DataFrames →](../../notebooks/analyzing-results/dataframe-analysis.ipynb)
 
+For qualitative, per-case inspection (passes and failures rendered as markdown files, bucketed by failure category, ready to hand to a coding agent), see [Error Analysis](error-analysis.md).
+
 ### 4. Persist to Database
 
 Save benchmarks and verification results to a database for long-term storage, querying, and cross-run comparison:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -239,6 +239,7 @@ nav:
       - Overview: workflows/analyzing-results/index.md
       - Verification Result: workflows/analyzing-results/verification-result.md
       - DataFrame Analysis: notebooks/analyzing-results/dataframe-analysis.ipynb
+      - Error Analysis: workflows/analyzing-results/error-analysis.md
       - Exporting: workflows/analyzing-results/exporting.md
       - Iterating: workflows/analyzing-results/iterating.md
     - Scenarios:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,9 +110,10 @@ Documentation = "https://karenina.readthedocs.io"
 [tool.hatch.build.targets.wheel]
 packages = ["src/karenina"]
 
-# Include ADeLe rubric data files in the wheel
+# Include ADeLe rubric data files and error-analysis packaged prompts in the wheel
 [tool.hatch.build.targets.wheel.force-include]
 "src/karenina/integrations/adele/data" = "karenina/integrations/adele/data"
+"src/karenina/benchmark/error_analysis/prompts" = "karenina/benchmark/error_analysis/prompts"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/karenina/benchmark/error_analysis/__init__.py
+++ b/src/karenina/benchmark/error_analysis/__init__.py
@@ -1,0 +1,29 @@
+"""Post-run error analysis: materialize a verification run into a navigable
+directory and optionally invoke a pluggable agent to produce REPORT.md.
+
+Public surface:
+  - analyze_errors: facade orchestrator (added in Task 10)
+  - ErrorAnalysisMaterializer: prepare the directory without launching (Task 8)
+  - ErrorAnalystLauncher, register_launcher, get_launcher, list_launchers (Task 9)
+  - exceptions: ErrorAnalysisError and subclasses (Task 1)
+"""
+
+from __future__ import annotations
+
+from karenina.benchmark.error_analysis.exceptions import (
+    ErrorAnalysisError,
+    LauncherExecutionError,
+    LauncherNoOutputError,
+    LauncherNotFoundError,
+    LauncherUnavailableError,
+    MaterializationError,
+)
+
+__all__ = [
+    "ErrorAnalysisError",
+    "LauncherExecutionError",
+    "LauncherNoOutputError",
+    "LauncherNotFoundError",
+    "LauncherUnavailableError",
+    "MaterializationError",
+]

--- a/src/karenina/benchmark/error_analysis/__init__.py
+++ b/src/karenina/benchmark/error_analysis/__init__.py
@@ -3,12 +3,21 @@ directory and optionally invoke a pluggable agent to produce REPORT.md.
 
 Public surface:
   - analyze_errors: facade orchestrator (added in Task 10)
-  - ErrorAnalysisMaterializer: prepare the directory without launching (Task 8)
-  - ErrorAnalystLauncher, register_launcher, get_launcher, list_launchers (Task 9)
+  - ErrorAnalysisMaterializer: prepare the directory without launching (Task 7)
+  - ErrorAnalystLauncher, register_launcher, get_launcher, list_launchers (Task 8)
   - exceptions: ErrorAnalysisError and subclasses (Task 1)
+
+``ErrorAnalysisMaterializer`` is exposed via ``__getattr__`` so that
+importing ``karenina.benchmark.error_analysis.exceptions`` (the canonical
+site for the exception hierarchy, re-exported by ``karenina.exceptions``)
+does not force the rendering pipeline, scenario schemas, and ``ModelConfig``
+to load. Loading the materializer before ``karenina.schemas.config`` has
+finished initializing triggers a circular import.
 """
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from karenina.benchmark.error_analysis.exceptions import (
     ErrorAnalysisError,
@@ -19,11 +28,25 @@ from karenina.benchmark.error_analysis.exceptions import (
     MaterializationError,
 )
 
+if TYPE_CHECKING:
+    from karenina.benchmark.error_analysis.materializer import ErrorAnalysisMaterializer
+
 __all__ = [
     "ErrorAnalysisError",
+    "ErrorAnalysisMaterializer",
     "LauncherExecutionError",
     "LauncherNoOutputError",
     "LauncherNotFoundError",
     "LauncherUnavailableError",
     "MaterializationError",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "ErrorAnalysisMaterializer":
+        from karenina.benchmark.error_analysis.materializer import (
+            ErrorAnalysisMaterializer as _ErrorAnalysisMaterializer,
+        )
+
+        return _ErrorAnalysisMaterializer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/karenina/benchmark/error_analysis/__init__.py
+++ b/src/karenina/benchmark/error_analysis/__init__.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from karenina.benchmark.error_analysis import launchers  # noqa: F401
 from karenina.benchmark.error_analysis.exceptions import (
     ErrorAnalysisError,
     LauncherExecutionError,
@@ -27,6 +28,12 @@ from karenina.benchmark.error_analysis.exceptions import (
     LauncherUnavailableError,
     MaterializationError,
 )
+from karenina.benchmark.error_analysis.launcher import (
+    ErrorAnalystLauncher,
+    get_launcher,
+    list_launchers,
+    register_launcher,
+)
 
 if TYPE_CHECKING:
     from karenina.benchmark.error_analysis.materializer import ErrorAnalysisMaterializer
@@ -34,11 +41,15 @@ if TYPE_CHECKING:
 __all__ = [
     "ErrorAnalysisError",
     "ErrorAnalysisMaterializer",
+    "ErrorAnalystLauncher",
     "LauncherExecutionError",
     "LauncherNoOutputError",
     "LauncherNotFoundError",
     "LauncherUnavailableError",
     "MaterializationError",
+    "get_launcher",
+    "list_launchers",
+    "register_launcher",
 ]
 
 

--- a/src/karenina/benchmark/error_analysis/__init__.py
+++ b/src/karenina/benchmark/error_analysis/__init__.py
@@ -36,6 +36,7 @@ from karenina.benchmark.error_analysis.launcher import (
 )
 
 if TYPE_CHECKING:
+    from karenina.benchmark.error_analysis.facade import analyze_errors
     from karenina.benchmark.error_analysis.materializer import ErrorAnalysisMaterializer
 
 __all__ = [
@@ -47,6 +48,7 @@ __all__ = [
     "LauncherNotFoundError",
     "LauncherUnavailableError",
     "MaterializationError",
+    "analyze_errors",
     "get_launcher",
     "list_launchers",
     "register_launcher",
@@ -60,4 +62,10 @@ def __getattr__(name: str) -> Any:
         )
 
         return _ErrorAnalysisMaterializer
+    if name == "analyze_errors":
+        from karenina.benchmark.error_analysis.facade import (
+            analyze_errors as _analyze_errors,
+        )
+
+        return _analyze_errors
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/karenina/benchmark/error_analysis/case_renderer.py
+++ b/src/karenina/benchmark/error_analysis/case_renderer.py
@@ -312,3 +312,131 @@ def render_qa_case(
         parts.append(failure_section)
 
     return "\n".join(p for p in parts if p)
+
+
+def _first_failing_turn(turn_results: list[VerificationResult]) -> VerificationResult | None:
+    """Return the first turn result with a failure, or None when all passed.
+
+    Args:
+        turn_results: The per-turn VerificationResults from a scenario run.
+
+    Returns:
+        The first failing VerificationResult, or None if none failed.
+    """
+    for r in turn_results:
+        if r.metadata.failure is not None:
+            return r
+    return None
+
+
+def _scenario_case_id(execution: Any, monotonic_n: int) -> str:
+    """Compute the frontmatter id for a scenario case.
+
+    Args:
+        execution: The ScenarioExecutionResult being rendered.
+        monotonic_n: Fallback run number when ``execution.replicate`` is None.
+
+    Returns:
+        A string like ``scenario_<scenario_id>__run_<n>``.
+    """
+    n = execution.replicate if execution.replicate is not None else monotonic_n
+    return f"scenario_{execution.scenario_id}__run_{n}"
+
+
+def render_scenario_case(
+    execution: Any,  # ScenarioExecutionResult; Any to avoid circular import at module load.
+    *,
+    template_sources: dict[str, str | None],
+    template_links: dict[str, str],
+    artifacts_dir: Path | None,
+    max_trace_chars: int | None = None,
+    monotonic_n: int = 1,
+) -> str:
+    """Render one ScenarioExecutionResult as a single markdown file.
+
+    The output has scenario-level YAML frontmatter, a scenario heading with
+    the path breadcrumb, one ``## Turn N <node>`` section per turn that
+    embeds :func:`render_qa_case` (frontmatter stripped), and a final
+    ``# Outcomes`` section enumerating ``outcome_results``.
+
+    Args:
+        execution: The ScenarioExecutionResult to render.
+        template_sources: Mapping from question_id to raw template source,
+            or None when no source is available.
+        template_links: Mapping from question_id to a relative link path
+            for the template file.
+        artifacts_dir: Directory for offloaded trace artifacts; None
+            disables offloading.
+        max_trace_chars: Optional override of the trace truncation
+            threshold, forwarded to each per-turn render.
+        monotonic_n: Fallback run number when ``execution.replicate`` is
+            None; used to build the case ID.
+
+    Returns:
+        The full markdown body, ready to be written to a ``.md`` file.
+    """
+    failing = _first_failing_turn(execution.turn_results)
+    failure = failing.metadata.failure if failing else None
+
+    first_turn_md = execution.turn_results[0].metadata if execution.turn_results else None
+    model_display = first_turn_md.answering.display_string if first_turn_md else ""
+    parsing_display = first_turn_md.parsing.display_string if first_turn_md else ""
+
+    fm: dict[str, Any] = {
+        "id": _scenario_case_id(execution, monotonic_n),
+        "outcome": "failure" if failure else "pass",
+        "scenario_id": execution.scenario_id,
+        "replicate": execution.replicate,
+        "model": model_display,
+        "parsing_model": parsing_display,
+        "category": failure.category.value if failure else None,
+        "group": failure.group.value if failure else None,
+        "stage": failure.stage if failure else None,
+        "path": list(execution.path or []),
+        "turn_count": execution.turn_count,
+        "failed_turn": failing.metadata.scenario_turn if failing else None,
+        "outcome_results": dict(execution.outcome_results or {}),
+    }
+
+    parts: list[str] = [
+        "---",
+        yaml.safe_dump(fm, sort_keys=True).rstrip(),
+        "---",
+        "",
+        f"# Scenario: {execution.scenario_id} (run {fm['id'].rsplit('__run_', 1)[-1]})",
+        "",
+        "Path: " + " -> ".join(execution.path or []),
+    ]
+    if failing is not None:
+        parts.append(f"Failed at turn {failing.metadata.scenario_turn} (`{failing.metadata.scenario_node}`).")
+    parts.append("")
+
+    for turn_result in execution.turn_results:
+        turn_num = turn_result.metadata.scenario_turn
+        node_id = turn_result.metadata.scenario_node or ""
+        marker = " (FAILED)" if turn_result.metadata.failure else ""
+        parts.append(f"## Turn {turn_num} {node_id}{marker}".rstrip())
+        parts.append("")
+        # Embed the per-turn QA body without its frontmatter.
+        qa_body = render_qa_case(
+            turn_result,
+            template_source=template_sources.get(turn_result.metadata.question_id),
+            template_link=template_links.get(turn_result.metadata.question_id),
+            artifacts_dir=artifacts_dir,
+            max_trace_chars=max_trace_chars,
+        )
+        # Strip frontmatter from the nested rendering.
+        if qa_body.startswith("---\n"):
+            _, _fm, rest = qa_body.split("---\n", 2)
+            parts.append(rest.strip())
+        else:
+            parts.append(qa_body.strip())
+        parts.append("")
+
+    parts.append("# Outcomes")
+    parts.append("")
+    for key, value in (execution.outcome_results or {}).items():
+        parts.append(f"- `{key}`: {value}")
+    parts.append("")
+
+    return "\n".join(parts)

--- a/src/karenina/benchmark/error_analysis/case_renderer.py
+++ b/src/karenina/benchmark/error_analysis/case_renderer.py
@@ -10,12 +10,22 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
 import yaml  # type: ignore[import-untyped]
 
+from karenina.replay.ports_message_hydration import hydrate_trace_messages
+from karenina.scenario.handover import TaggedMessage, format_transcript
+from karenina.scenario.trace_materialization import (
+    DEFAULT_TRACE_TRUNCATION_THRESHOLD,
+    format_turns_as_xml,
+    group_entries_into_turns,
+    parse_transcript_entries,
+)
 from karenina.schemas.verification.result import VerificationResult
+from karenina.schemas.verification.result_components import VerificationResultMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +139,77 @@ def _render_section(title: str, body: str) -> str:
     return f"# {title}\n\n{body}\n"
 
 
+def _resolve_truncation_threshold(override: int | None) -> int:
+    """Pick the effective truncation threshold for trace rendering.
+
+    Args:
+        override: Caller-supplied max_trace_chars; takes precedence over env.
+
+    Returns:
+        The chosen threshold, falling back to the env var and then to
+        DEFAULT_TRACE_TRUNCATION_THRESHOLD when the env var is missing or
+        invalid.
+    """
+    if override is not None:
+        return override
+    raw = os.environ.get("KARENINA_TRACE_TRUNCATION_THRESHOLD")
+    if raw is None:
+        return DEFAULT_TRACE_TRUNCATION_THRESHOLD
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid KARENINA_TRACE_TRUNCATION_THRESHOLD=%s, using default %d",
+            raw,
+            DEFAULT_TRACE_TRUNCATION_THRESHOLD,
+        )
+        return DEFAULT_TRACE_TRUNCATION_THRESHOLD
+
+
+def _render_trace(
+    trace_messages: list[dict[str, Any]],
+    metadata: VerificationResultMetadata,
+    artifacts_dir: Path | None,
+    max_trace_chars: int | None,
+) -> str:
+    """Convert stored trace_messages into the XML turn body.
+
+    Args:
+        trace_messages: Stored raw message dicts from the template record.
+        metadata: Case metadata; supplies the answering agent identity.
+        artifacts_dir: Directory for offloaded long-message artifacts.
+        max_trace_chars: Optional threshold override.
+
+    Returns:
+        An XML-formatted transcript string, or a stub when no messages
+        are available.
+    """
+    if not trace_messages:
+        return "_No trace captured for this case._"
+
+    messages = hydrate_trace_messages(trace_messages)
+    agent_id = metadata.answering.display_string
+    tagged = [
+        TaggedMessage(
+            message=msg,
+            agent_id="__user__" if msg.role.value == "user" else agent_id,
+        )
+        for msg in messages
+    ]
+    transcript = format_transcript(tagged)
+    if not transcript:
+        return "_No trace captured for this case._"
+    entries = parse_transcript_entries(transcript)
+    turns = group_entries_into_turns(entries)
+    threshold = _resolve_truncation_threshold(max_trace_chars)
+    xml = format_turns_as_xml(
+        turns,
+        artifacts_dir=artifacts_dir,
+        truncation_threshold=threshold,
+    )
+    return xml
+
+
 def _render_failure(result: VerificationResult) -> str:
     """Render the Failure section for cases that carry a Failure.
 
@@ -157,12 +238,10 @@ def render_qa_case(
     *,
     template_source: str | None,
     template_link: str | None = None,
-    artifacts_dir: Path | None,  # noqa: ARG001  # threaded for Task 3 trace rendering
+    artifacts_dir: Path | None,
+    max_trace_chars: int | None = None,
 ) -> str:
     """Render a QA-style VerificationResult as markdown with YAML frontmatter.
-
-    The ``artifacts_dir`` parameter is threaded to the trace-rendering code
-    (added in Task 3). Pass None to disable trace offloading.
 
     Args:
         result: The VerificationResult to render.
@@ -170,6 +249,10 @@ def render_qa_case(
         template_link: Relative path to the template file, or None.
         artifacts_dir: Directory where artifacts (traces, attachments) may
             be written. None disables offloading.
+        max_trace_chars: Optional override of the trace truncation
+            threshold. When None, the env var
+            ``KARENINA_TRACE_TRUNCATION_THRESHOLD`` is consulted, falling
+            back to the module default.
 
     Returns:
         The full markdown body, ready to be written to a ``.md`` file.
@@ -203,9 +286,14 @@ def render_qa_case(
     if tmpl is not None and tmpl.raw_llm_response:
         parts.append(_render_section("LLM Response", tmpl.raw_llm_response))
 
-    # Trace section is added in Task 3. For now emit a stub so existing
-    # body-layout assertions remain stable.
-    parts.append(_render_section("Trace", "_No trace captured for this case._"))
+    trace_messages = tmpl.trace_messages if tmpl is not None else []
+    trace_body = _render_trace(
+        trace_messages,
+        md,
+        artifacts_dir,
+        max_trace_chars,
+    )
+    parts.append(_render_section("Trace", trace_body))
 
     if tmpl is not None and tmpl.parsed_llm_response is not None:
         parts.append(

--- a/src/karenina/benchmark/error_analysis/case_renderer.py
+++ b/src/karenina/benchmark/error_analysis/case_renderer.py
@@ -1,0 +1,226 @@
+"""Render one VerificationResult (or one ScenarioExecutionResult) as a
+Markdown case file with YAML frontmatter.
+
+This module contains only the single-case rendering logic. Bucket
+placement, filename sanitization, and directory orchestration are in
+materializer.py (Task 8).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+from karenina.schemas.verification.result import VerificationResult
+
+logger = logging.getLogger(__name__)
+
+TEMPLATE_INLINE_THRESHOLD_LINES = 100
+TEMPLATE_EXCERPT_LINES = 20
+
+
+def _qa_case_id(metadata: Any) -> str:
+    """Build the case ID stamped into the frontmatter.
+
+    Args:
+        metadata: The VerificationResultMetadata for the case.
+
+    Returns:
+        A string like ``q_<question_id>`` or ``q_<question_id>__rep_<n>``
+        when a replicate number is present.
+    """
+    base = f"q_{metadata.question_id}"
+    if metadata.replicate is not None:
+        return f"{base}__rep_{metadata.replicate}"
+    return base
+
+
+def _qa_frontmatter(result: VerificationResult) -> dict[str, Any]:
+    """Compute the YAML frontmatter mapping for a QA case.
+
+    Args:
+        result: The VerificationResult being rendered.
+
+    Returns:
+        A plain dict ready for ``yaml.safe_dump``.
+    """
+    md = result.metadata
+    failure = md.failure
+    fm: dict[str, Any] = {
+        "id": _qa_case_id(md),
+        "outcome": "failure" if failure is not None else "pass",
+        "question_id": md.question_id,
+        "replicate": md.replicate,
+        "model": md.answering.display_string,
+        "parsing_model": md.parsing.display_string,
+        "category": failure.category.value if failure else None,
+        "group": failure.group.value if failure else None,
+        "stage": failure.stage if failure else None,
+        "rubric_scores": _collect_rubric_scores(result),
+    }
+    return fm
+
+
+def _collect_rubric_scores(result: VerificationResult) -> dict[str, Any]:
+    """Use the rubric's native get_all_trait_scores() aggregator.
+
+    Args:
+        result: The VerificationResult whose rubric scores to collect.
+
+    Returns:
+        An empty dict when result.rubric is None (rubric is Optional on
+        VerificationResult) or when no trait scores are present.
+    """
+    if result.rubric is None:
+        return {}
+    # VerificationResultRubric.get_all_trait_scores() unions every
+    # *_trait_scores dict into a single mapping, which is exactly what the
+    # frontmatter wants.
+    return dict(result.rubric.get_all_trait_scores())
+
+
+def _render_template_section(template_source: str | None, template_link: str | None) -> str:
+    """Render the Template section: link + inline source or excerpt.
+
+    Args:
+        template_source: Raw Python source of the answer template, or None.
+        template_link: Relative path to the template file, or None.
+
+    Returns:
+        The rendered section as a string (empty when both inputs are None).
+    """
+    if template_source is None and template_link is None:
+        return ""
+    lines: list[str] = ["# Template", ""]
+    if template_link:
+        lines.append(f"Source: [{template_link}]({template_link})")
+        lines.append("")
+    if template_source is not None:
+        source_lines = template_source.splitlines()
+        if len(source_lines) <= TEMPLATE_INLINE_THRESHOLD_LINES:
+            lines.append("```python")
+            lines.extend(source_lines)
+            lines.append("```")
+        else:
+            lines.append("```python")
+            lines.extend(source_lines[:TEMPLATE_EXCERPT_LINES])
+            lines.append("```")
+            lines.append(f"_Excerpt: first {TEMPLATE_EXCERPT_LINES} lines of {len(source_lines)}._")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _render_section(title: str, body: str) -> str:
+    """Render a ``# Title`` section with the supplied body.
+
+    Args:
+        title: Heading text (without the leading ``#``).
+        body: Body content; returns empty string when body is falsy.
+
+    Returns:
+        The full section string or an empty string.
+    """
+    if not body:
+        return ""
+    return f"# {title}\n\n{body}\n"
+
+
+def _render_failure(result: VerificationResult) -> str:
+    """Render the Failure section for cases that carry a Failure.
+
+    Args:
+        result: The VerificationResult being rendered.
+
+    Returns:
+        The rendered section, or empty string when the case is a pass.
+    """
+    failure = result.metadata.failure
+    if failure is None:
+        return ""
+    lines = [
+        f"- Category: `{failure.category.value}`",
+        f"- Group: `{failure.group.value}`",
+        f"- Stage: `{failure.stage}`",
+        f"- Reason: {failure.reason}",
+    ]
+    if failure.details:
+        lines.append(f"- Details: `{json.dumps(failure.details, sort_keys=True)}`")
+    return "# Failure\n\n" + "\n".join(lines) + "\n"
+
+
+def render_qa_case(
+    result: VerificationResult,
+    *,
+    template_source: str | None,
+    template_link: str | None = None,
+    artifacts_dir: Path | None,  # noqa: ARG001  # threaded for Task 3 trace rendering
+) -> str:
+    """Render a QA-style VerificationResult as markdown with YAML frontmatter.
+
+    The ``artifacts_dir`` parameter is threaded to the trace-rendering code
+    (added in Task 3). Pass None to disable trace offloading.
+
+    Args:
+        result: The VerificationResult to render.
+        template_source: Raw Python source of the answer template, or None.
+        template_link: Relative path to the template file, or None.
+        artifacts_dir: Directory where artifacts (traces, attachments) may
+            be written. None disables offloading.
+
+    Returns:
+        The full markdown body, ready to be written to a ``.md`` file.
+    """
+    fm = _qa_frontmatter(result)
+    parts: list[str] = [
+        "---",
+        yaml.safe_dump(fm, sort_keys=True).rstrip(),
+        "---",
+        "",
+    ]
+
+    md = result.metadata
+    tmpl = result.template
+
+    question_body_lines = [md.question_text.strip()]
+    if md.keywords:
+        question_body_lines.append("")
+        question_body_lines.append(f"Keywords: {', '.join(md.keywords)}")
+    if md.raw_answer is not None:
+        question_body_lines.append("")
+        question_body_lines.append("Expected answer:")
+        question_body_lines.append("")
+        question_body_lines.append(md.raw_answer)
+    parts.append(_render_section("Question", "\n".join(question_body_lines)))
+
+    template_section = _render_template_section(template_source, template_link)
+    if template_section:
+        parts.append(template_section)
+
+    if tmpl is not None and tmpl.raw_llm_response:
+        parts.append(_render_section("LLM Response", tmpl.raw_llm_response))
+
+    # Trace section is added in Task 3. For now emit a stub so existing
+    # body-layout assertions remain stable.
+    parts.append(_render_section("Trace", "_No trace captured for this case._"))
+
+    if tmpl is not None and tmpl.parsed_llm_response is not None:
+        parts.append(
+            _render_section(
+                "Parsed Answer",
+                "```json\n" + json.dumps(tmpl.parsed_llm_response, sort_keys=True, indent=2) + "\n```",
+            )
+        )
+
+    if tmpl is not None and tmpl.field_results:
+        rows = "\n".join(f"- `{field}`: {'pass' if ok else 'fail'}" for field, ok in tmpl.field_results.items())
+        parts.append(_render_section("Field Results", rows))
+
+    failure_section = _render_failure(result)
+    if failure_section:
+        parts.append(failure_section)
+
+    return "\n".join(p for p in parts if p)

--- a/src/karenina/benchmark/error_analysis/exceptions.py
+++ b/src/karenina/benchmark/error_analysis/exceptions.py
@@ -1,0 +1,102 @@
+"""Exception hierarchy for the error-analysis feature.
+
+All exceptions inherit from ErrorAnalysisError, which inherits from
+KareninaError. The hierarchy is re-exported from karenina.exceptions
+for convenience.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from karenina.exceptions import KareninaError
+
+
+class ErrorAnalysisError(KareninaError):
+    """Base exception for the error-analysis feature."""
+
+
+class MaterializationError(ErrorAnalysisError):
+    """Raised when the materializer cannot produce the analysis directory.
+
+    Args:
+        message: Human-readable description.
+        details: Structured context (unwritable path, missing template id, etc.).
+    """
+
+    def __init__(self, message: str, details: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.details = details or {}
+
+
+class LauncherNotFoundError(ErrorAnalysisError):
+    """Raised when a launcher name is not present in the registry.
+
+    Args:
+        launcher: The requested name.
+        registered: Names currently in the registry.
+    """
+
+    def __init__(self, launcher: str, registered: list[str]) -> None:
+        self.launcher = launcher
+        self.registered = registered
+        message = (
+            f"Launcher '{launcher}' is not registered. "
+            f"Available launchers: {', '.join(registered) if registered else '<none>'}."
+        )
+        super().__init__(message)
+
+
+class LauncherUnavailableError(ErrorAnalysisError):
+    """Raised when a launcher is registered but its runtime dependency is missing.
+
+    Args:
+        launcher: The launcher name.
+        hint: Install or configuration hint shown to the user.
+    """
+
+    def __init__(self, launcher: str, hint: str) -> None:
+        self.launcher = launcher
+        self.hint = hint
+        super().__init__(f"Launcher '{launcher}' is unavailable: {hint}")
+
+
+class LauncherExecutionError(ErrorAnalysisError):
+    """Raised when a launcher subprocess failed.
+
+    Preserves the returncode and the last 2048 bytes of stderr so callers
+    can diagnose without replaying the subprocess.
+
+    Args:
+        launcher: The launcher name.
+        cause: The originating CalledProcessError.
+    """
+
+    STDERR_TAIL_BYTES = 2048
+
+    def __init__(self, launcher: str, cause: subprocess.CalledProcessError) -> None:
+        self.launcher = launcher
+        self.returncode = cause.returncode
+        raw = cause.stderr or b""
+        if isinstance(raw, bytes):
+            tail_bytes = raw[-self.STDERR_TAIL_BYTES :]
+            self.stderr_tail = tail_bytes.decode("utf-8", errors="replace")
+        else:
+            self.stderr_tail = raw[-self.STDERR_TAIL_BYTES :]
+        super().__init__(
+            f"Launcher '{launcher}' exited with status {self.returncode}. Last stderr: {self.stderr_tail!r}"
+        )
+
+
+class LauncherNoOutputError(ErrorAnalysisError):
+    """Raised when a launcher returned without error but REPORT.md is absent.
+
+    Args:
+        analysis_dir: The analysis directory that was expected to contain REPORT.md.
+    """
+
+    def __init__(self, analysis_dir: Path) -> None:
+        self.analysis_dir = analysis_dir
+        super().__init__(f"Launcher completed but no REPORT.md was produced at {analysis_dir / 'REPORT.md'}.")

--- a/src/karenina/benchmark/error_analysis/facade.py
+++ b/src/karenina/benchmark/error_analysis/facade.py
@@ -1,0 +1,118 @@
+"""Facade for the error-analysis feature: glue materializer + prompt + launcher."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from karenina.benchmark.error_analysis.exceptions import LauncherNoOutputError
+from karenina.benchmark.error_analysis.launcher import (
+    ErrorAnalystLauncher,
+    get_launcher,
+)
+from karenina.benchmark.error_analysis.materializer import ErrorAnalysisMaterializer
+from karenina.benchmark.error_analysis.prompt_io import (
+    PromptContext,
+    resolve_and_write_prompt,
+)
+
+logger = logging.getLogger(__name__)
+
+_CLAUDE_CODE_MODULE = "karenina.benchmark.error_analysis.launchers.claude_code"
+
+
+def analyze_errors(
+    results: Any,
+    checkpoint: Any,
+    out_dir: Path,
+    *,
+    prompt_path: Path | None = None,
+    launcher: str | ErrorAnalystLauncher = "prepare-only",
+    launcher_kwargs: dict[str, object] | None = None,
+    max_trace_chars: int | None = None,
+    force: bool = False,
+) -> Path:
+    """Materialize a run into out_dir and invoke a launcher to produce REPORT.md.
+
+    Args:
+        results: a VerificationResultSet or a path to its JSON export.
+        checkpoint: a Benchmark or a path to its JSON-LD file.
+        out_dir: destination directory for the analysis (created if absent).
+        prompt_path: optional user-supplied PROMPT.md source.
+        launcher: registered launcher name, or an instance conforming to
+            ErrorAnalystLauncher.
+        launcher_kwargs: forwarded to launcher.run().
+        max_trace_chars: override for KARENINA_TRACE_TRUNCATION_THRESHOLD
+            just for this analysis.
+        force: allow writing into a non-empty out_dir.
+
+    Returns:
+        Path to out_dir / "REPORT.md" on success.
+
+    Raises:
+        MaterializationError: on any materialization failure.
+        LauncherNotFoundError: if launcher is an unknown name.
+        LauncherUnavailableError: if the launcher is registered but its
+            dependency (for example, the claude binary) is missing.
+        LauncherExecutionError: if the launcher subprocess failed.
+        LauncherNoOutputError: if the launcher claimed success but
+            REPORT.md is absent.
+    """
+    results_obj = _load_results(results)
+    checkpoint_obj = _load_checkpoint(checkpoint)
+
+    materializer = ErrorAnalysisMaterializer(max_trace_chars=max_trace_chars)
+    materializer.build(results_obj, checkpoint_obj, out_dir, force=force)
+
+    context = _prompt_context(checkpoint_obj, results_obj)
+    resolve_and_write_prompt(prompt_path=prompt_path, out_dir=out_dir, context=context)
+
+    resolved_launcher = _resolve_launcher(launcher)
+    resolved_launcher.run(out_dir, **(launcher_kwargs or {}))
+
+    report_path = out_dir / "REPORT.md"
+    if not report_path.exists():
+        raise LauncherNoOutputError(out_dir)
+    logger.info("Analysis complete: %s", report_path)
+    return report_path
+
+
+def _load_results(results: Any) -> Any:
+    from karenina.schemas.results.verification_result_set import VerificationResultSet
+
+    if isinstance(results, Path):
+        return VerificationResultSet.model_validate_json(results.read_text(encoding="utf-8"))
+    return results
+
+
+def _load_checkpoint(checkpoint: Any) -> Any:
+    from karenina.benchmark.benchmark import Benchmark
+
+    if isinstance(checkpoint, Path):
+        return Benchmark.load(checkpoint)
+    return checkpoint
+
+
+def _prompt_context(checkpoint_obj: Any, result_set: Any) -> PromptContext:
+    answering = sorted({r.metadata.answering.display_string for r in result_set.results})
+    failed = [r for r in result_set.results if r.metadata.failure is not None]
+    categories = sorted({r.metadata.failure.category.value for r in failed})
+    return PromptContext(
+        benchmark_name=getattr(checkpoint_obj, "name", "(unknown)"),
+        answering_model=", ".join(answering) if answering else "(unknown)",
+        total=len(result_set.results),
+        passed=len(result_set.results) - len(failed),
+        failed=len(failed),
+        failure_categories=categories,
+    )
+
+
+def _resolve_launcher(launcher: str | ErrorAnalystLauncher) -> ErrorAnalystLauncher:
+    if isinstance(launcher, str):
+        if launcher == "claude-code":
+            import importlib
+
+            importlib.import_module(_CLAUDE_CODE_MODULE)  # triggers registration
+        return get_launcher(launcher)()
+    return launcher

--- a/src/karenina/benchmark/error_analysis/facade.py
+++ b/src/karenina/benchmark/error_analysis/facade.py
@@ -81,16 +81,16 @@ def analyze_errors(
 def _load_results(results: Any) -> Any:
     from karenina.schemas.results.verification_result_set import VerificationResultSet
 
-    if isinstance(results, Path):
-        return VerificationResultSet.model_validate_json(results.read_text(encoding="utf-8"))
+    if isinstance(results, str | Path):
+        return VerificationResultSet.model_validate_json(Path(results).read_text(encoding="utf-8"))
     return results
 
 
 def _load_checkpoint(checkpoint: Any) -> Any:
     from karenina.benchmark.benchmark import Benchmark
 
-    if isinstance(checkpoint, Path):
-        return Benchmark.load(checkpoint)
+    if isinstance(checkpoint, str | Path):
+        return Benchmark.load(Path(checkpoint))
     return checkpoint
 
 

--- a/src/karenina/benchmark/error_analysis/indexer.py
+++ b/src/karenina/benchmark/error_analysis/indexer.py
@@ -1,0 +1,111 @@
+"""Build INDEX.md from already-rendered case metadata.
+
+The indexer does not open case files. Callers (materializer.py) supply
+small IndexEntry records capturing what the index needs to know.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+
+REASON_TRUNCATE_CHARS = 100
+PASS_TABLE_LIMIT = 50
+
+
+@dataclass(frozen=True)
+class IndexEntry:
+    """Minimal projection of a materialized case for INDEX.md assembly."""
+
+    case_id: str
+    bucket_path: str
+    outcome: str
+    category: str
+    group: str
+    stage: str
+    reason: str
+
+
+def _directory_map() -> list[str]:
+    return [
+        "- `benchmark/`: the checkpoint's questions, templates, and rubric.",
+        "- `passes/`: one file per passing case.",
+        "- `failures/<category>/`: one file per failure, bucketed by category.",
+        "- `case_assets/`: offloaded trace content referenced from case files.",
+        "- `PROMPT.md`: the prompt the analyst agent is asked to follow.",
+        "- `REPORT.md`: the agent's output; absent until a launcher runs.",
+    ]
+
+
+def build_index_markdown(
+    *,
+    benchmark_name: str,
+    answering_model: str,
+    run_timestamp: str,
+    entries: list[IndexEntry],
+    run_id: str | None = None,
+) -> str:
+    passes = [e for e in entries if e.outcome == "pass"]
+    failures = [e for e in entries if e.outcome == "failure"]
+    total = len(entries)
+    pass_count = len(passes)
+    fail_count = len(failures)
+    pass_pct = (pass_count / total * 100.0) if total else 0.0
+
+    lines: list[str] = [
+        f"# Error Analysis: {benchmark_name}",
+        "",
+        f"- Model: {answering_model}",
+        f"- Run timestamp: {run_timestamp}",
+    ]
+    if run_id is not None:
+        lines.append(f"- Run id: {run_id}")
+    lines.extend(
+        [
+            f"- Total: {total}",
+            f"- Passed: {pass_count} ({pass_pct:.0f}%)",
+            f"- Failed: {fail_count}",
+            "",
+            "## Failure breakdown",
+            "",
+            "| Group | Category | Count |",
+            "| --- | --- | --- |",
+        ]
+    )
+    by_cat: Counter[tuple[str, str]] = Counter()
+    for e in failures:
+        by_cat[(e.group, e.category)] += 1
+    for (group, category), count in sorted(by_cat.items()):
+        lines.append(f"| {group} | {category} | {count} |")
+
+    lines += ["", "## Directory", ""]
+    lines += _directory_map()
+
+    lines += ["", "## Failures by category", ""]
+    grouped: dict[str, list[IndexEntry]] = defaultdict(list)
+    for e in failures:
+        grouped[e.category].append(e)
+    for category in sorted(grouped):
+        bucket_entries = grouped[category]
+        lines.append(f"### {category} ({len(bucket_entries)})")
+        lines.append("")
+        lines.append("| ID | Stage | One-line reason |")
+        lines.append("| --- | --- | --- |")
+        for e in bucket_entries:
+            reason = (e.reason or "").replace("\n", " ").strip()
+            if len(reason) > REASON_TRUNCATE_CHARS:
+                reason = reason[:REASON_TRUNCATE_CHARS]
+            lines.append(f"| [{e.case_id}]({e.bucket_path}) | {e.stage} | {reason} |")
+        lines.append("")
+
+    lines += ["## Passes", ""]
+    if passes:
+        lines += ["| ID | Stage |", "| --- | --- |"]
+        for e in passes[:PASS_TABLE_LIMIT]:
+            lines.append(f"| {e.case_id} | {e.stage or '-'} |")
+        if len(passes) > PASS_TABLE_LIMIT:
+            lines.append(f"_(... and {len(passes) - PASS_TABLE_LIMIT} more)_")
+    else:
+        lines.append("_No passing cases._")
+
+    return "\n".join(lines) + "\n"

--- a/src/karenina/benchmark/error_analysis/launcher.py
+++ b/src/karenina/benchmark/error_analysis/launcher.py
@@ -1,0 +1,53 @@
+"""Pluggable launcher Protocol + registry for error-analysis agents.
+
+A launcher receives a materialized analysis directory and must cause a
+REPORT.md to appear at <analysis_dir>/REPORT.md. Launchers never mutate
+files outside analysis_dir.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from karenina.benchmark.error_analysis.exceptions import LauncherNotFoundError
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ErrorAnalystLauncher(Protocol):
+    """Protocol for swappable analyst launchers."""
+
+    def run(self, analysis_dir: Path, **kwargs: object) -> Path: ...
+
+
+_REGISTRY: dict[str, type[ErrorAnalystLauncher]] = {}
+
+
+def register_launcher(name: str, cls: type[ErrorAnalystLauncher]) -> None:
+    """Register a launcher class under a name.
+
+    Subsequent registrations under the same name overwrite the previous
+    binding; this is intentional, to support user overrides.
+    """
+    _REGISTRY[name] = cls
+    logger.debug("Registered error-analyst launcher %s", name)
+
+
+def get_launcher(name: str) -> type[ErrorAnalystLauncher]:
+    """Look up a launcher class by name.
+
+    Raises:
+        LauncherNotFoundError: if the name is not registered. The error
+            message lists all currently-registered launchers.
+    """
+    if name not in _REGISTRY:
+        raise LauncherNotFoundError(name, registered=sorted(_REGISTRY))
+    return _REGISTRY[name]
+
+
+def list_launchers() -> list[str]:
+    """Return the sorted list of currently-registered launcher names."""
+    return sorted(_REGISTRY)

--- a/src/karenina/benchmark/error_analysis/launchers/__init__.py
+++ b/src/karenina/benchmark/error_analysis/launchers/__init__.py
@@ -1,0 +1,15 @@
+"""Built-in error-analyst launchers.
+
+Importing this package registers prepare-only. claude-code is not
+imported by default; the facade imports it lazily when the user selects
+launcher="claude-code".
+"""
+
+from __future__ import annotations
+
+from karenina.benchmark.error_analysis.launcher import register_launcher
+from karenina.benchmark.error_analysis.launchers.prepare_only import PrepareOnlyLauncher
+
+register_launcher("prepare-only", PrepareOnlyLauncher)
+
+__all__ = ["PrepareOnlyLauncher"]

--- a/src/karenina/benchmark/error_analysis/launchers/claude_code.py
+++ b/src/karenina/benchmark/error_analysis/launchers/claude_code.py
@@ -45,9 +45,18 @@ class ClaudeCodeLauncher:
         ]
         logger.info("Invoking claude-code launcher in %s", analysis_dir)
         try:
-            subprocess.run(cmd, cwd=analysis_dir, check=True, timeout=timeout)
+            subprocess.run(cmd, cwd=analysis_dir, check=True, timeout=timeout, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as exc:
             raise LauncherExecutionError("claude-code", exc) from exc
+        except subprocess.TimeoutExpired as exc:
+            # Synthesize a CalledProcessError so LauncherExecutionError can stash returncode + stderr.
+            stderr_bytes = exc.stderr if isinstance(exc.stderr, bytes) else b""
+            synthetic = subprocess.CalledProcessError(
+                returncode=-1,
+                cmd=cmd,
+                stderr=stderr_bytes or f"timeout after {timeout}s".encode(),
+            )
+            raise LauncherExecutionError("claude-code", synthetic) from exc
         return analysis_dir / "REPORT.md"
 
 

--- a/src/karenina/benchmark/error_analysis/launchers/claude_code.py
+++ b/src/karenina/benchmark/error_analysis/launchers/claude_code.py
@@ -1,0 +1,54 @@
+"""Opt-in launcher that shells out to the `claude` CLI.
+
+Registered on import; the facade imports this module lazily when the
+user selects launcher="claude-code".
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+
+from karenina.benchmark.error_analysis.exceptions import (
+    LauncherExecutionError,
+    LauncherUnavailableError,
+)
+from karenina.benchmark.error_analysis.launcher import register_launcher
+
+logger = logging.getLogger(__name__)
+
+_CLAUDE_BINARY = "claude"
+_INSTALL_HINT = (
+    "Install the Claude Code CLI from https://docs.anthropic.com/claude/code and ensure `claude` is on PATH."
+)
+
+
+class ClaudeCodeLauncher:
+    """Shells out to the `claude` CLI against the analysis directory."""
+
+    def run(self, analysis_dir: Path, **kwargs: object) -> Path:
+        if shutil.which(_CLAUDE_BINARY) is None:
+            raise LauncherUnavailableError(launcher="claude-code", hint=_INSTALL_HINT)
+        timeout_arg = kwargs.get("timeout", 1800)
+        if not isinstance(timeout_arg, int | float):
+            raise TypeError(f"timeout must be int or float, got {type(timeout_arg).__name__}")
+        timeout = int(timeout_arg)
+        prompt_arg = f"@{analysis_dir / 'PROMPT.md'}"
+        cmd = [
+            _CLAUDE_BINARY,
+            "-p",
+            prompt_arg,
+            "--permission-mode",
+            "acceptEdits",
+        ]
+        logger.info("Invoking claude-code launcher in %s", analysis_dir)
+        try:
+            subprocess.run(cmd, cwd=analysis_dir, check=True, timeout=timeout)
+        except subprocess.CalledProcessError as exc:
+            raise LauncherExecutionError("claude-code", exc) from exc
+        return analysis_dir / "REPORT.md"
+
+
+register_launcher("claude-code", ClaudeCodeLauncher)

--- a/src/karenina/benchmark/error_analysis/launchers/prepare_only.py
+++ b/src/karenina/benchmark/error_analysis/launchers/prepare_only.py
@@ -1,0 +1,25 @@
+"""The default launcher: materialize only; do not invoke any agent.
+
+Useful for workflows where the user runs their own agent (Claude Code,
+Codex, etc.) against the prepared directory by hand.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from karenina.benchmark.error_analysis.exceptions import LauncherNoOutputError
+
+logger = logging.getLogger(__name__)
+
+
+class PrepareOnlyLauncher:
+    """No-op launcher that verifies REPORT.md exists after the fact."""
+
+    def run(self, analysis_dir: Path, **_: object) -> Path:
+        report = analysis_dir / "REPORT.md"
+        if not report.exists():
+            raise LauncherNoOutputError(analysis_dir)
+        logger.info("prepare-only launcher: REPORT.md already present at %s", report)
+        return report

--- a/src/karenina/benchmark/error_analysis/materializer.py
+++ b/src/karenina/benchmark/error_analysis/materializer.py
@@ -1,0 +1,126 @@
+"""Materialize a VerificationResultSet + Benchmark into an analysis directory.
+
+This module owns: the partition over results vs scenario_results, filename
+sanitization and collision handling, benchmark artifact writing, the
+force/REPORT.previous.md rules, and the INDEX.md assembly (via indexer).
+Per-case rendering is delegated to case_renderer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from typing import Any
+
+from karenina.benchmark.error_analysis.exceptions import MaterializationError
+from karenina.schemas.results.verification_result_set import VerificationResultSet
+from karenina.schemas.scenario.state import ScenarioExecutionResult
+from karenina.schemas.verification.result import VerificationResult
+from karenina.schemas.verification.result_components import VerificationResultMetadata
+
+logger = logging.getLogger(__name__)
+
+_ID_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def sanitize_id(raw: str) -> str:
+    """Replace any character that is not alphanumeric, underscore, or dash with an underscore.
+
+    Args:
+        raw: Original identifier (question_id, scenario_id, etc.).
+
+    Returns:
+        Sanitized identifier safe for use as a filename component.
+    """
+    return _ID_SANITIZE_RE.sub("_", raw)
+
+
+def _hash_suffix(result_id: str) -> str:
+    """Compute an 8-char SHA-1 suffix for collision disambiguation."""
+    return hashlib.sha1(result_id.encode("utf-8")).hexdigest()[:8]
+
+
+def case_filename(
+    *,
+    metadata: VerificationResultMetadata | None = None,
+    scenario: ScenarioExecutionResult | None = None,
+    monotonic_n: int = 1,
+    existing: set[str] | None = None,
+) -> str:
+    """Generate the on-disk filename for a QA or scenario case.
+
+    QA cases use ``q_{question_id}[__rep_{N}].md``. Scenario cases use
+    ``scenario_{scenario_id}__run_{N}.md`` where N is the scenario's
+    ``replicate`` if present or a monotonic counter otherwise. On
+    collision with ``existing``, append an 8-char SHA-1 suffix derived
+    from the result_id (QA) or ``scenario_id:monotonic_n`` (scenario).
+
+    Args:
+        metadata: VerificationResultMetadata for a QA case. Mutually
+            exclusive with ``scenario``.
+        scenario: ScenarioExecutionResult for a scenario case.
+        monotonic_n: Fallback scenario run number when
+            ``scenario.replicate`` is None.
+        existing: Set of filenames already assigned in the current
+            analysis directory; triggers the SHA-1 suffix on match.
+
+    Returns:
+        The filename (basename only, no directory component).
+    """
+    existing = existing or set()
+    if scenario is not None:
+        raw_id = sanitize_id(scenario.scenario_id)
+        n = scenario.replicate if scenario.replicate is not None else monotonic_n
+        base = f"scenario_{raw_id}__run_{n}.md"
+    else:
+        assert metadata is not None, "case_filename requires metadata or scenario"
+        raw_id = sanitize_id(metadata.question_id)
+        base = f"q_{raw_id}"
+        if metadata.replicate is not None:
+            base = f"{base}__rep_{metadata.replicate}"
+        base = f"{base}.md"
+
+    if base not in existing:
+        return base
+    # Collision: append an 8-char SHA-1 suffix of the result_id.
+    if metadata is not None:
+        suffix = _hash_suffix(metadata.result_id)
+    else:
+        # Scenario collision: use scenario_id + run number.
+        assert scenario is not None
+        suffix = _hash_suffix(f"{scenario.scenario_id}:{monotonic_n}")
+    stem, _, _ = base.rpartition(".md")
+    return f"{stem}__h{suffix}.md"
+
+
+def partition_results(
+    result_set: VerificationResultSet,
+) -> tuple[list[VerificationResult], list[ScenarioExecutionResult]]:
+    """Split VerificationResultSet into classical QA results and scenario runs.
+
+    Classical QA results are those whose ``metadata.scenario_id`` is None.
+    Scenario runs come directly from ``result_set.scenario_results``.
+
+    Args:
+        result_set: The aggregated result set to partition.
+
+    Returns:
+        A 2-tuple ``(classical, scenarios)``.
+
+    Raises:
+        MaterializationError: If any result carries ``scenario_id`` but
+            ``scenario_results`` is None (legacy result set; the
+            aggregated per-scenario view is required for rendering).
+    """
+    scenario_aware = [r for r in result_set.results if r.metadata.scenario_id is not None]
+    if scenario_aware and not result_set.scenario_results:
+        raise MaterializationError(
+            "Result set carries scenario turns but no aggregated scenario_results; "
+            "this usually means the run was produced by an older pipeline version. "
+            "Re-run the benchmark to produce a result set with scenario_results populated.",
+            details={"scenario_turn_count": len(scenario_aware)},
+        )
+    classical = [r for r in result_set.results if r.metadata.scenario_id is None]
+    scenarios: list[Any] = list(result_set.scenario_results or [])
+    return classical, scenarios

--- a/src/karenina/benchmark/error_analysis/materializer.py
+++ b/src/karenina/benchmark/error_analysis/materializer.py
@@ -68,13 +68,18 @@ def case_filename(
     Returns:
         The filename (basename only, no directory component).
     """
+    if scenario is None and metadata is None:
+        raise ValueError("case_filename requires either metadata or scenario")
     existing = existing or set()
     if scenario is not None:
         raw_id = sanitize_id(scenario.scenario_id)
         n = scenario.replicate if scenario.replicate is not None else monotonic_n
         base = f"scenario_{raw_id}__run_{n}.md"
     else:
-        assert metadata is not None, "case_filename requires metadata or scenario"
+        # metadata is guaranteed non-None here by the guard at the top;
+        # the `assert` is for the type checker only (runtime safety is
+        # provided by the ValueError above, which survives python -O).
+        assert metadata is not None
         raw_id = sanitize_id(metadata.question_id)
         base = f"q_{raw_id}"
         if metadata.replicate is not None:
@@ -91,7 +96,13 @@ def case_filename(
         assert scenario is not None
         suffix = _hash_suffix(f"{scenario.scenario_id}:{monotonic_n}")
     stem, _, _ = base.rpartition(".md")
-    return f"{stem}__h{suffix}.md"
+    hashed = f"{stem}__h{suffix}.md"
+    if hashed in existing:
+        raise MaterializationError(
+            "Filename collision after SHA-1 disambiguation.",
+            details={"base": base, "hashed": hashed},
+        )
+    return hashed
 
 
 def partition_results(

--- a/src/karenina/benchmark/error_analysis/materializer.py
+++ b/src/karenina/benchmark/error_analysis/materializer.py
@@ -9,11 +9,20 @@ Per-case rendering is delegated to case_renderer.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import re
+import shutil
+from collections import defaultdict
+from pathlib import Path
 from typing import Any
 
+from karenina.benchmark.error_analysis.case_renderer import (
+    render_qa_case,
+    render_scenario_case,
+)
 from karenina.benchmark.error_analysis.exceptions import MaterializationError
+from karenina.benchmark.error_analysis.indexer import IndexEntry, build_index_markdown
 from karenina.schemas.results.verification_result_set import VerificationResultSet
 from karenina.schemas.scenario.state import ScenarioExecutionResult
 from karenina.schemas.verification.result import VerificationResult
@@ -22,6 +31,15 @@ from karenina.schemas.verification.result_components import VerificationResultMe
 logger = logging.getLogger(__name__)
 
 _ID_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9_-]")
+
+BENCHMARK_DIRNAME = "benchmark"
+TEMPLATES_DIRNAME = "templates"
+PASSES_DIRNAME = "passes"
+FAILURES_DIRNAME = "failures"
+CASE_ASSETS_DIRNAME = "case_assets"
+QUESTIONS_FILENAME = "questions.jsonl"
+RUBRIC_FILENAME = "rubric.json"
+BENCHMARK_METADATA_FILENAME = "metadata.md"
 
 
 def sanitize_id(raw: str) -> str:
@@ -135,3 +153,290 @@ def partition_results(
     classical = [r for r in result_set.results if r.metadata.scenario_id is None]
     scenarios: list[Any] = list(result_set.scenario_results or [])
     return classical, scenarios
+
+
+class ErrorAnalysisMaterializer:
+    """Orchestrator that turns a VerificationResultSet + Benchmark into a navigable directory.
+
+    The materializer writes the full analysis tree (benchmark artifacts,
+    per-case markdown files bucketed by outcome/category, and INDEX.md).
+    It does not launch the analyst agent; that is the facade's job in
+    Task 10.
+
+    Attributes:
+        max_trace_chars: Optional override of the trace truncation
+            threshold applied to every rendered case. When None, the
+            case renderer consults the env var
+            ``KARENINA_TRACE_TRUNCATION_THRESHOLD`` or its module default.
+    """
+
+    def __init__(self, *, max_trace_chars: int | None = None) -> None:
+        self.max_trace_chars = max_trace_chars
+
+    def build(
+        self,
+        result_set: VerificationResultSet,
+        checkpoint: Any,
+        out_dir: Path,
+        *,
+        force: bool = False,
+    ) -> Path:
+        """Materialize the full analysis directory for a verification run.
+
+        Args:
+            result_set: The aggregated results to render.
+            checkpoint: Benchmark-like object exposing ``name``,
+                ``questions``, ``get_question``, ``get_template_source``,
+                and ``rubric``.
+            out_dir: Destination directory. Created if missing. See
+                ``_prepare_out_dir`` for the force/overwrite rules.
+            force: If True, overwrite the existing directory, preserving
+                any prior ``REPORT.md`` as ``REPORT.previous.md``.
+
+        Returns:
+            The resolved ``out_dir`` path.
+        """
+        self._prepare_out_dir(out_dir, force=force)
+        self._checkpoint_name = checkpoint.name
+        classical, scenarios = partition_results(result_set)
+        self._write_benchmark_artifacts(checkpoint, result_set, out_dir)
+
+        entries: list[IndexEntry] = []
+        used_by_bucket: dict[Path, set[str]] = defaultdict(set)
+
+        for result in classical:
+            entries.append(self._materialize_qa(result, checkpoint, out_dir, used_by_bucket))
+
+        monotonic_by_scenario: dict[str, int] = defaultdict(int)
+        for scenario in scenarios:
+            monotonic_by_scenario[scenario.scenario_id] += 1
+            entries.append(
+                self._materialize_scenario(
+                    scenario,
+                    checkpoint,
+                    out_dir,
+                    used_by_bucket,
+                    monotonic_n=monotonic_by_scenario[scenario.scenario_id],
+                )
+            )
+
+        self._write_index(result_set, out_dir, entries)
+        # PROMPT.md is written by the facade (Task 10), not the
+        # materializer, so it can accept a user-supplied prompt_path.
+        return out_dir
+
+    def _prepare_out_dir(self, out_dir: Path, *, force: bool) -> None:
+        """Clear ``out_dir`` per the overwrite rules.
+
+        If ``out_dir`` is non-empty and ``force`` is False, raises
+        MaterializationError. Otherwise preserves any prior REPORT.md as
+        REPORT.previous.md and removes everything else.
+        """
+        if out_dir.exists() and any(out_dir.iterdir()):
+            if not force:
+                raise MaterializationError(
+                    f"Output directory {out_dir} is not empty; pass force=True to overwrite.",
+                    details={"out_dir": str(out_dir)},
+                )
+            prior_report = out_dir / "REPORT.md"
+            if prior_report.exists():
+                target = out_dir / "REPORT.previous.md"
+                if target.exists():
+                    target.unlink()
+                prior_report.rename(target)
+            for child in out_dir.iterdir():
+                if child.name == "REPORT.previous.md":
+                    continue
+                if child.is_dir():
+                    shutil.rmtree(child)
+                else:
+                    child.unlink()
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+    def _write_benchmark_artifacts(
+        self,
+        checkpoint: Any,
+        result_set: VerificationResultSet,
+        out_dir: Path,
+    ) -> None:
+        """Write questions.jsonl, rubric.json, metadata.md, and templates."""
+        bench_dir = out_dir / BENCHMARK_DIRNAME
+        bench_dir.mkdir(parents=True, exist_ok=True)
+        templates_dir = bench_dir / TEMPLATES_DIRNAME
+        templates_dir.mkdir(exist_ok=True)
+
+        # questions.jsonl
+        with (bench_dir / QUESTIONS_FILENAME).open("w", encoding="utf-8") as handle:
+            for question in checkpoint.questions:
+                record = {
+                    "id": question.id,
+                    "text": question.question,
+                    "keywords": list(question.keywords or []),
+                    "raw_answer": question.raw_answer,
+                }
+                handle.write(json.dumps(record, sort_keys=True, ensure_ascii=False) + "\n")
+                # Copy the template source for this question.
+                source = checkpoint.get_template_source(question.id)
+                if source is not None:
+                    (templates_dir / f"q_{sanitize_id(question.id)}.py").write_text(source, encoding="utf-8")
+
+        # rubric.json
+        rubric = checkpoint.rubric
+        rubric_dump = rubric.model_dump() if rubric is not None else {}
+        (bench_dir / RUBRIC_FILENAME).write_text(
+            json.dumps(rubric_dump, sort_keys=True, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        # metadata.md
+        answering = sorted({r.metadata.answering.display_string for r in result_set.results})
+        parsing = sorted({r.metadata.parsing.display_string for r in result_set.results})
+        lines = [
+            f"# Benchmark: {checkpoint.name}",
+            "",
+            "## Run",
+            "",
+            f"- Answering models: {', '.join(answering) if answering else '-'}",
+            f"- Parsing models: {', '.join(parsing) if parsing else '-'}",
+            "",
+        ]
+        (bench_dir / BENCHMARK_METADATA_FILENAME).write_text("\n".join(lines), encoding="utf-8")
+
+    def _materialize_qa(
+        self,
+        result: VerificationResult,
+        checkpoint: Any,
+        out_dir: Path,
+        used_by_bucket: dict[Path, set[str]],
+    ) -> IndexEntry:
+        """Render a single QA case and return the matching IndexEntry."""
+        failure = result.metadata.failure
+        bucket = out_dir / PASSES_DIRNAME if failure is None else out_dir / FAILURES_DIRNAME / failure.category.value
+        bucket.mkdir(parents=True, exist_ok=True)
+        filename = case_filename(metadata=result.metadata, existing=used_by_bucket[bucket])
+        used_by_bucket[bucket].add(filename)
+        case_path = bucket / filename
+
+        question = checkpoint.get_question(result.metadata.question_id)
+        template_source = checkpoint.get_template_source(result.metadata.question_id)
+        template_link: str | None = None
+        if question is not None:
+            template_link = f"../../{BENCHMARK_DIRNAME}/{TEMPLATES_DIRNAME}/q_{sanitize_id(question.id)}.py"
+
+        assets_dir = out_dir / CASE_ASSETS_DIRNAME / case_path.stem / "traces" / "artifacts"
+        body = render_qa_case(
+            result,
+            template_source=template_source,
+            template_link=template_link,
+            artifacts_dir=assets_dir,
+            max_trace_chars=self.max_trace_chars,
+        )
+        case_path.write_text(body, encoding="utf-8")
+
+        case_id = case_path.stem
+        rel = case_path.relative_to(out_dir).as_posix()
+        if failure is None:
+            return IndexEntry(
+                case_id=case_id,
+                bucket_path=rel,
+                outcome="pass",
+                category="",
+                group="",
+                stage="",
+                reason="",
+            )
+        return IndexEntry(
+            case_id=case_id,
+            bucket_path=rel,
+            outcome="failure",
+            category=failure.category.value,
+            group=failure.group.value,
+            stage=failure.stage,
+            reason=failure.reason or "",
+        )
+
+    def _materialize_scenario(
+        self,
+        scenario: Any,
+        checkpoint: Any,
+        out_dir: Path,
+        used_by_bucket: dict[Path, set[str]],
+        *,
+        monotonic_n: int,
+    ) -> IndexEntry:
+        """Render a scenario run, bucketing by the first failing turn's category."""
+        failing = next(
+            (r for r in scenario.turn_results if r.metadata.failure is not None),
+            None,
+        )
+        if failing is None:
+            bucket = out_dir / PASSES_DIRNAME
+            failure_category = ""
+            failure_group = ""
+            failure_stage = ""
+            failure_reason = ""
+            outcome = "pass"
+        else:
+            assert failing.metadata.failure is not None
+            bucket = out_dir / FAILURES_DIRNAME / failing.metadata.failure.category.value
+            failure_category = failing.metadata.failure.category.value
+            failure_group = failing.metadata.failure.group.value
+            failure_stage = failing.metadata.failure.stage
+            failure_reason = failing.metadata.failure.reason or ""
+            outcome = "failure"
+
+        bucket.mkdir(parents=True, exist_ok=True)
+        filename = case_filename(
+            scenario=scenario,
+            monotonic_n=monotonic_n,
+            existing=used_by_bucket[bucket],
+        )
+        used_by_bucket[bucket].add(filename)
+        case_path = bucket / filename
+
+        template_sources: dict[str, str | None] = {}
+        template_links: dict[str, str] = {}
+        for turn in scenario.turn_results:
+            qid = turn.metadata.question_id
+            template_sources[qid] = checkpoint.get_template_source(qid)
+            template_links[qid] = f"../../{BENCHMARK_DIRNAME}/{TEMPLATES_DIRNAME}/q_{sanitize_id(qid)}.py"
+
+        assets_dir = out_dir / CASE_ASSETS_DIRNAME / case_path.stem / "traces" / "artifacts"
+        body = render_scenario_case(
+            scenario,
+            template_sources=template_sources,
+            template_links=template_links,
+            artifacts_dir=assets_dir,
+            max_trace_chars=self.max_trace_chars,
+            monotonic_n=monotonic_n,
+        )
+        case_path.write_text(body, encoding="utf-8")
+
+        return IndexEntry(
+            case_id=case_path.stem,
+            bucket_path=case_path.relative_to(out_dir).as_posix(),
+            outcome=outcome,
+            category=failure_category,
+            group=failure_group,
+            stage=failure_stage,
+            reason=failure_reason,
+        )
+
+    def _write_index(
+        self,
+        result_set: VerificationResultSet,
+        out_dir: Path,
+        entries: list[IndexEntry],
+    ) -> None:
+        """Compose and write INDEX.md from the entries collected during build."""
+        answering = sorted({r.metadata.answering.display_string for r in result_set.results})
+        answering_model = ", ".join(answering) if answering else "-"
+        timestamp = sorted({r.metadata.timestamp for r in result_set.results})[-1] if result_set.results else ""
+        benchmark_name = getattr(self, "_checkpoint_name", "(unknown)")
+        index_md = build_index_markdown(
+            benchmark_name=benchmark_name,
+            answering_model=answering_model,
+            run_timestamp=timestamp,
+            entries=entries,
+        )
+        (out_dir / "INDEX.md").write_text(index_md, encoding="utf-8")

--- a/src/karenina/benchmark/error_analysis/materializer.py
+++ b/src/karenina/benchmark/error_analysis/materializer.py
@@ -195,9 +195,16 @@ class ErrorAnalysisMaterializer:
 
         Returns:
             The resolved ``out_dir`` path.
+
+        Raises:
+            MaterializationError: If ``out_dir`` is non-empty and
+                ``force`` is False (refusing to overwrite), or if the
+                result set carries scenario turns without the aggregated
+                ``scenario_results`` view (raised by
+                ``partition_results``), or if filename collisions cannot
+                be disambiguated even with an 8-char SHA-1 suffix.
         """
         self._prepare_out_dir(out_dir, force=force)
-        self._checkpoint_name = checkpoint.name
         classical, scenarios = partition_results(result_set)
         self._write_benchmark_artifacts(checkpoint, result_set, out_dir)
 
@@ -220,7 +227,7 @@ class ErrorAnalysisMaterializer:
                 )
             )
 
-        self._write_index(result_set, out_dir, entries)
+        self._write_index(result_set, out_dir, entries, benchmark_name=checkpoint.name)
         # PROMPT.md is written by the facade (Task 10), not the
         # materializer, so it can accept a user-supplied prompt_path.
         return out_dir
@@ -228,9 +235,31 @@ class ErrorAnalysisMaterializer:
     def _prepare_out_dir(self, out_dir: Path, *, force: bool) -> None:
         """Clear ``out_dir`` per the overwrite rules.
 
-        If ``out_dir`` is non-empty and ``force`` is False, raises
-        MaterializationError. Otherwise preserves any prior REPORT.md as
-        REPORT.previous.md and removes everything else.
+        The contract has three steps when ``out_dir`` exists and is
+        non-empty:
+
+        1. Refuse: if ``force`` is False, raise ``MaterializationError``
+           without modifying the directory.
+        2. Preserve the prior report: if ``force`` is True and a
+           ``REPORT.md`` exists at the top level, rename it to
+           ``REPORT.previous.md``, overwriting any prior
+           ``REPORT.previous.md`` already present.
+        3. Wipe the rest: remove every other top-level entry
+           (files and subdirectories), keeping only the renamed
+           ``REPORT.previous.md``.
+
+        When ``out_dir`` does not exist or is empty, the function simply
+        ensures the directory exists (``mkdir(parents=True,
+        exist_ok=True)``) and returns.
+
+        Args:
+            out_dir: Destination directory to prepare.
+            force: If True, permit overwriting a non-empty directory
+                following the preserve-and-wipe contract above.
+
+        Raises:
+            MaterializationError: If ``out_dir`` is non-empty and
+                ``force`` is False.
         """
         if out_dir.exists() and any(out_dir.iterdir()):
             if not force:
@@ -427,12 +456,13 @@ class ErrorAnalysisMaterializer:
         result_set: VerificationResultSet,
         out_dir: Path,
         entries: list[IndexEntry],
+        *,
+        benchmark_name: str,
     ) -> None:
         """Compose and write INDEX.md from the entries collected during build."""
         answering = sorted({r.metadata.answering.display_string for r in result_set.results})
         answering_model = ", ".join(answering) if answering else "-"
         timestamp = sorted({r.metadata.timestamp for r in result_set.results})[-1] if result_set.results else ""
-        benchmark_name = getattr(self, "_checkpoint_name", "(unknown)")
         index_md = build_index_markdown(
             benchmark_name=benchmark_name,
             answering_model=answering_model,

--- a/src/karenina/benchmark/error_analysis/prompt_io.py
+++ b/src/karenina/benchmark/error_analysis/prompt_io.py
@@ -1,0 +1,86 @@
+"""Resolve and write PROMPT.md for an analysis directory.
+
+Resolution order:
+  1. User-supplied prompt_path, if provided.
+  2. Packaged default_prompt.md loaded via importlib.resources.
+
+Placeholders are substituted via string.Template before writing.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from string import Template
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PROMPT_PACKAGE = "karenina.benchmark.error_analysis.prompts"
+_DEFAULT_PROMPT_FILENAME = "default_prompt.md"
+
+
+@dataclass(frozen=True)
+class PromptContext:
+    """Values substituted into the analyst prompt before it is written.
+
+    Attributes:
+        benchmark_name: Human-readable benchmark identifier.
+        answering_model: Model identifier used to produce responses under test.
+        total: Total number of verification results.
+        passed: Number of passing results.
+        failed: Number of failing results.
+        failure_categories: Ordered list of failure categories observed.
+    """
+
+    benchmark_name: str
+    answering_model: str
+    total: int
+    passed: int
+    failed: int
+    failure_categories: list[str]
+
+    def as_mapping(self) -> dict[str, str]:
+        """Return the string mapping used by string.Template.safe_substitute."""
+        return {
+            "BENCHMARK_NAME": self.benchmark_name,
+            "ANSWERING_MODEL": self.answering_model,
+            "TOTAL": str(self.total),
+            "PASSED": str(self.passed),
+            "FAILED": str(self.failed),
+            "FAILURE_CATEGORIES": ", ".join(self.failure_categories),
+        }
+
+
+def _load_default_prompt() -> str:
+    return resources.files(_DEFAULT_PROMPT_PACKAGE).joinpath(_DEFAULT_PROMPT_FILENAME).read_text(encoding="utf-8")
+
+
+def resolve_and_write_prompt(
+    *,
+    prompt_path: Path | None,
+    out_dir: Path,
+    context: PromptContext,
+) -> Path:
+    """Write PROMPT.md under out_dir and return its path.
+
+    Substitutes placeholders via string.Template. If the source prompt
+    contains no placeholders, the substitute call is still safe (Template
+    leaves non-identifier $-sequences alone thanks to safe_substitute).
+
+    Args:
+        prompt_path: Optional user-supplied prompt file. If None, the
+            packaged default is used.
+        out_dir: Directory into which PROMPT.md is written.
+        context: Values substituted into the prompt.
+
+    Returns:
+        The path to the written PROMPT.md.
+    """
+    source_text = prompt_path.read_text(encoding="utf-8") if prompt_path else _load_default_prompt()
+    rendered = Template(source_text).safe_substitute(context.as_mapping())
+    target = out_dir / "PROMPT.md"
+    target.write_text(rendered, encoding="utf-8")
+    logger.debug("Wrote PROMPT.md to %s", target)
+    return target

--- a/src/karenina/benchmark/error_analysis/prompts/__init__.py
+++ b/src/karenina/benchmark/error_analysis/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged prompts for error analysis. Loaded via importlib.resources."""

--- a/src/karenina/benchmark/error_analysis/prompts/default_prompt.md
+++ b/src/karenina/benchmark/error_analysis/prompts/default_prompt.md
@@ -1,0 +1,20 @@
+You are an error analyst for the karenina evaluation benchmark "$BENCHMARK_NAME".
+
+A run of $TOTAL tests against $ANSWERING_MODEL produced $PASSED passes and $FAILED failures.
+Failure categories present: $FAILURE_CATEGORIES.
+
+Your job:
+  1. Read INDEX.md to understand the run and the directory layout.
+  2. Read the passes/ and failures/<category>/ files that look representative.
+  3. Identify recurring patterns in failures (prompt brittleness, template bugs,
+     hallucination types, tool-use errors, scenario branch issues).
+  4. For each pattern: cite specific case IDs as evidence and propose a concrete fix
+     (template change, prompt change, rubric tweak, or benchmark correction).
+  5. Write your findings to REPORT.md at the root of this directory.
+
+Constraints:
+  - Do not modify files outside this directory.
+  - Cite cases by ID (for example "q_007" or "scenario_auth_flow__run_03").
+  - Distinguish model-side failures (model got it wrong) from benchmark-side
+    issues (template, rubric, or ground-truth is the real problem).
+  - Be concrete: if you suggest a fix, name the file.

--- a/src/karenina/cli/__init__.py
+++ b/src/karenina/cli/__init__.py
@@ -104,8 +104,8 @@ try:
     from .analyze_errors import analyze_errors as _analyze_errors_cmd
 
     app.command(name="analyze-errors")(_analyze_errors_cmd)
-except ImportError as e:  # pragma: no cover - optional dependency guard
-    logger.warning("analyze-errors command unavailable: %s", e)
+except ImportError as e:  # pragma: no cover: defensive guard only
+    logger.debug("analyze-errors command unavailable: %s", e)
 
 
 def main() -> None:

--- a/src/karenina/cli/__init__.py
+++ b/src/karenina/cli/__init__.py
@@ -100,6 +100,13 @@ except ImportError as e:
     # GEPA not installed
     logger.debug("optimize-compare command unavailable: %s", e)
 
+try:
+    from .analyze_errors import analyze_errors as _analyze_errors_cmd
+
+    app.command(name="analyze-errors")(_analyze_errors_cmd)
+except ImportError as e:  # pragma: no cover - optional dependency guard
+    logger.warning("analyze-errors command unavailable: %s", e)
+
 
 def main() -> None:
     """Main entry point for the CLI."""

--- a/src/karenina/cli/analyze_errors.py
+++ b/src/karenina/cli/analyze_errors.py
@@ -1,0 +1,66 @@
+"""`karenina analyze-errors` CLI command."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import typer
+
+from karenina.benchmark.error_analysis import analyze_errors as _analyze_errors
+from karenina.benchmark.error_analysis.exceptions import (
+    ErrorAnalysisError,
+    LauncherExecutionError,
+    LauncherNoOutputError,
+    LauncherNotFoundError,
+    LauncherUnavailableError,
+    MaterializationError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def analyze_errors(
+    results: Path = typer.Option(..., "--results", help="Path to VerificationResultSet JSON export"),
+    checkpoint: Path = typer.Option(..., "--checkpoint", help="Path to benchmark JSON-LD file"),
+    out_dir: Path = typer.Option(..., "--out-dir", help="Directory to create or overwrite"),
+    prompt: Path | None = typer.Option(None, "--prompt", help="Custom PROMPT.md source"),
+    launcher: str = typer.Option("prepare-only", "--launcher", help="Registered launcher name"),
+    max_trace_chars: int | None = typer.Option(
+        None, "--max-trace-chars", help="Override KARENINA_TRACE_TRUNCATION_THRESHOLD"
+    ),
+    timeout: int = typer.Option(1800, "--timeout", help="Launcher timeout in seconds"),
+    force: bool = typer.Option(False, "--force", help="Allow writing into a non-empty out-dir"),
+) -> None:
+    """Materialize a verification run and optionally run an error-analyst agent."""
+    try:
+        report_path = _analyze_errors(
+            results=results,
+            checkpoint=checkpoint,
+            out_dir=out_dir,
+            prompt_path=prompt,
+            launcher=launcher,
+            launcher_kwargs={"timeout": timeout},
+            max_trace_chars=max_trace_chars,
+            force=force,
+        )
+    except MaterializationError as exc:
+        typer.echo(f"Materialization failed: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    except LauncherNotFoundError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=2) from exc
+    except LauncherUnavailableError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=2) from exc
+    except LauncherExecutionError as exc:
+        typer.echo(f"Launcher subprocess failed: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+    except LauncherNoOutputError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=3) from exc
+    except ErrorAnalysisError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(str(report_path.resolve()))

--- a/src/karenina/exceptions.py
+++ b/src/karenina/exceptions.py
@@ -23,11 +23,17 @@ Exception hierarchy::
     ├── StreamingTimeoutError        # LLM streaming timeout (also inherits TimeoutError)
     ├── VerificationBatchError       # Partial-failure batch verification errors
     ├── BenchmarkConversionError     # Benchmark conversion errors
-    └── ReplayError                  # Replay layer errors (see replay/exceptions.py)
-        ├── ReplayMissError
-        ├── ReplayHydrationError
-        ├── ReplayPersistenceError
-        └── ProjectionError
+    ├── ReplayError                  # Replay layer errors (see replay/exceptions.py)
+    │   ├── ReplayMissError
+    │   ├── ReplayHydrationError
+    │   ├── ReplayPersistenceError
+    │   └── ProjectionError
+    └── ErrorAnalysisError           # Error-analysis errors (see benchmark/error_analysis/exceptions.py)
+        ├── MaterializationError
+        ├── LauncherNotFoundError
+        ├── LauncherUnavailableError
+        ├── LauncherExecutionError
+        └── LauncherNoOutputError
 
 Domain-specific modules (ports/errors.py, adapters/manual/exceptions.py, etc.)
 remain the canonical definition sites for their respective exceptions. This module
@@ -133,6 +139,17 @@ class VerificationBatchError(KareninaError):
         self.partial_results = partial_results
         self.errors = errors
 
+
+# Re-export error-analysis exceptions for convenience. The canonical
+# definition lives in karenina.benchmark.error_analysis.exceptions.
+from karenina.benchmark.error_analysis.exceptions import (  # noqa: E402, F401
+    ErrorAnalysisError,
+    LauncherExecutionError,
+    LauncherNoOutputError,
+    LauncherNotFoundError,
+    LauncherUnavailableError,
+    MaterializationError,
+)
 
 # Re-export replay layer exceptions for convenience. The canonical
 # definition lives in karenina.replay.exceptions.

--- a/tests/unit/benchmark/error_analysis/__init__.py
+++ b/tests/unit/benchmark/error_analysis/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the error-analysis feature."""

--- a/tests/unit/benchmark/error_analysis/fixtures.py
+++ b/tests/unit/benchmark/error_analysis/fixtures.py
@@ -1,0 +1,115 @@
+"""Fixture builders that stamp out VerificationResult instances.
+
+These are hand-constructed results used by materializer, renderer, and
+indexer unit tests. The materializer is a pure renderer; capturing its
+inputs from a live pipeline run adds no fidelity and cannot reach
+failure categories like RATE_LIMIT or TRACE_VALIDATION.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from karenina.schemas.results.failure import Failure, FailureCategory
+from karenina.schemas.verification.model_identity import ModelIdentity
+from karenina.schemas.verification.result import VerificationResult
+from karenina.schemas.verification.result_components import (
+    VerificationResultMetadata,
+    VerificationResultRubric,
+    VerificationResultTemplate,
+)
+
+
+def _model_identity(display: str = "anthropic/claude-opus-4-6") -> ModelIdentity:
+    interface, name = display.split("/", 1)
+    return ModelIdentity(interface=interface, model_name=name)
+
+
+def make_metadata(
+    *,
+    question_id: str = "q_test",
+    template_id: str = "template_test",
+    replicate: int | None = None,
+    failure: Failure | None = None,
+    scenario_id: str | None = None,
+    scenario_turn: int | None = None,
+    scenario_path: list[str] | None = None,
+    scenario_node: str | None = None,
+    answering_display: str = "anthropic/claude-opus-4-6",
+    parsing_display: str = "anthropic/claude-sonnet-4-6",
+) -> VerificationResultMetadata:
+    answering = _model_identity(answering_display)
+    parsing = _model_identity(parsing_display)
+    timestamp = "2026-04-16T12:00:00Z"
+    result_id = VerificationResultMetadata.compute_result_id(
+        question_id=question_id,
+        answering=answering,
+        parsing=parsing,
+        timestamp=timestamp,
+        replicate=replicate,
+    )
+    return VerificationResultMetadata(
+        question_id=question_id,
+        template_id=template_id,
+        failure=failure,
+        question_text="What is 2+2?",
+        answering=answering,
+        parsing=parsing,
+        execution_time=0.1,
+        timestamp=timestamp,
+        result_id=result_id,
+        replicate=replicate,
+        scenario_id=scenario_id,
+        scenario_turn=scenario_turn,
+        scenario_path=scenario_path,
+        scenario_node=scenario_node,
+    )
+
+
+def make_template(
+    *,
+    raw_response: str = "4",
+    trace_messages: list[dict[str, Any]] | None = None,
+    verify_result: bool | None = True,
+    field_results: dict[str, bool] | None = None,
+) -> VerificationResultTemplate:
+    return VerificationResultTemplate(
+        raw_llm_response=raw_response,
+        trace_messages=trace_messages or [],
+        verify_result=verify_result,
+        field_results=field_results,
+        template_verification_performed=True,
+    )
+
+
+def make_pass(*, question_id: str = "q_pass", replicate: int | None = None) -> VerificationResult:
+    return VerificationResult(
+        metadata=make_metadata(question_id=question_id, replicate=replicate, failure=None),
+        template=make_template(verify_result=True),
+        rubric=VerificationResultRubric(),
+    )
+
+
+def make_failure(
+    *,
+    question_id: str = "q_fail",
+    category: FailureCategory = FailureCategory.CONTENT,
+    stage: str = "verify_template",
+    reason: str = "mismatch",
+    replicate: int | None = None,
+    trace_messages: list[dict[str, Any]] | None = None,
+) -> VerificationResult:
+    # Failure.group is a computed field derived from category via
+    # CATEGORY_TO_GROUP; never pass group= to the Failure constructor.
+    return VerificationResult(
+        metadata=make_metadata(
+            question_id=question_id,
+            replicate=replicate,
+            failure=Failure(category=category, stage=stage, reason=reason),
+        ),
+        template=make_template(
+            verify_result=False if category == FailureCategory.CONTENT else None,
+            trace_messages=trace_messages or [],
+        ),
+        rubric=VerificationResultRubric(),
+    )

--- a/tests/unit/benchmark/error_analysis/test_case_renderer_frontmatter.py
+++ b/tests/unit/benchmark/error_analysis/test_case_renderer_frontmatter.py
@@ -1,0 +1,86 @@
+"""Tests for the YAML frontmatter emitted by case_renderer."""
+
+from __future__ import annotations
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+
+from karenina.benchmark.error_analysis.case_renderer import render_qa_case
+from karenina.schemas.results.failure import FailureCategory
+
+from .fixtures import make_failure, make_pass
+
+
+def _split_frontmatter(body: str) -> tuple[dict, str]:
+    assert body.startswith("---\n"), f"Missing frontmatter prefix: {body[:40]!r}"
+    _, fm, rest = body.split("---\n", 2)
+    return yaml.safe_load(fm), rest
+
+
+@pytest.mark.unit
+class TestQaCaseFrontmatter:
+    def test_pass_frontmatter_keys(self):
+        result = make_pass(question_id="q_001", replicate=1)
+        body = render_qa_case(result, template_source=None, artifacts_dir=None)
+        fm, _ = _split_frontmatter(body)
+        assert fm["id"] == "q_q_001__rep_1"
+        assert fm["outcome"] == "pass"
+        assert fm["question_id"] == "q_001"
+        assert fm["replicate"] == 1
+        assert fm["model"] == "anthropic:claude-opus-4-6"
+        assert fm["parsing_model"] == "anthropic:claude-sonnet-4-6"
+        assert fm["category"] is None
+        assert fm["group"] is None
+        assert fm["stage"] is None
+
+    def test_failure_frontmatter_keys(self):
+        result = make_failure(
+            question_id="q_003",
+            category=FailureCategory.CONTENT,
+            stage="verify_template",
+            reason="price mismatch",
+        )
+        body = render_qa_case(result, template_source=None, artifacts_dir=None)
+        fm, _ = _split_frontmatter(body)
+        assert fm["outcome"] == "failure"
+        assert fm["category"] == "content"
+        assert fm["group"] == "content"
+        assert fm["stage"] == "verify_template"
+        assert fm["replicate"] is None
+
+    def test_failure_section_present_only_for_failures(self):
+        pass_body = render_qa_case(make_pass(), template_source=None, artifacts_dir=None)
+        fail_body = render_qa_case(
+            make_failure(reason="x"),
+            template_source=None,
+            artifacts_dir=None,
+        )
+        assert "# Failure" not in pass_body
+        assert "# Failure" in fail_body
+
+    def test_template_section_inline_under_100_lines(self):
+        short_template = "class Answer(BaseAnswer):\n    result: int\n"
+        body = render_qa_case(
+            make_pass(),
+            template_source=short_template,
+            template_link="../../benchmark/templates/q_pass.py",
+            artifacts_dir=None,
+        )
+        assert "```python" in body
+        assert "class Answer(BaseAnswer):" in body
+        assert "../../benchmark/templates/q_pass.py" in body
+
+    def test_template_section_excerpt_over_100_lines(self):
+        long_template = "\n".join(f"line_{i} = {i}" for i in range(150))
+        body = render_qa_case(
+            make_pass(),
+            template_source=long_template,
+            template_link="../../benchmark/templates/q_pass.py",
+            artifacts_dir=None,
+        )
+        # Only 20 lines of the source appear in the body
+        assert body.count("\nline_") == 20
+        # The full 150-line source is NOT inlined.
+        assert "line_149 = 149" not in body
+        # The link is still there.
+        assert "../../benchmark/templates/q_pass.py" in body

--- a/tests/unit/benchmark/error_analysis/test_case_renderer_scenario.py
+++ b/tests/unit/benchmark/error_analysis/test_case_renderer_scenario.py
@@ -1,0 +1,116 @@
+"""Tests for scenario case rendering."""
+
+from __future__ import annotations
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+
+from karenina.benchmark.error_analysis.case_renderer import render_scenario_case
+from karenina.schemas.results.failure import FailureCategory
+from karenina.schemas.scenario.state import ScenarioExecutionResult, ScenarioState
+
+from .fixtures import make_failure, make_metadata, make_pass
+
+
+def _split_frontmatter(body: str) -> tuple[dict, str]:
+    assert body.startswith("---\n")
+    _, fm, rest = body.split("---\n", 2)
+    return yaml.safe_load(fm), rest
+
+
+def _empty_state(current: str = "done") -> ScenarioState:
+    return ScenarioState(
+        turn=0,
+        current_node=current,
+        verify_result=None,
+        parsed={},
+        node_visits={},
+        history=[],
+        accumulated={},
+        node_results={},
+    )
+
+
+def _scenario_turn(question_id: str, turn: int, path: list[str], failing: bool = False):
+    if failing:
+        r = make_failure(
+            question_id=question_id,
+            category=FailureCategory.CONTENT,
+            stage="verify_template",
+            reason="wrong answer",
+        )
+    else:
+        r = make_pass(question_id=question_id)
+    # Attach scenario metadata.
+    r.metadata = make_metadata(
+        question_id=question_id,
+        scenario_id="auth_flow",
+        scenario_turn=turn,
+        scenario_node=path[turn - 1],
+        scenario_path=path,
+        failure=r.metadata.failure,
+    )
+    return r
+
+
+@pytest.mark.unit
+class TestScenarioRender:
+    def test_scenario_pass_frontmatter(self):
+        path = ["intro", "clarify", "verify"]
+        execution = ScenarioExecutionResult(
+            scenario_id="auth_flow",
+            status="completed",
+            path=path,
+            turn_count=3,
+            history=[],
+            turn_results=[_scenario_turn(f"q_turn_{i + 1}", i + 1, path) for i in range(3)],
+            final_state=_empty_state(path[-1]),
+            outcome_results={"completed": True},
+            replicate=1,
+        )
+        body = render_scenario_case(
+            execution,
+            template_sources={"q_turn_1": None, "q_turn_2": None, "q_turn_3": None},
+            template_links={},
+            artifacts_dir=None,
+        )
+        fm, rest = _split_frontmatter(body)
+        assert fm["outcome"] == "pass"
+        assert fm["path"] == path
+        assert fm["turn_count"] == 3
+        assert fm["failed_turn"] is None
+        assert fm["outcome_results"] == {"completed": True}
+        assert "## Turn 1" in rest
+        assert "## Turn 3" in rest
+
+    def test_scenario_first_failing_turn_marked(self):
+        path = ["intro", "act", "verify"]
+        turns = [
+            _scenario_turn("q_turn_1", 1, path),
+            _scenario_turn("q_turn_2", 2, path, failing=True),
+            _scenario_turn("q_turn_3", 3, path),
+        ]
+        execution = ScenarioExecutionResult(
+            scenario_id="auth_flow",
+            status="completed",
+            path=path,
+            turn_count=3,
+            history=[],
+            turn_results=turns,
+            final_state=_empty_state(path[-1]),
+            outcome_results={"completed": False},
+            replicate=None,
+        )
+        body = render_scenario_case(
+            execution,
+            template_sources={},
+            template_links={},
+            artifacts_dir=None,
+        )
+        fm, rest = _split_frontmatter(body)
+        assert fm["outcome"] == "failure"
+        assert fm["category"] == "content"
+        assert fm["group"] == "content"
+        assert fm["failed_turn"] == 2
+        assert "# Outcomes" in rest
+        assert "completed" in rest

--- a/tests/unit/benchmark/error_analysis/test_case_renderer_trace.py
+++ b/tests/unit/benchmark/error_analysis/test_case_renderer_trace.py
@@ -1,0 +1,66 @@
+"""Tests for the trace-conversion subsection of case_renderer."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.benchmark.error_analysis.case_renderer import render_qa_case
+
+from .fixtures import make_pass
+
+
+def _minimal_trace_message(role: str, text: str) -> dict:
+    # Matches the format produced by Message.to_dict() and consumed by
+    # Message.from_dict(): a flat dict whose ``content`` is a plain
+    # string. Anthropic-style content-block lists are intentionally not
+    # supported here (see ports/messages.py).
+    return {
+        "role": role,
+        "content": text,
+    }
+
+
+@pytest.mark.unit
+class TestCaseRendererTrace:
+    def test_no_trace_messages_emits_stub(self):
+        result = make_pass()
+        body = render_qa_case(result, template_source=None, artifacts_dir=None)
+        assert "# Trace" in body
+        assert "_No trace captured for this case._" in body
+
+    def test_trace_with_messages_emits_xml_turns(self, tmp_path):
+        result = make_pass()
+        result.template.trace_messages = [
+            _minimal_trace_message("user", "please answer 2+2"),
+            _minimal_trace_message("assistant", "4"),
+        ]
+        body = render_qa_case(
+            result,
+            template_source=None,
+            artifacts_dir=tmp_path / "artifacts",
+        )
+        assert "<turn" in body
+        assert "4" in body
+        assert "_No trace captured" not in body
+
+    def test_trace_offloads_long_messages(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KARENINA_TRACE_TRUNCATION_THRESHOLD", "50")
+        long_text = "X" * 500
+        result = make_pass()
+        result.template.trace_messages = [
+            _minimal_trace_message("user", "short prompt"),
+            _minimal_trace_message("assistant", long_text),
+        ]
+        body = render_qa_case(
+            result,
+            template_source=None,
+            artifacts_dir=tmp_path / "artifacts",
+        )
+        assert "[Content offloaded:" in body
+        assert 'offloaded="true"' in body
+        # Pointer names the offloaded file.
+        assert "text_" in body
+        # Artifact file actually exists.
+        artifacts = list((tmp_path / "artifacts").glob("text_*.txt"))
+        assert artifacts, "expected at least one offloaded artifact"
+        assert artifacts[0].read_text() == long_text

--- a/tests/unit/benchmark/error_analysis/test_exceptions.py
+++ b/tests/unit/benchmark/error_analysis/test_exceptions.py
@@ -1,0 +1,70 @@
+"""Tests for the error-analysis exception hierarchy."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from karenina.benchmark.error_analysis.exceptions import (
+    ErrorAnalysisError,
+    LauncherExecutionError,
+    LauncherNoOutputError,
+    LauncherNotFoundError,
+    LauncherUnavailableError,
+    MaterializationError,
+)
+from karenina.exceptions import KareninaError
+
+
+@pytest.mark.unit
+class TestErrorAnalysisExceptions:
+    def test_base_inherits_from_karenina_error(self):
+        assert issubclass(ErrorAnalysisError, KareninaError)
+
+    def test_all_leaves_inherit_from_base(self):
+        for cls in (
+            MaterializationError,
+            LauncherNotFoundError,
+            LauncherUnavailableError,
+            LauncherExecutionError,
+            LauncherNoOutputError,
+        ):
+            assert issubclass(cls, ErrorAnalysisError)
+
+    def test_launcher_not_found_includes_registered_names(self):
+        exc = LauncherNotFoundError("codex", registered=["prepare-only", "claude-code"])
+        assert "codex" in str(exc)
+        assert "prepare-only" in str(exc)
+        assert "claude-code" in str(exc)
+
+    def test_launcher_unavailable_includes_hint(self):
+        exc = LauncherUnavailableError(
+            launcher="claude-code",
+            hint="Install via https://docs.anthropic.com/claude/code",
+        )
+        assert "claude-code" in str(exc)
+        assert "https://docs.anthropic.com/claude/code" in str(exc)
+
+    def test_launcher_execution_error_preserves_returncode_and_stderr_tail(self):
+        called = subprocess.CalledProcessError(
+            returncode=42,
+            cmd=["claude", "-p", "@PROMPT.md"],
+            stderr=b"x" * 3000,
+        )
+        exc = LauncherExecutionError("claude-code", called)
+        assert exc.returncode == 42
+        # last 2048 bytes preserved
+        assert exc.stderr_tail == "x" * 2048
+        assert exc.__cause__ is None  # explicit chaining is caller's job; stash, don't chain by default
+
+    def test_launcher_no_output_error_mentions_report_path(self, tmp_path):
+        exc = LauncherNoOutputError(analysis_dir=tmp_path)
+        assert str(tmp_path / "REPORT.md") in str(exc)
+
+    def test_materialization_error_preserves_detail_map(self):
+        exc = MaterializationError(
+            "missing template for question q_foo",
+            details={"question_id": "q_foo"},
+        )
+        assert exc.details == {"question_id": "q_foo"}

--- a/tests/unit/benchmark/error_analysis/test_facade.py
+++ b/tests/unit/benchmark/error_analysis/test_facade.py
@@ -1,0 +1,114 @@
+"""Tests for the analyze_errors facade."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from karenina.benchmark.error_analysis import analyze_errors
+from karenina.benchmark.error_analysis.exceptions import (
+    LauncherNoOutputError,
+    LauncherNotFoundError,
+)
+from karenina.schemas.entities.question import Question
+from karenina.schemas.results.failure import FailureCategory
+from karenina.schemas.results.verification_result_set import VerificationResultSet
+
+from .fixtures import make_failure, make_pass
+from .test_materializer_build import _StubBenchmark
+
+
+@pytest.fixture
+def tiny_benchmark():
+    q1 = Question(question="2+2?", raw_answer="4")
+    return _StubBenchmark(name="sample", questions=[q1])
+
+
+@pytest.fixture
+def tiny_result_set(tiny_benchmark):
+    (q1,) = tiny_benchmark.questions
+    passed = make_pass(question_id=q1.id)
+    failed = make_failure(
+        question_id=q1.id,
+        category=FailureCategory.CONTENT,
+        stage="verify_template",
+        reason="oops",
+    )
+    return VerificationResultSet(results=[passed, failed], scenario_results=None)
+
+
+class _RecordingLauncher:
+    def __init__(self):
+        self.seen: list[Path] = []
+
+    def run(self, analysis_dir: Path, **_):
+        self.seen.append(analysis_dir)
+        (analysis_dir / "REPORT.md").write_text("# Findings\nnothing to see here.")
+        return analysis_dir / "REPORT.md"
+
+
+@pytest.mark.unit
+class TestFacade:
+    def test_default_launcher_requires_user_to_produce_report(
+        self,
+        tmp_path,
+        tiny_benchmark,
+        tiny_result_set,
+    ):
+        with pytest.raises(LauncherNoOutputError):
+            analyze_errors(
+                results=tiny_result_set,
+                checkpoint=tiny_benchmark,
+                out_dir=tmp_path / "analysis",
+            )
+
+    def test_instance_launcher_is_used_verbatim(
+        self,
+        tmp_path,
+        tiny_benchmark,
+        tiny_result_set,
+    ):
+        launcher = _RecordingLauncher()
+        out = tmp_path / "analysis"
+        report_path = analyze_errors(
+            results=tiny_result_set,
+            checkpoint=tiny_benchmark,
+            out_dir=out,
+            launcher=launcher,
+        )
+        assert report_path == out / "REPORT.md"
+        assert launcher.seen == [out]
+        assert report_path.read_text().startswith("# Findings")
+
+    def test_unknown_named_launcher_raises(
+        self,
+        tmp_path,
+        tiny_benchmark,
+        tiny_result_set,
+    ):
+        with pytest.raises(LauncherNotFoundError):
+            analyze_errors(
+                results=tiny_result_set,
+                checkpoint=tiny_benchmark,
+                out_dir=tmp_path / "analysis",
+                launcher="no-such-launcher",
+            )
+
+    def test_prompt_md_written_with_substitutions(
+        self,
+        tmp_path,
+        tiny_benchmark,
+        tiny_result_set,
+    ):
+        launcher = _RecordingLauncher()
+        out = tmp_path / "analysis"
+        analyze_errors(
+            results=tiny_result_set,
+            checkpoint=tiny_benchmark,
+            out_dir=out,
+            launcher=launcher,
+        )
+        prompt = (out / "PROMPT.md").read_text()
+        assert "sample" in prompt  # benchmark name
+        assert "anthropic:claude-opus-4-6" in prompt

--- a/tests/unit/benchmark/error_analysis/test_facade.py
+++ b/tests/unit/benchmark/error_analysis/test_facade.py
@@ -112,3 +112,71 @@ class TestFacade:
         prompt = (out / "PROMPT.md").read_text()
         assert "sample" in prompt  # benchmark name
         assert "anthropic:claude-opus-4-6" in prompt
+
+    def test_launcher_kwargs_forwarded(
+        self,
+        tmp_path,
+        tiny_benchmark,
+        tiny_result_set,
+    ):
+        """launcher_kwargs is passed verbatim to launcher.run()."""
+        captured: dict[str, object] = {}
+
+        class _CapturingLauncher:
+            def run(self, analysis_dir: Path, **kwargs: object) -> Path:
+                captured.update(kwargs)
+                (analysis_dir / "REPORT.md").write_text("ok")
+                return analysis_dir / "REPORT.md"
+
+        out = tmp_path / "analysis"
+        analyze_errors(
+            results=tiny_result_set,
+            checkpoint=tiny_benchmark,
+            out_dir=out,
+            launcher=_CapturingLauncher(),
+            launcher_kwargs={"extra": "payload", "count": 42},
+        )
+        assert captured == {"extra": "payload", "count": 42}
+
+    def test_custom_prompt_path_is_respected(
+        self,
+        tmp_path,
+        tiny_benchmark,
+        tiny_result_set,
+    ):
+        """A user-supplied prompt_path overrides the packaged default."""
+        custom_prompt = tmp_path / "my_prompt.md"
+        custom_prompt.write_text("CUSTOM ANALYST for $BENCHMARK_NAME")
+
+        out = tmp_path / "analysis"
+        analyze_errors(
+            results=tiny_result_set,
+            checkpoint=tiny_benchmark,
+            out_dir=out,
+            prompt_path=custom_prompt,
+            launcher=_RecordingLauncher(),
+        )
+        prompt = (out / "PROMPT.md").read_text()
+        assert prompt.startswith("CUSTOM ANALYST for")
+        assert "sample" in prompt  # benchmark_name placeholder substituted
+
+    def test_force_permits_non_empty_out_dir(
+        self,
+        tmp_path,
+        tiny_benchmark,
+        tiny_result_set,
+    ):
+        """force=True allows writing into a pre-populated out_dir."""
+        out = tmp_path / "analysis"
+        out.mkdir()
+        (out / "stale.txt").write_text("leftover")
+
+        analyze_errors(
+            results=tiny_result_set,
+            checkpoint=tiny_benchmark,
+            out_dir=out,
+            launcher=_RecordingLauncher(),
+            force=True,
+        )
+        assert (out / "REPORT.md").exists()
+        assert not (out / "stale.txt").exists()  # wiped by materializer

--- a/tests/unit/benchmark/error_analysis/test_indexer.py
+++ b/tests/unit/benchmark/error_analysis/test_indexer.py
@@ -1,0 +1,139 @@
+"""Tests for INDEX.md generation."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.benchmark.error_analysis.indexer import IndexEntry, build_index_markdown
+
+
+def _entry(
+    *,
+    case_id: str,
+    bucket_path: str,
+    category: str,
+    group: str,
+    stage: str,
+    reason: str,
+    outcome: str = "failure",
+) -> IndexEntry:
+    return IndexEntry(
+        case_id=case_id,
+        bucket_path=bucket_path,
+        outcome=outcome,
+        category=category,
+        group=group,
+        stage=stage,
+        reason=reason,
+    )
+
+
+@pytest.mark.unit
+class TestIndexBuilder:
+    def test_header_has_totals_and_percentage(self):
+        entries = [
+            _entry(
+                case_id="q_001",
+                bucket_path="passes/q_001.md",
+                category="",
+                group="",
+                stage="",
+                reason="",
+                outcome="pass",
+            ),
+            _entry(
+                case_id="q_002",
+                bucket_path="failures/content/q_002.md",
+                category="content",
+                group="content",
+                stage="verify_template",
+                reason="mismatch on price",
+            ),
+        ]
+        md = build_index_markdown(
+            benchmark_name="legal_qa",
+            answering_model="anthropic/claude-opus-4-6",
+            run_timestamp="2026-04-16T12:00:00Z",
+            entries=entries,
+        )
+        assert "# Error Analysis: legal_qa" in md
+        assert "anthropic/claude-opus-4-6" in md
+        assert "Total: 2" in md
+        assert "Passed: 1" in md
+        assert "Failed: 1" in md
+        assert "50" in md  # pass rate
+
+    def test_failure_breakdown_table_rows(self):
+        entries = [
+            _entry(
+                case_id="q_a",
+                bucket_path="failures/content/q_a.md",
+                category="content",
+                group="content",
+                stage="verify_template",
+                reason="r",
+            ),
+            _entry(
+                case_id="q_b",
+                bucket_path="failures/parsing/q_b.md",
+                category="parsing",
+                group="system",
+                stage="parse_template",
+                reason="r",
+            ),
+        ]
+        md = build_index_markdown(
+            benchmark_name="x",
+            answering_model="m",
+            run_timestamp="t",
+            entries=entries,
+        )
+        assert "| content | 1 |" in md or "| content  | 1 |" in md
+        assert "| parsing | 1 |" in md or "| parsing  | 1 |" in md
+
+    def test_failures_by_category_links(self):
+        entries = [
+            _entry(
+                case_id="q_a",
+                bucket_path="failures/content/q_a.md",
+                category="content",
+                group="content",
+                stage="verify_template",
+                reason="a" * 200,
+            ),
+        ]
+        md = build_index_markdown(
+            benchmark_name="x",
+            answering_model="m",
+            run_timestamp="t",
+            entries=entries,
+        )
+        assert "### content (1)" in md
+        assert "[q_a](failures/content/q_a.md)" in md
+        # One-line reason capped at 100 chars.
+        assert "a" * 100 in md
+        assert "a" * 101 not in md
+
+    def test_pass_table_caps_at_50(self):
+        entries = [
+            _entry(
+                case_id=f"q_{i}",
+                bucket_path=f"passes/q_{i}.md",
+                category="",
+                group="",
+                stage="",
+                reason="",
+                outcome="pass",
+            )
+            for i in range(60)
+        ]
+        md = build_index_markdown(
+            benchmark_name="x",
+            answering_model="m",
+            run_timestamp="t",
+            entries=entries,
+        )
+        lines = md.splitlines()
+        pass_rows = [line for line in lines if line.startswith("| q_")]
+        assert 50 <= len(pass_rows) <= 51  # 50 data rows + optional header variations
+        assert "10 more" in md

--- a/tests/unit/benchmark/error_analysis/test_launcher.py
+++ b/tests/unit/benchmark/error_analysis/test_launcher.py
@@ -1,0 +1,58 @@
+"""Tests for the launcher Protocol + registry and the prepare-only launcher."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.benchmark.error_analysis.exceptions import (
+    LauncherNoOutputError,
+    LauncherNotFoundError,
+)
+from karenina.benchmark.error_analysis.launcher import (
+    get_launcher,
+    list_launchers,
+    register_launcher,
+)
+from karenina.benchmark.error_analysis.launchers.prepare_only import PrepareOnlyLauncher
+
+
+@pytest.mark.unit
+class TestRegistry:
+    def test_prepare_only_always_registered(self):
+        assert "prepare-only" in list_launchers()
+
+    def test_get_launcher_returns_class(self):
+        cls = get_launcher("prepare-only")
+        assert cls is PrepareOnlyLauncher
+
+    def test_unknown_launcher_raises_with_registered_names(self):
+        with pytest.raises(LauncherNotFoundError) as exc_info:
+            get_launcher("no-such-launcher")
+        assert "prepare-only" in str(exc_info.value)
+
+    def test_register_launcher_persists(self):
+        class DummyLauncher:
+            def run(self, analysis_dir, **_):
+                return analysis_dir / "REPORT.md"
+
+        register_launcher("dummy-test", DummyLauncher)
+        try:
+            assert "dummy-test" in list_launchers()
+            assert get_launcher("dummy-test") is DummyLauncher
+        finally:
+            # Avoid cross-test pollution.
+            from karenina.benchmark.error_analysis.launcher import _REGISTRY
+
+            _REGISTRY.pop("dummy-test", None)
+
+
+@pytest.mark.unit
+class TestPrepareOnlyLauncher:
+    def test_returns_report_path_when_file_exists(self, tmp_path):
+        (tmp_path / "REPORT.md").write_text("written by hand")
+        path = PrepareOnlyLauncher().run(tmp_path)
+        assert path == tmp_path / "REPORT.md"
+
+    def test_raises_when_report_missing(self, tmp_path):
+        with pytest.raises(LauncherNoOutputError):
+            PrepareOnlyLauncher().run(tmp_path)

--- a/tests/unit/benchmark/error_analysis/test_launcher_claude_code.py
+++ b/tests/unit/benchmark/error_analysis/test_launcher_claude_code.py
@@ -1,0 +1,73 @@
+"""Tests for the opt-in claude-code launcher (all subprocess calls mocked)."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+
+@pytest.mark.unit
+class TestClaudeCodeLauncher:
+    def test_registers_when_imported(self):
+        import importlib
+
+        importlib.import_module("karenina.benchmark.error_analysis.launchers.claude_code")
+        from karenina.benchmark.error_analysis.launcher import list_launchers
+
+        assert "claude-code" in list_launchers()
+
+    def test_missing_binary_raises_unavailable(self, tmp_path, monkeypatch):
+        from karenina.benchmark.error_analysis.exceptions import LauncherUnavailableError
+        from karenina.benchmark.error_analysis.launchers.claude_code import ClaudeCodeLauncher
+
+        monkeypatch.setattr(
+            "karenina.benchmark.error_analysis.launchers.claude_code.shutil.which",
+            lambda _name: None,
+        )
+        with pytest.raises(LauncherUnavailableError) as exc:
+            ClaudeCodeLauncher().run(tmp_path)
+        assert "claude-code" in str(exc.value)
+
+    def test_invokes_subprocess_with_expected_args(self, tmp_path, monkeypatch):
+        from karenina.benchmark.error_analysis.launchers import claude_code
+
+        (tmp_path / "PROMPT.md").write_text("prompt")
+        calls: list[dict] = []
+
+        def _which(_name: str):
+            return "/usr/local/bin/claude"
+
+        def _run(cmd, **kwargs):
+            calls.append({"cmd": cmd, "kwargs": kwargs})
+            (tmp_path / "REPORT.md").write_text("generated")
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(claude_code.shutil, "which", _which)
+        monkeypatch.setattr(claude_code.subprocess, "run", _run)
+
+        report = claude_code.ClaudeCodeLauncher().run(tmp_path, timeout=60)
+        assert report == tmp_path / "REPORT.md"
+        assert calls[0]["kwargs"]["cwd"] == tmp_path
+        assert calls[0]["kwargs"]["timeout"] == 60
+        assert "-p" in calls[0]["cmd"]
+        assert any("@" in part and "PROMPT.md" in part for part in calls[0]["cmd"])
+
+    def test_subprocess_failure_wraps_in_launcher_execution_error(self, tmp_path, monkeypatch):
+        from karenina.benchmark.error_analysis.exceptions import LauncherExecutionError
+        from karenina.benchmark.error_analysis.launchers import claude_code
+
+        monkeypatch.setattr(claude_code.shutil, "which", lambda _name: "/usr/local/bin/claude")
+
+        def _run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(
+                returncode=2,
+                cmd=cmd,
+                stderr=b"permission denied",
+            )
+
+        monkeypatch.setattr(claude_code.subprocess, "run", _run)
+        with pytest.raises(LauncherExecutionError) as exc:
+            claude_code.ClaudeCodeLauncher().run(tmp_path)
+        assert exc.value.returncode == 2
+        assert "permission denied" in exc.value.stderr_tail

--- a/tests/unit/benchmark/error_analysis/test_launcher_claude_code.py
+++ b/tests/unit/benchmark/error_analysis/test_launcher_claude_code.py
@@ -71,3 +71,35 @@ class TestClaudeCodeLauncher:
             claude_code.ClaudeCodeLauncher().run(tmp_path)
         assert exc.value.returncode == 2
         assert "permission denied" in exc.value.stderr_tail
+
+    def test_subprocess_run_captures_stderr(self, tmp_path, monkeypatch):
+        """stderr must be piped so LauncherExecutionError.stderr_tail is populated."""
+        from karenina.benchmark.error_analysis.launchers import claude_code
+
+        monkeypatch.setattr(claude_code.shutil, "which", lambda _name: "/usr/local/bin/claude")
+        calls: list[dict] = []
+
+        def _run(cmd, **kwargs):
+            calls.append({"cmd": cmd, "kwargs": kwargs})
+            (tmp_path / "REPORT.md").write_text("ok")
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(claude_code.subprocess, "run", _run)
+        claude_code.ClaudeCodeLauncher().run(tmp_path)
+        assert calls[0]["kwargs"]["stderr"] == subprocess.PIPE
+
+    def test_subprocess_timeout_wraps_in_launcher_execution_error(self, tmp_path, monkeypatch):
+        """TimeoutExpired is wrapped into LauncherExecutionError with negative returncode."""
+        from karenina.benchmark.error_analysis.exceptions import LauncherExecutionError
+        from karenina.benchmark.error_analysis.launchers import claude_code
+
+        monkeypatch.setattr(claude_code.shutil, "which", lambda _name: "/usr/local/bin/claude")
+
+        def _run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)
+
+        monkeypatch.setattr(claude_code.subprocess, "run", _run)
+        with pytest.raises(LauncherExecutionError) as exc:
+            claude_code.ClaudeCodeLauncher().run(tmp_path, timeout=1)
+        assert exc.value.returncode == -1
+        assert "timeout" in exc.value.stderr_tail.lower()

--- a/tests/unit/benchmark/error_analysis/test_materializer_build.py
+++ b/tests/unit/benchmark/error_analysis/test_materializer_build.py
@@ -1,0 +1,130 @@
+"""End-to-end materializer tests over hand-constructed fixtures."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+
+from karenina.benchmark.error_analysis.exceptions import MaterializationError
+from karenina.benchmark.error_analysis.materializer import ErrorAnalysisMaterializer
+from karenina.schemas.entities.question import Question
+from karenina.schemas.results.failure import FailureCategory
+from karenina.schemas.results.verification_result_set import VerificationResultSet
+
+from .fixtures import make_failure, make_pass
+
+
+class _StubBenchmark:
+    """Minimal stand-in for Benchmark, carrying just the fields the materializer reads."""
+
+    def __init__(self, name: str, questions: list[Question], rubric_dump: dict | None = None):
+        self.name = name
+        self._questions = {q.id: q for q in questions}
+        self._rubric_dump = rubric_dump
+
+    @property
+    def questions(self):
+        return list(self._questions.values())
+
+    def get_question(self, question_id: str) -> Question | None:
+        return self._questions.get(question_id)
+
+    @property
+    def rubric(self):
+        if self._rubric_dump is None:
+            return None
+
+        class _Dumpable:
+            def __init__(self, data):
+                self._data = data
+
+            def model_dump(self, **_):
+                return self._data
+
+        return _Dumpable(self._rubric_dump)
+
+    def get_template_source(self, question_id: str) -> str | None:
+        return f"# template for {question_id}\nclass Answer: pass\n"
+
+
+@pytest.fixture
+def tiny_benchmark():
+    q1 = Question(question="2+2?", raw_answer="4", keywords=["arith"])
+    q2 = Question(question="Capital of France?", raw_answer="Paris")
+    return _StubBenchmark(name="sample", questions=[q1, q2])
+
+
+@pytest.fixture
+def tiny_result_set(tiny_benchmark):
+    q1, q2 = tiny_benchmark.questions
+    passed = make_pass(question_id=q1.id)
+    failed = make_failure(
+        question_id=q2.id,
+        category=FailureCategory.CONTENT,
+        stage="verify_template",
+        reason="expected Paris",
+    )
+    return VerificationResultSet(results=[passed, failed], scenario_results=None)
+
+
+@pytest.mark.unit
+class TestMaterializerBuild:
+    def test_builds_expected_tree(self, tmp_path, tiny_benchmark, tiny_result_set):
+        out_dir = tmp_path / "analysis"
+        materializer = ErrorAnalysisMaterializer()
+        materializer.build(tiny_result_set, tiny_benchmark, out_dir)
+        assert (out_dir / "INDEX.md").exists()
+        assert (out_dir / "benchmark" / "questions.jsonl").exists()
+        assert (out_dir / "benchmark" / "rubric.json").exists()
+        assert any((out_dir / "passes").glob("q_*.md"))
+        assert any((out_dir / "failures" / "content").glob("q_*.md"))
+
+    def test_questions_jsonl_uses_keywords_key(self, tmp_path, tiny_benchmark, tiny_result_set):
+        out_dir = tmp_path / "analysis"
+        ErrorAnalysisMaterializer().build(tiny_result_set, tiny_benchmark, out_dir)
+        lines = (out_dir / "benchmark" / "questions.jsonl").read_text().splitlines()
+        parsed = [json.loads(line) for line in lines]
+        assert all(set(q.keys()) == {"id", "keywords", "raw_answer", "text"} for q in parsed)
+        has_keywords = next(q for q in parsed if q["keywords"])
+        assert has_keywords["keywords"] == ["arith"]
+
+    def test_refuses_nonempty_out_dir_without_force(self, tmp_path, tiny_benchmark, tiny_result_set):
+        out_dir = tmp_path / "analysis"
+        out_dir.mkdir()
+        (out_dir / "preexisting.txt").write_text("something")
+        with pytest.raises(MaterializationError):
+            ErrorAnalysisMaterializer().build(tiny_result_set, tiny_benchmark, out_dir)
+
+    def test_force_preserves_prior_report(self, tmp_path, tiny_benchmark, tiny_result_set):
+        out_dir = tmp_path / "analysis"
+        out_dir.mkdir()
+        (out_dir / "REPORT.md").write_text("previous analysis")
+        ErrorAnalysisMaterializer().build(tiny_result_set, tiny_benchmark, out_dir, force=True)
+        assert (out_dir / "REPORT.previous.md").read_text() == "previous analysis"
+        assert not (out_dir / "REPORT.md").exists()  # launcher has not run
+
+    def test_idempotence_except_index_timestamp(self, tmp_path, tiny_benchmark, tiny_result_set):
+        out_dir = tmp_path / "analysis"
+        materializer = ErrorAnalysisMaterializer()
+        materializer.build(tiny_result_set, tiny_benchmark, out_dir)
+        first = {p.relative_to(out_dir): p.read_text() for p in out_dir.rglob("*") if p.is_file()}
+        materializer.build(tiny_result_set, tiny_benchmark, out_dir, force=True)
+        second = {p.relative_to(out_dir): p.read_text() for p in out_dir.rglob("*") if p.is_file()}
+        for rel_path in set(first) | set(second):
+            if rel_path.name == "INDEX.md":
+                continue
+            assert first.get(rel_path) == second.get(rel_path), f"mismatch at {rel_path}"
+
+    def test_bucketing_by_category(self, tmp_path, tiny_benchmark, tiny_result_set):
+        out_dir = tmp_path / "analysis"
+        ErrorAnalysisMaterializer().build(tiny_result_set, tiny_benchmark, out_dir)
+        parsing_bucket = out_dir / "failures" / "parsing"
+        assert not parsing_bucket.exists()  # only content failures in this set
+        content_bucket = out_dir / "failures" / "content"
+        assert content_bucket.exists()
+        cases = list(content_bucket.glob("*.md"))
+        assert len(cases) == 1
+        fm = yaml.safe_load(cases[0].read_text().split("---\n", 2)[1])
+        assert fm["category"] == "content"

--- a/tests/unit/benchmark/error_analysis/test_materializer_partition.py
+++ b/tests/unit/benchmark/error_analysis/test_materializer_partition.py
@@ -1,0 +1,126 @@
+"""Tests for the materializer's partitioning + filename rules."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.benchmark.error_analysis.materializer import (
+    case_filename,
+    partition_results,
+    sanitize_id,
+)
+from karenina.schemas.results.verification_result_set import VerificationResultSet
+from karenina.schemas.scenario.state import ScenarioExecutionResult, ScenarioState
+
+from .fixtures import make_metadata, make_pass
+
+
+def _empty_state(current: str = "done") -> ScenarioState:
+    return ScenarioState(
+        turn=0,
+        current_node=current,
+        verify_result=None,
+        parsed={},
+        node_visits={},
+        history=[],
+        accumulated={},
+        node_results={},
+    )
+
+
+@pytest.mark.unit
+class TestSanitize:
+    def test_accepts_alphanumerics_and_dashes(self):
+        assert sanitize_id("q-foo_bar1") == "q-foo_bar1"
+
+    def test_replaces_other_characters(self):
+        assert sanitize_id("q.foo/bar baz") == "q_foo_bar_baz"
+
+
+@pytest.mark.unit
+class TestCaseFilename:
+    def test_qa_filename_without_replicate(self):
+        md = make_metadata(question_id="q-001")
+        assert case_filename(metadata=md).endswith("q_q-001.md")
+
+    def test_qa_filename_with_replicate(self):
+        md = make_metadata(question_id="q-001", replicate=3)
+        assert case_filename(metadata=md).endswith("q_q-001__rep_3.md")
+
+    def test_qa_filename_collision_uses_hash(self):
+        md = make_metadata(question_id="q.001")
+        used = {"q_q_001.md"}
+        name = case_filename(metadata=md, existing=used)
+        assert name.startswith("q_q_001__h")
+        assert name.endswith(".md")
+
+    def test_scenario_filename_uses_replicate_when_present(self):
+        scenario = ScenarioExecutionResult(
+            scenario_id="auth.flow",
+            status="completed",
+            path=["a"],
+            turn_count=1,
+            history=[],
+            turn_results=[make_pass(question_id="q_x")],
+            final_state=_empty_state("a"),
+            outcome_results={},
+            replicate=5,
+        )
+        name = case_filename(scenario=scenario, monotonic_n=1)
+        assert name.endswith("scenario_auth_flow__run_5.md")
+
+    def test_scenario_filename_uses_monotonic_when_replicate_none(self):
+        scenario = ScenarioExecutionResult(
+            scenario_id="auth",
+            status="completed",
+            path=["a"],
+            turn_count=1,
+            history=[],
+            turn_results=[make_pass()],
+            final_state=_empty_state("a"),
+            outcome_results={},
+            replicate=None,
+        )
+        name = case_filename(scenario=scenario, monotonic_n=7)
+        assert name.endswith("scenario_auth__run_7.md")
+
+
+@pytest.mark.unit
+class TestPartition:
+    def test_classical_qa_skips_scenario_turns(self):
+        qa = make_pass(question_id="q_qa")
+        scn_turn = make_pass(question_id="q_turn")
+        scn_turn.metadata = make_metadata(
+            question_id="q_turn",
+            scenario_id="s1",
+            scenario_turn=1,
+        )
+        scenario = ScenarioExecutionResult(
+            scenario_id="s1",
+            status="completed",
+            path=["a"],
+            turn_count=1,
+            history=[],
+            turn_results=[scn_turn],
+            final_state=_empty_state("a"),
+            outcome_results={},
+            replicate=None,
+        )
+        rs = VerificationResultSet(results=[qa, scn_turn], scenario_results=[scenario])
+        qa_list, scn_list = partition_results(rs)
+        assert [r.metadata.question_id for r in qa_list] == ["q_qa"]
+        assert scn_list == [scenario]
+
+    def test_missing_scenario_aggregate_raises(self):
+        qa = make_pass(question_id="q_qa")
+        scn_turn = make_pass(question_id="q_turn")
+        scn_turn.metadata = make_metadata(
+            question_id="q_turn",
+            scenario_id="s1",
+            scenario_turn=1,
+        )
+        rs = VerificationResultSet(results=[qa, scn_turn], scenario_results=None)
+        from karenina.exceptions import MaterializationError
+
+        with pytest.raises(MaterializationError):
+            partition_results(rs)

--- a/tests/unit/benchmark/error_analysis/test_materializer_partition.py
+++ b/tests/unit/benchmark/error_analysis/test_materializer_partition.py
@@ -86,6 +86,33 @@ class TestCaseFilename:
 
 
 @pytest.mark.unit
+class TestCaseFilenameEdge:
+    def test_raises_when_neither_metadata_nor_scenario_given(self):
+        with pytest.raises(ValueError, match="metadata or scenario"):
+            case_filename()
+
+    def test_double_collision_raises_materialization_error(self):
+        from karenina.benchmark.error_analysis.exceptions import MaterializationError
+
+        md = make_metadata(question_id="q.001")
+        # Collide on both base and hashed names.
+        # First call: compute the actual hashed filename, then pre-populate `existing`.
+        existing_base_only = {"q_q_001.md"}
+        hashed_name = case_filename(metadata=md, existing=existing_base_only)
+        # Now include both in `existing` and expect a raise.
+        existing_both = {"q_q_001.md", hashed_name}
+        with pytest.raises(MaterializationError):
+            case_filename(metadata=md, existing=existing_both)
+
+    def test_hash_is_deterministic_for_same_metadata(self):
+        md = make_metadata(question_id="q.001")
+        existing = {"q_q_001.md"}
+        name1 = case_filename(metadata=md, existing=existing)
+        name2 = case_filename(metadata=md, existing=existing)
+        assert name1 == name2
+
+
+@pytest.mark.unit
 class TestPartition:
     def test_classical_qa_skips_scenario_turns(self):
         qa = make_pass(question_id="q_qa")

--- a/tests/unit/benchmark/error_analysis/test_prompt_io.py
+++ b/tests/unit/benchmark/error_analysis/test_prompt_io.py
@@ -1,0 +1,58 @@
+"""Tests for prompt resolution and placeholder substitution."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.benchmark.error_analysis.prompt_io import (
+    PromptContext,
+    resolve_and_write_prompt,
+)
+
+
+@pytest.mark.unit
+class TestPromptIO:
+    def test_default_prompt_written_with_substitutions(self, tmp_path):
+        context = PromptContext(
+            benchmark_name="legal_qa",
+            answering_model="anthropic/claude-opus-4-6",
+            total=10,
+            passed=7,
+            failed=3,
+            failure_categories=["content", "parsing"],
+        )
+        path = resolve_and_write_prompt(prompt_path=None, out_dir=tmp_path, context=context)
+        assert path == tmp_path / "PROMPT.md"
+        text = path.read_text()
+        assert "legal_qa" in text
+        assert "anthropic/claude-opus-4-6" in text
+        assert "10" in text
+        assert "content, parsing" in text
+
+    def test_user_prompt_copied_verbatim_when_no_placeholders(self, tmp_path):
+        source = tmp_path / "custom.md"
+        source.write_text("# Custom\nJust do the thing.\n")
+        context = PromptContext(
+            benchmark_name="x",
+            answering_model="m",
+            total=0,
+            passed=0,
+            failed=0,
+            failure_categories=[],
+        )
+        path = resolve_and_write_prompt(prompt_path=source, out_dir=tmp_path, context=context)
+        assert path.read_text() == "# Custom\nJust do the thing.\n"
+
+    def test_user_prompt_with_placeholders_substituted(self, tmp_path):
+        source = tmp_path / "custom.md"
+        source.write_text("Audit $BENCHMARK_NAME on $ANSWERING_MODEL: $FAILED failures.")
+        context = PromptContext(
+            benchmark_name="bench",
+            answering_model="mod",
+            total=10,
+            passed=7,
+            failed=3,
+            failure_categories=[],
+        )
+        path = resolve_and_write_prompt(prompt_path=source, out_dir=tmp_path, context=context)
+        assert path.read_text() == "Audit bench on mod: 3 failures."

--- a/tests/unit/cli/test_analyze_errors.py
+++ b/tests/unit/cli/test_analyze_errors.py
@@ -1,0 +1,120 @@
+"""Tests for the `karenina analyze-errors` CLI command."""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from karenina.cli import app
+from karenina.schemas.entities.question import Question
+from karenina.schemas.results.failure import FailureCategory
+from karenina.schemas.results.verification_result_set import VerificationResultSet
+from tests.unit.benchmark.error_analysis.fixtures import make_failure, make_pass
+from tests.unit.benchmark.error_analysis.test_materializer_build import _StubBenchmark
+
+
+@pytest.fixture
+def sample_inputs(tmp_path):
+    q = Question(question="2+2?", raw_answer="4")
+    bench = _StubBenchmark(name="sample", questions=[q])
+    passed = make_pass(question_id=q.id)
+    failed = make_failure(
+        question_id=q.id,
+        category=FailureCategory.CONTENT,
+        stage="verify_template",
+        reason="oops",
+    )
+    rs = VerificationResultSet(results=[passed, failed], scenario_results=None)
+
+    results_path = tmp_path / "results.json"
+    results_path.write_text(rs.model_dump_json())
+
+    # The CLI expects a real Benchmark JSON-LD file; intercept Benchmark.load in
+    # the test by monkeypatching instead. Return a placeholder path.
+    return rs, bench, results_path
+
+
+@pytest.fixture
+def runner():
+    return CliRunner(mix_stderr=False)
+
+
+@pytest.mark.unit
+class TestAnalyzeErrorsCli:
+    def test_unknown_launcher_exits_with_2(self, runner, tmp_path, sample_inputs, monkeypatch):
+        _rs, bench, results_path = sample_inputs
+        monkeypatch.setattr(
+            "karenina.benchmark.benchmark.Benchmark.load",
+            classmethod(lambda _cls, _path, **_kwargs: bench),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "analyze-errors",
+                "--results",
+                str(results_path),
+                "--checkpoint",
+                str(tmp_path / "does-not-matter.json"),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--launcher",
+                "no-such-launcher",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "prepare-only" in result.stdout or "prepare-only" in result.stderr
+
+    def test_missing_report_exits_with_3(self, runner, tmp_path, sample_inputs, monkeypatch):
+        _rs, bench, results_path = sample_inputs
+        monkeypatch.setattr(
+            "karenina.benchmark.benchmark.Benchmark.load",
+            classmethod(lambda _cls, _path, **_kwargs: bench),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "analyze-errors",
+                "--results",
+                str(results_path),
+                "--checkpoint",
+                str(tmp_path / "any.json"),
+                "--out-dir",
+                str(tmp_path / "out"),
+            ],
+        )
+        # prepare-only launcher raises LauncherNoOutputError.
+        assert result.exit_code == 3
+
+    def test_force_on_nonempty_preserves_prior_report(
+        self,
+        runner,
+        tmp_path,
+        sample_inputs,
+        monkeypatch,
+    ):
+        _rs, bench, results_path = sample_inputs
+        monkeypatch.setattr(
+            "karenina.benchmark.benchmark.Benchmark.load",
+            classmethod(lambda _cls, _path, **_kwargs: bench),
+        )
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "REPORT.md").write_text("old analysis")
+
+        # Pre-existing prior analysis: facade renames it to REPORT.previous.md
+        # but the default prepare-only launcher still fails with exit 3.
+        result = runner.invoke(
+            app,
+            [
+                "analyze-errors",
+                "--results",
+                str(results_path),
+                "--checkpoint",
+                str(tmp_path / "any.json"),
+                "--out-dir",
+                str(out),
+                "--force",
+            ],
+        )
+        assert result.exit_code == 3
+        assert (out / "REPORT.previous.md").read_text() == "old analysis"


### PR DESCRIPTION
## Summary
Adds a new `karenina.benchmark.error_analysis` subpackage that materializes verification failures and scenario runs into per-case markdown review files (frontmatter + structured body + trace) with a top-level `INDEX.md`, and exposes them through a Python facade (`analyze_errors`) and a `karenina analyze-errors` CLI. A pluggable launcher protocol ships with a `prepare-only` default and an opt-in `claude-code` launcher that feeds the rendered cases to an LLM for triage.

## Changes Made

### New subpackage (`src/karenina/benchmark/error_analysis/`)
- `facade.py`: `analyze_errors(results, output_dir, launcher=..., prompt=..., benchmark_name=...)` Python entry point
- `materializer.py` (472 lines): partitions results, applies filename rules, orchestrates rendering + indexing
- `case_renderer.py` (442 lines): per-case markdown with YAML frontmatter, QA-structured body, scenario runs split into per-turn sections, full trace conversion pipeline
- `indexer.py`: `INDEX.md` builder (threads `benchmark_name` through the header)
- `launcher.py` + `launchers/`: `Launcher` protocol + registry; ships `prepare_only` (default, writes files only) and `claude_code` (opt-in, invokes `claude` CLI with timeout + stderr capture)
- `prompt_io.py` + `prompts/default_prompt.md`: packaged default prompt with `{{placeholder}}` substitution for benchmark name and case path
- `exceptions.py`: new exception hierarchy (`ErrorAnalysisError`, `CaseRenderError`, `MaterializationError`, `LauncherError`, …), wired into top-level `exceptions.py`

### New CLI command (`src/karenina/cli/analyze_errors.py`)
- `karenina analyze-errors <results> --output <dir> [--launcher claude-code] [--prompt path] [--benchmark-name name]`
- `ImportError` on optional launcher registration is logged at `DEBUG`, not `WARNING`

### Docs
- New page: `docs/workflows/analyzing-results/error-analysis.md` (129 lines)
- Cross-references added from `advanced-pipeline/error-handling.md`, `core_concepts/results-and-scoring.md`, `core_concepts/scenarios/index.md`, `workflows/analyzing-results/index.md`
- Added to `mkdocs.yml` nav

### pyproject
- Adds optional `claude-code` extra (pulled in only when the launcher is used)

## Testing
- `tests/unit/benchmark/error_analysis/`: 11 new test modules covering facade, materializer (build + partition), case renderer (frontmatter, scenario runs, trace pipeline), indexer, launcher + claude-code launcher, prompt I/O, and the exception hierarchy
- `tests/unit/cli/test_analyze_errors.py`: CLI command coverage (flags, launcher selection, prompt override, error paths)
- Shared `fixtures.py` for synthetic results
- Total: 37 files changed, +3212 / −6

## Additional Context
- **Optional dependency**: the `claude-code` launcher requires the `claude` CLI on `PATH`; without it, the launcher registers at `DEBUG` level and only `prepare-only` is available.
- **Default behavior**: running `analyze-errors` without `--launcher` writes the case files + `INDEX.md` and exits — no LLM is invoked.
- **Timeouts**: the claude-code launcher wraps its subprocess in a timeout and captures stderr, so hung LLM invocations no longer block the pipeline.
- Builds on the `Failure` + `Caveats` metadata from #158 (merged) — case rendering reads `failure.group` / `failure.category` directly.