### PR TITLE
feat(benchmark): add extend_template and extend_rubric replay-backed extension APIs

### DIFF
--- a/docs/core_concepts/extending-runs.md
+++ b/docs/core_concepts/extending-runs.md
@@ -1,0 +1,231 @@
+---
+jupyter:
+  jupytext:
+    formats: docs/core_concepts//md,docs/notebooks/core_concepts//ipynb
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.18.1
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
+# Extending Prior Runs: `extend_template` and `extend_rubric`
+
+A verification run captures enough state on every result row that later runs can reuse parts of it instead of re-executing the whole pipeline. Two facades on `Benchmark` expose this reuse as a first-class operation:
+
+- [`Benchmark.extend_template`](../verification-pipeline/) extends a prior run along the template-verification axes: new judges, new answerers, more replicates. Prior `(question, answerer, replicate)` traces are served from a [ReplayStore](../../reference/replay/) so no answering tokens are spent twice; parsing runs live against new judges.
+- [`Benchmark.extend_rubric`](../rubrics/) attaches a new rubric to a prior run and scores every existing trace against it. Answering is replayed, template parsing and verification are skipped entirely, and the new trait scores are merged onto copies of the prior rows.
+
+```python tags=["hide-cell"]
+from karenina.benchmark import Benchmark
+from karenina.schemas import ModelConfig, VerificationConfig
+from karenina.schemas.entities import LLMRubricTrait, RegexRubricTrait, Rubric
+```
+
+## 1. When to Use Which
+
+| You want to... | Use | Output shape |
+|---|---|---|
+| Score the same traces with a second judge LLM | `extend_template` | prior rows + one new row per (qid, answerer, new-judge, replicate) |
+| Add a second answering model to an existing matrix | `extend_template` | prior rows + one new row per (qid, new-answerer, judge, replicate) |
+| Add more replicates (`replicate_count=3` -> `=4`) | `extend_template` | prior rows + one new row per added replicate |
+| Attach a rubric to a prior run that didn't have one | `extend_rubric` | prior rows enriched in-place; row count unchanged |
+| Add a trait to a rubric you already ran | `extend_rubric` | prior rows enriched; `rubric.*_trait_scores` unioned by trait name |
+
+Composing both: if you need new judges *and* new rubric traits on top of a single prior run, call `extend_template` first, then `extend_rubric` on the merged result. The two facades do not compose in a single call.
+
+## 2. Shared Mechanics
+
+Both facades build a [ReplayStore](../../reference/replay/) from the prior `VerificationResultSet` and pass it through `VerificationConfig.replay_store`. At the generate-answer stage, any `(question, answering_model, replicate)` triple that hits the store replays the captured trace instead of invoking the LLM. Anything that misses runs live.
+
+| Field captured in the store | `extend_template` | `extend_rubric` |
+|---|---|---|
+| Raw trace / messages | Yes | Yes |
+| Parsed template fields | No (parsing always runs live) | No (parsing is skipped entirely) |
+
+The two facades differ in what the pipeline does downstream:
+
+- `extend_template` runs the full template-verification path in `evaluation_mode="template_only"`. New triples run answering live, parsing runs live for everyone. Prior triples are filtered out of the task queue via `VerificationConfig.skip_triples` so they pass through the merge verbatim.
+- `extend_rubric` runs the pipeline in `evaluation_mode="rubric_only"` (the orchestrator keeps `GenerateAnswer` + rubric evaluation + finalize, drops parse/verify). Every prior triple flows through; the rubric scores are then merged onto copies of the prior rows by matching `(qid, answerer, judge, replicate)`.
+
+In both cases the merged `VerificationResultSet` carries a single `run_name` so downstream consumers see one logical run.
+
+## 3. `extend_template`: Three Composable Axes
+
+### 3.1 Minimum viable call: add a second judge
+
+The caller expresses the **final** shape in the config as a full union of everything they want in the output. The helper diffs against `prior_results` to decide what is new.
+
+```python
+answerer = ModelConfig(id="answerer", model_provider="anthropic", model_name="claude-haiku-4-5")
+judge_a = ModelConfig(id="judge-a", model_provider="anthropic", model_name="claude-haiku-4-5", temperature=0.0)
+judge_b = ModelConfig(id="judge-b", model_provider="openai", model_name="gpt-4.1-mini", temperature=0.0)
+
+phase_a = VerificationConfig(answering_models=[answerer], parsing_models=[judge_a])
+# prior = bench.run_verification(config=phase_a, run_name="demo")
+
+phase_b = VerificationConfig(
+    answering_models=[answerer],              # same as prior
+    parsing_models=[judge_a, judge_b],        # old + new, full union
+    replicate_count=1,                        # same as prior
+)
+# merged = bench.extend_template(prior_results=prior, config=phase_b, run_name="demo")
+```
+
+After the call, `merged.results` has the shape of a joint run with `parsing_models=[judge_a, judge_b]`. The `judge_a` rows come verbatim from `prior`; the `judge_b` rows were produced live with answering served from replay.
+
+### 3.2 Add an answering model
+
+```python
+other_answerer = ModelConfig(id="other", model_provider="openai", model_name="gpt-4.1-mini")
+
+phase_b = VerificationConfig(
+    answering_models=[answerer, other_answerer],   # union: old + new
+    parsing_models=[judge_a],                       # same as prior
+    replicate_count=1,
+)
+# merged = bench.extend_template(prior_results=prior, config=phase_b)
+```
+
+`(answerer, judge_a)` rows pass through; `(other_answerer, judge_a)` rows run answering and parsing live.
+
+### 3.3 Add replicates
+
+```python
+phase_b = VerificationConfig(
+    answering_models=[answerer],
+    parsing_models=[judge_a],
+    replicate_count=3,                              # prior had 2
+)
+# merged = bench.extend_template(prior_results=prior, config=phase_b)
+```
+
+Replicates 1 and 2 pass through; replicate 3 runs answering and parsing live for every question.
+
+### 3.4 All three axes at once
+
+```python
+phase_b = VerificationConfig(
+    answering_models=[answerer, other_answerer],
+    parsing_models=[judge_a, judge_b],
+    replicate_count=3,
+)
+# merged = bench.extend_template(prior_results=prior, config=phase_b)
+```
+
+If prior was `(answerer, judge_a)` at `replicate_count=2` over `N` questions, the merged output has the full symmetric matrix `2 answerers x 2 judges x N questions x 3 replicates` rows. The `2N` prior rows pass through verbatim; everything else is produced live (with answering replayed for `answerer` replicates 1 and 2).
+
+### 3.5 Validation
+
+`extend_template` raises `ValueError` when:
+
+- `prior_results` is empty.
+- `config.replay_store` is pre-populated (the helper owns that slot).
+- `config.answering_models` does not cover every answering identity in `prior_results` (superset allowed, missing is rejected).
+- `config.replicate_count` is lower than the fan-out observed in `prior_results`. Replicate reduction is out of scope.
+- `run_name` is inconsistent across `prior_results` and no override is passed.
+
+## 4. `extend_rubric`: Attach a Rubric to a Prior Run
+
+### 4.1 Usage pattern
+
+The rubric lives on the benchmark. Attach it (global and/or per-question) before the call:
+
+```python
+# prior = bench.run_verification(config=phase_a, run_name="demo")
+
+bench.set_global_rubric(
+    Rubric(
+        llm_traits=[
+            LLMRubricTrait(
+                name="answer_confidence",
+                description="Rate how confident the response sounds, 1 (hedged) to 5 (definitive).",
+                kind="score",
+                min_score=1,
+                max_score=5,
+            ),
+        ],
+        regex_traits=[
+            RegexRubricTrait(
+                name="cites_source",
+                description="True if the response mentions a source or reference.",
+                pattern=r"(?i)\b(source|reference|according to)\b",
+            ),
+        ],
+    )
+)
+
+phase_b = VerificationConfig(
+    answering_models=[answerer],        # must match prior
+    parsing_models=[judge_a],           # must match prior
+    replicate_count=1,                  # must match prior
+)
+# merged = bench.extend_rubric(prior_results=prior, config=phase_b)
+```
+
+`merged.results` has **exactly the same length** as `prior.results`. Each row is a deep copy of the prior row with `rubric.llm_trait_scores` and `rubric.regex_trait_scores` now populated.
+
+### 4.2 Merge semantics: trait-name union
+
+If a prior row already carried rubric scores (for example, the seed ran under `evaluation_mode="template_and_rubric"`), the new trait dictionaries are unioned with the old ones by trait name.
+
+- New trait `clarity` added to a row that already had `coherence` -> merged row has both.
+- Same-name trait on both sides -> `ValueError`, naming the colliding trait and the bucket (one of `llm_trait_scores`, `llm_trait_labels`, `regex_trait_scores`, `callable_trait_scores`, `agentic_trait_scores`, `agentic_trait_investigation_traces`).
+
+This rules out silent overwrites: if you want to re-run an existing trait, clear it from the prior results first.
+
+### 4.3 Shape-match requirements
+
+Unlike `extend_template`, `extend_rubric` preserves the prior shape exactly. All three axes must equal what was observed in `prior_results`:
+
+- `config.answering_models` identities match.
+- `config.parsing_models` identities match.
+- `config.replicate_count` equals the observed replicate fan-out (`==`, not `>=`).
+
+This is intentional. Changing the shape while extending the rubric would require either dropping prior rows (inconsistent) or duplicating them (breaks the 1:1 mapping). If you need both, run `extend_template` first, then `extend_rubric` on the merged result.
+
+### 4.4 Scope
+
+Supported trait types: LLM, regex, callable, agentic, plus `DynamicRubric` presence-gated traits.
+
+**Metric traits are rejected.** Metric evaluation consumes parsed template fields, and the rubric-only pipeline does not produce them. Attaching a metric trait to the benchmark before calling `extend_rubric` raises `ValueError`. Use `template_and_rubric` on a fresh run if you need metric evaluation.
+
+### 4.5 Validation
+
+`extend_rubric` raises `ValueError` when:
+
+- `prior_results` is empty.
+- `config.replay_store` is pre-populated.
+- `config.evaluation_mode` is set to `"template_and_rubric"` (the caller should not preset a conflicting mode; the helper rewrites it to `"rubric_only"` internally).
+- The benchmark has no rubric attached anywhere (global or per-question) for any question in `prior_results`.
+- Any attached rubric contains metric traits.
+- `config.answering_models`, `config.parsing_models`, or `config.replicate_count` disagree with the observed prior shape.
+
+## 5. Reading the Merged Result
+
+Both facades return a `VerificationResultSet` with a single `run_name`. They differ in what changes:
+
+| Aspect | `extend_template` | `extend_rubric` |
+|---|---|---|
+| Row count vs prior | Can grow | Equal |
+| Prior rows | Passed through verbatim | Copied and enriched |
+| New rows | Appended | None |
+| `rubric.*` fields on prior rows | Unchanged | Populated / unioned |
+| `result_id` stability | Preserved on prior rows | Preserved (deep copy keeps the same id) |
+
+The `run_name` on every row is stamped to the effective name: the `run_name=` override if passed, otherwise the run name inferred from `prior_results` (rejected when inconsistent).
+
+## 6. Storage Flag
+
+Both facades accept `store: bool = True`. When true, the merged set is written to the benchmark's results manager under the effective `run_name` so `bench.get_verification_results(run_name=...)` can retrieve it. Set `store=False` for exploratory use where you only want the returned object.
+
+## 7. Further Reading
+
+- [Verification Pipeline](../verification-pipeline/): the 13-stage engine both facades drive.
+- [Evaluation Modes](../evaluation-modes/): how `rubric_only` differs from `template_only` and `template_and_rubric`.
+- [Rubrics](../../../core_concepts/rubrics/): trait types and `DynamicRubric`.
+- `karenina/src/karenina/benchmark/verification/extension.py`: the helper implementations (`extend_template_run`, `extend_rubric_run`) if you need to read the exact validation and merge code.

--- a/docs/core_concepts/index.md
+++ b/docs/core_concepts/index.md
@@ -19,6 +19,7 @@ Concepts are ordered to follow the evaluation pipeline — from what you're eval
 | **Verification Pipeline** | The 13-stage engine that executes evaluation end to end | [Verification Pipeline](../notebooks/core_concepts/verification-pipeline.ipynb) |
 | **Prompt Assembly** | How prompts are constructed for pipeline LLM calls (tri-section pattern) | [Prompt Assembly](../notebooks/core_concepts/prompt-assembly.ipynb) |
 | **Results & Scoring** | What verification produces: pass/fail, scores, traits, and metrics | [Results & Scoring](../notebooks/core_concepts/results-and-scoring.ipynb) |
+| **Extending Runs** | Reuse prior traces to add judges/answerers/replicates (`extend_template`) or attach a new rubric (`extend_rubric`) | [Extending Runs](../notebooks/core_concepts/extending-runs.ipynb) |
 | **Adapters** | LLM backend interfaces (LangChain, Claude SDK, Claude Tool, Manual, and more) | [Adapters](adapters.md) |
 | **MCP** | Tool-augmented evaluation via Model Context Protocol servers | [MCP Overview](../notebooks/core_concepts/mcp-overview.ipynb) |
 | **Manual Interface** | Evaluation using pre-recorded LLM traces instead of live API calls | [Manual Interface](../notebooks/core_concepts/manual-interface.ipynb) |

--- a/docs/notebooks/core_concepts/extending-runs.ipynb
+++ b/docs/notebooks/core_concepts/extending-runs.ipynb
@@ -1,0 +1,315 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "050aefd0",
+   "metadata": {},
+   "source": [
+    "# Extending Prior Runs: `extend_template` and `extend_rubric`\n",
+    "\n",
+    "A verification run captures enough state on every result row that later runs can reuse parts of it instead of re-executing the whole pipeline. Two facades on `Benchmark` expose this reuse as a first-class operation:\n",
+    "\n",
+    "- [`Benchmark.extend_template`](../verification-pipeline/) extends a prior run along the template-verification axes: new judges, new answerers, more replicates. Prior `(question, answerer, replicate)` traces are served from a [ReplayStore](../../reference/replay/) so no answering tokens are spent twice; parsing runs live against new judges.\n",
+    "- [`Benchmark.extend_rubric`](../rubrics/) attaches a new rubric to a prior run and scores every existing trace against it. Answering is replayed, template parsing and verification are skipped entirely, and the new trait scores are merged onto copies of the prior rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa825344",
+   "metadata": {
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from karenina.benchmark import Benchmark\n",
+    "from karenina.schemas import ModelConfig, VerificationConfig\n",
+    "from karenina.schemas.entities import LLMRubricTrait, RegexRubricTrait, Rubric"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "124bcb40",
+   "metadata": {},
+   "source": [
+    "## 1. When to Use Which\n",
+    "\n",
+    "| You want to... | Use | Output shape |\n",
+    "|---|---|---|\n",
+    "| Score the same traces with a second judge LLM | `extend_template` | prior rows + one new row per (qid, answerer, new-judge, replicate) |\n",
+    "| Add a second answering model to an existing matrix | `extend_template` | prior rows + one new row per (qid, new-answerer, judge, replicate) |\n",
+    "| Add more replicates (`replicate_count=3` -> `=4`) | `extend_template` | prior rows + one new row per added replicate |\n",
+    "| Attach a rubric to a prior run that didn't have one | `extend_rubric` | prior rows enriched in-place; row count unchanged |\n",
+    "| Add a trait to a rubric you already ran | `extend_rubric` | prior rows enriched; `rubric.*_trait_scores` unioned by trait name |\n",
+    "\n",
+    "Composing both: if you need new judges *and* new rubric traits on top of a single prior run, call `extend_template` first, then `extend_rubric` on the merged result. The two facades do not compose in a single call.\n",
+    "\n",
+    "## 2. Shared Mechanics\n",
+    "\n",
+    "Both facades build a [ReplayStore](../../reference/replay/) from the prior `VerificationResultSet` and pass it through `VerificationConfig.replay_store`. At the generate-answer stage, any `(question, answering_model, replicate)` triple that hits the store replays the captured trace instead of invoking the LLM. Anything that misses runs live.\n",
+    "\n",
+    "| Field captured in the store | `extend_template` | `extend_rubric` |\n",
+    "|---|---|---|\n",
+    "| Raw trace / messages | Yes | Yes |\n",
+    "| Parsed template fields | No (parsing always runs live) | No (parsing is skipped entirely) |\n",
+    "\n",
+    "The two facades differ in what the pipeline does downstream:\n",
+    "\n",
+    "- `extend_template` runs the full template-verification path in `evaluation_mode=\"template_only\"`. New triples run answering live, parsing runs live for everyone. Prior triples are filtered out of the task queue via `VerificationConfig.skip_triples` so they pass through the merge verbatim.\n",
+    "- `extend_rubric` runs the pipeline in `evaluation_mode=\"rubric_only\"` (the orchestrator keeps `GenerateAnswer` + rubric evaluation + finalize, drops parse/verify). Every prior triple flows through; the rubric scores are then merged onto copies of the prior rows by matching `(qid, answerer, judge, replicate)`.\n",
+    "\n",
+    "In both cases the merged `VerificationResultSet` carries a single `run_name` so downstream consumers see one logical run.\n",
+    "\n",
+    "## 3. `extend_template`: Three Composable Axes\n",
+    "\n",
+    "### 3.1 Minimum viable call: add a second judge\n",
+    "\n",
+    "The caller expresses the **final** shape in the config as a full union of everything they want in the output. The helper diffs against `prior_results` to decide what is new."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ca75963",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "answerer = ModelConfig(id=\"answerer\", model_provider=\"anthropic\", model_name=\"claude-haiku-4-5\")\n",
+    "judge_a = ModelConfig(id=\"judge-a\", model_provider=\"anthropic\", model_name=\"claude-haiku-4-5\", temperature=0.0)\n",
+    "judge_b = ModelConfig(id=\"judge-b\", model_provider=\"openai\", model_name=\"gpt-4.1-mini\", temperature=0.0)\n",
+    "\n",
+    "phase_a = VerificationConfig(answering_models=[answerer], parsing_models=[judge_a])\n",
+    "# prior = bench.run_verification(config=phase_a, run_name=\"demo\")\n",
+    "\n",
+    "phase_b = VerificationConfig(\n",
+    "    answering_models=[answerer],              # same as prior\n",
+    "    parsing_models=[judge_a, judge_b],        # old + new, full union\n",
+    "    replicate_count=1,                        # same as prior\n",
+    ")\n",
+    "# merged = bench.extend_template(prior_results=prior, config=phase_b, run_name=\"demo\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88190bbd",
+   "metadata": {},
+   "source": [
+    "After the call, `merged.results` has the shape of a joint run with `parsing_models=[judge_a, judge_b]`. The `judge_a` rows come verbatim from `prior`; the `judge_b` rows were produced live with answering served from replay.\n",
+    "\n",
+    "### 3.2 Add an answering model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df8e3622",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "other_answerer = ModelConfig(id=\"other\", model_provider=\"openai\", model_name=\"gpt-4.1-mini\")\n",
+    "\n",
+    "phase_b = VerificationConfig(\n",
+    "    answering_models=[answerer, other_answerer],   # union: old + new\n",
+    "    parsing_models=[judge_a],                       # same as prior\n",
+    "    replicate_count=1,\n",
+    ")\n",
+    "# merged = bench.extend_template(prior_results=prior, config=phase_b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59394ebb",
+   "metadata": {},
+   "source": [
+    "`(answerer, judge_a)` rows pass through; `(other_answerer, judge_a)` rows run answering and parsing live.\n",
+    "\n",
+    "### 3.3 Add replicates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c7b9fd8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phase_b = VerificationConfig(\n",
+    "    answering_models=[answerer],\n",
+    "    parsing_models=[judge_a],\n",
+    "    replicate_count=3,                              # prior had 2\n",
+    ")\n",
+    "# merged = bench.extend_template(prior_results=prior, config=phase_b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb9b1a2a",
+   "metadata": {},
+   "source": [
+    "Replicates 1 and 2 pass through; replicate 3 runs answering and parsing live for every question.\n",
+    "\n",
+    "### 3.4 All three axes at once"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c217163",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phase_b = VerificationConfig(\n",
+    "    answering_models=[answerer, other_answerer],\n",
+    "    parsing_models=[judge_a, judge_b],\n",
+    "    replicate_count=3,\n",
+    ")\n",
+    "# merged = bench.extend_template(prior_results=prior, config=phase_b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a56493b1",
+   "metadata": {},
+   "source": [
+    "If prior was `(answerer, judge_a)` at `replicate_count=2` over `N` questions, the merged output has the full symmetric matrix `2 answerers x 2 judges x N questions x 3 replicates` rows. The `2N` prior rows pass through verbatim; everything else is produced live (with answering replayed for `answerer` replicates 1 and 2).\n",
+    "\n",
+    "### 3.5 Validation\n",
+    "\n",
+    "`extend_template` raises `ValueError` when:\n",
+    "\n",
+    "- `prior_results` is empty.\n",
+    "- `config.replay_store` is pre-populated (the helper owns that slot).\n",
+    "- `config.answering_models` does not cover every answering identity in `prior_results` (superset allowed, missing is rejected).\n",
+    "- `config.replicate_count` is lower than the fan-out observed in `prior_results`. Replicate reduction is out of scope.\n",
+    "- `run_name` is inconsistent across `prior_results` and no override is passed.\n",
+    "\n",
+    "## 4. `extend_rubric`: Attach a Rubric to a Prior Run\n",
+    "\n",
+    "### 4.1 Usage pattern\n",
+    "\n",
+    "The rubric lives on the benchmark. Attach it (global and/or per-question) before the call:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25f13e57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# prior = bench.run_verification(config=phase_a, run_name=\"demo\")\n",
+    "\n",
+    "bench.set_global_rubric(\n",
+    "    Rubric(\n",
+    "        llm_traits=[\n",
+    "            LLMRubricTrait(\n",
+    "                name=\"answer_confidence\",\n",
+    "                description=\"Rate how confident the response sounds, 1 (hedged) to 5 (definitive).\",\n",
+    "                kind=\"score\",\n",
+    "                min_score=1,\n",
+    "                max_score=5,\n",
+    "            ),\n",
+    "        ],\n",
+    "        regex_traits=[\n",
+    "            RegexRubricTrait(\n",
+    "                name=\"cites_source\",\n",
+    "                description=\"True if the response mentions a source or reference.\",\n",
+    "                pattern=r\"(?i)\\b(source|reference|according to)\\b\",\n",
+    "            ),\n",
+    "        ],\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "phase_b = VerificationConfig(\n",
+    "    answering_models=[answerer],        # must match prior\n",
+    "    parsing_models=[judge_a],           # must match prior\n",
+    "    replicate_count=1,                  # must match prior\n",
+    ")\n",
+    "# merged = bench.extend_rubric(prior_results=prior, config=phase_b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "277039a6",
+   "metadata": {},
+   "source": [
+    "`merged.results` has **exactly the same length** as `prior.results`. Each row is a deep copy of the prior row with `rubric.llm_trait_scores` and `rubric.regex_trait_scores` now populated.\n",
+    "\n",
+    "### 4.2 Merge semantics: trait-name union\n",
+    "\n",
+    "If a prior row already carried rubric scores (for example, the seed ran under `evaluation_mode=\"template_and_rubric\"`), the new trait dictionaries are unioned with the old ones by trait name.\n",
+    "\n",
+    "- New trait `clarity` added to a row that already had `coherence` -> merged row has both.\n",
+    "- Same-name trait on both sides -> `ValueError`, naming the colliding trait and the bucket (one of `llm_trait_scores`, `llm_trait_labels`, `regex_trait_scores`, `callable_trait_scores`, `agentic_trait_scores`, `agentic_trait_investigation_traces`).\n",
+    "\n",
+    "This rules out silent overwrites: if you want to re-run an existing trait, clear it from the prior results first.\n",
+    "\n",
+    "### 4.3 Shape-match requirements\n",
+    "\n",
+    "Unlike `extend_template`, `extend_rubric` preserves the prior shape exactly. All three axes must equal what was observed in `prior_results`:\n",
+    "\n",
+    "- `config.answering_models` identities match.\n",
+    "- `config.parsing_models` identities match.\n",
+    "- `config.replicate_count` equals the observed replicate fan-out (`==`, not `>=`).\n",
+    "\n",
+    "This is intentional. Changing the shape while extending the rubric would require either dropping prior rows (inconsistent) or duplicating them (breaks the 1:1 mapping). If you need both, run `extend_template` first, then `extend_rubric` on the merged result.\n",
+    "\n",
+    "### 4.4 Scope\n",
+    "\n",
+    "Supported trait types: LLM, regex, callable, agentic, plus `DynamicRubric` presence-gated traits.\n",
+    "\n",
+    "**Metric traits are rejected.** Metric evaluation consumes parsed template fields, and the rubric-only pipeline does not produce them. Attaching a metric trait to the benchmark before calling `extend_rubric` raises `ValueError`. Use `template_and_rubric` on a fresh run if you need metric evaluation.\n",
+    "\n",
+    "### 4.5 Validation\n",
+    "\n",
+    "`extend_rubric` raises `ValueError` when:\n",
+    "\n",
+    "- `prior_results` is empty.\n",
+    "- `config.replay_store` is pre-populated.\n",
+    "- `config.evaluation_mode` is set to `\"template_and_rubric\"` (the caller should not preset a conflicting mode; the helper rewrites it to `\"rubric_only\"` internally).\n",
+    "- The benchmark has no rubric attached anywhere (global or per-question) for any question in `prior_results`.\n",
+    "- Any attached rubric contains metric traits.\n",
+    "- `config.answering_models`, `config.parsing_models`, or `config.replicate_count` disagree with the observed prior shape.\n",
+    "\n",
+    "## 5. Reading the Merged Result\n",
+    "\n",
+    "Both facades return a `VerificationResultSet` with a single `run_name`. They differ in what changes:\n",
+    "\n",
+    "| Aspect | `extend_template` | `extend_rubric` |\n",
+    "|---|---|---|\n",
+    "| Row count vs prior | Can grow | Equal |\n",
+    "| Prior rows | Passed through verbatim | Copied and enriched |\n",
+    "| New rows | Appended | None |\n",
+    "| `rubric.*` fields on prior rows | Unchanged | Populated / unioned |\n",
+    "| `result_id` stability | Preserved on prior rows | Preserved (deep copy keeps the same id) |\n",
+    "\n",
+    "The `run_name` on every row is stamped to the effective name: the `run_name=` override if passed, otherwise the run name inferred from `prior_results` (rejected when inconsistent).\n",
+    "\n",
+    "## 6. Storage Flag\n",
+    "\n",
+    "Both facades accept `store: bool = True`. When true, the merged set is written to the benchmark's results manager under the effective `run_name` so `bench.get_verification_results(run_name=...)` can retrieve it. Set `store=False` for exploratory use where you only want the returned object.\n",
+    "\n",
+    "## 7. Further Reading\n",
+    "\n",
+    "- [Verification Pipeline](../verification-pipeline/): the 13-stage engine both facades drive.\n",
+    "- [Evaluation Modes](../evaluation-modes/): how `rubric_only` differs from `template_only` and `template_and_rubric`.\n",
+    "- [Rubrics](../../../core_concepts/rubrics/): trait types and `DynamicRubric`.\n",
+    "- `karenina/src/karenina/benchmark/verification/extension.py`: the helper implementations (`extend_template_run`, `extend_rubric_run`) if you need to read the exact validation and merge code."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "formats": "docs/core_concepts//md,docs/notebooks/core_concepts//ipynb"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/karenina/benchmark/benchmark.py
+++ b/src/karenina/benchmark/benchmark.py
@@ -1085,6 +1085,81 @@ class Benchmark:
             self._results_manager.store_verification_results(results_dict, effective_run_name)
         return merged
 
+    def extend_rubric(
+        self,
+        prior_results: VerificationResultSet,
+        config: VerificationConfig,
+        *,
+        run_name: str | None = None,
+        question_ids: list[str] | None = None,
+        async_enabled: bool | None = None,
+        progress_callback: Callable[[float, str], None] | None = None,
+        store: bool = True,
+    ) -> VerificationResultSet:
+        """Attach a new rubric to a prior verification run.
+
+        Enriches every row of ``prior_results`` with rubric scores
+        produced against the rubric currently attached to this benchmark
+        (global and per-question). Answering is replayed from the prior
+        traces; template parsing and verification are skipped. Row count
+        is preserved: the merged set has the same shape as
+        ``prior_results`` with a populated ``rubric`` sub-object on each
+        row.
+
+        Trait scores are unioned with any rubric fields already present
+        on prior rows. Same-name trait collisions raise ``ValueError``.
+
+        Args:
+            prior_results: Result set from an earlier ``run_verification``
+                call.
+            config: Verification configuration matching the shape of
+                ``prior_results``. ``answering_models``,
+                ``parsing_models``, and ``replicate_count`` must equal
+                the values observed in ``prior_results``.
+                ``replay_store`` must be ``None``;
+                ``evaluation_mode`` must be ``"template_only"`` or
+                ``"rubric_only"`` (the helper rewrites it internally).
+            run_name: Optional override for the merged run name.
+            question_ids: Optional subset of question IDs.
+            async_enabled: Forwarded to ``run_verification``.
+            progress_callback: Forwarded to ``run_verification``.
+            store: When True (default), write the merged set into the
+                results manager.
+
+        Returns:
+            ``VerificationResultSet`` of enriched prior rows.
+
+        Raises:
+            ValueError: On input validation failure; see
+                :func:`~karenina.benchmark.verification.extension.extend_rubric_run`.
+        """
+        from .verification.extension import extend_rubric_run
+
+        merged = extend_rubric_run(
+            self,
+            prior_results,
+            config,
+            run_name=run_name,
+            question_ids=question_ids,
+            async_enabled=async_enabled,
+            progress_callback=progress_callback,
+        )
+        if store:
+            results_dict: dict[str, VerificationResult] = {}
+            for idx, row in enumerate(merged.results):
+                md = row.metadata
+                key = f"{md.question_id}_{md.answering_model}_{md.parsing_model}"
+                if md.replicate is not None:
+                    key += f"_rep{md.replicate}"
+                if md.timestamp:
+                    key += f"_{md.timestamp}"
+                if key in results_dict:
+                    key += f"_{idx}"
+                results_dict[key] = row
+            effective_run_name = merged.results[0].metadata.run_name if merged.results else run_name
+            self._results_manager.store_verification_results(results_dict, effective_run_name)
+        return merged
+
     # ── Results management ───────────────────────────────────────────────
 
     def store_verification_results(

--- a/src/karenina/benchmark/benchmark.py
+++ b/src/karenina/benchmark/benchmark.py
@@ -1007,7 +1007,7 @@ class Benchmark:
             errors=[(d, e) for d, e in errors] if errors else None,
         )
 
-    def extend_judgment(
+    def extend_template(
         self,
         prior_results: VerificationResultSet,
         config: VerificationConfig,
@@ -1058,9 +1058,9 @@ class Benchmark:
             Merged ``VerificationResultSet`` with the prior rows plus the
             newly-produced rows, all stamped with the effective ``run_name``.
         """
-        from .verification.extension import extend_verification_run
+        from .verification.extension import extend_template_run
 
-        merged = extend_verification_run(
+        merged = extend_template_run(
             self,
             prior_results,
             config,

--- a/src/karenina/benchmark/benchmark.py
+++ b/src/karenina/benchmark/benchmark.py
@@ -1018,22 +1018,30 @@ class Benchmark:
         progress_callback: Callable[[float, str], None] | None = None,
         store: bool = True,
     ) -> VerificationResultSet:
-        """Extend a prior verification run with additional parsing models via replay.
+        """Extend a prior verification run along any combination of three axes.
 
-        Reuses the answering traces captured in ``prior_results`` (no live
-        answering calls), runs the parsing / judgment / rubric stages against
-        ``config.parsing_models`` (the new judges), and returns a single merged
-        ``VerificationResultSet`` under one ``run_name``. The output shape
-        matches a joint ``parsing_models=[j1, j2, ...]`` run.
+        Axes, all optional and composable in a single call:
+
+        1. New judges (``config.parsing_models``).
+        2. New answerers (``config.answering_models``).
+        3. More replicates (higher ``config.replicate_count``).
+
+        Prior ``(question, answerer, replicate)`` answering traces are served
+        from a :class:`~karenina.replay.ReplayStore`; new answerers, new
+        replicates, or any combination thereof run answering live. Parsing
+        always runs live. Triples already present in ``prior_results`` are
+        skipped so prior rows pass through verbatim. The merged output matches
+        a joint run over the full ``(answerers × judges × replicates)`` matrix.
 
         Args:
             prior_results: Result set from an earlier ``run_verification``
                 call to extend.
-            config: Verification configuration for the extension. Must carry
-                the new parsing models in ``parsing_models``, the original
-                answering model(s) in ``answering_models``, and the same
-                ``replicate_count`` observed in ``prior_results``.
-                ``config.replay_store`` must be ``None``.
+            config: Verification configuration describing the **final**
+                state (full union, not deltas): every judge in
+                ``parsing_models``, every answerer in ``answering_models``,
+                and the final ``replicate_count`` (must be ``>=`` observed
+                in ``prior_results``). ``config.replay_store`` must be
+                ``None``.
             run_name: Optional override for the merged run name. Defaults to
                 the run name carried by ``prior_results``.
             question_ids: Optional subset of question IDs to re-judge.

--- a/src/karenina/benchmark/benchmark.py
+++ b/src/karenina/benchmark/benchmark.py
@@ -1007,6 +1007,76 @@ class Benchmark:
             errors=[(d, e) for d, e in errors] if errors else None,
         )
 
+    def extend_judgment(
+        self,
+        prior_results: VerificationResultSet,
+        config: VerificationConfig,
+        *,
+        run_name: str | None = None,
+        question_ids: list[str] | None = None,
+        async_enabled: bool | None = None,
+        progress_callback: Callable[[float, str], None] | None = None,
+        store: bool = True,
+    ) -> VerificationResultSet:
+        """Extend a prior verification run with additional parsing models via replay.
+
+        Reuses the answering traces captured in ``prior_results`` (no live
+        answering calls), runs the parsing / judgment / rubric stages against
+        ``config.parsing_models`` (the new judges), and returns a single merged
+        ``VerificationResultSet`` under one ``run_name``. The output shape
+        matches a joint ``parsing_models=[j1, j2, ...]`` run.
+
+        Args:
+            prior_results: Result set from an earlier ``run_verification``
+                call to extend.
+            config: Verification configuration for the extension. Must carry
+                the new parsing models in ``parsing_models``, the original
+                answering model(s) in ``answering_models``, and the same
+                ``replicate_count`` observed in ``prior_results``.
+                ``config.replay_store`` must be ``None``.
+            run_name: Optional override for the merged run name. Defaults to
+                the run name carried by ``prior_results``.
+            question_ids: Optional subset of question IDs to re-judge.
+                Defaults to every question present in ``prior_results``.
+            async_enabled: Optional async control forwarded to
+                ``run_verification``.
+            progress_callback: Optional progress callback forwarded to
+                ``run_verification``.
+            store: When True (default), also store the merged set into the
+                in-memory results manager under ``run_name`` so it is
+                available to ``get_verification_results`` and the exporters.
+
+        Returns:
+            Merged ``VerificationResultSet`` with the prior rows plus the
+            newly-produced rows, all stamped with the effective ``run_name``.
+        """
+        from .verification.extension import extend_verification_run
+
+        merged = extend_verification_run(
+            self,
+            prior_results,
+            config,
+            run_name=run_name,
+            question_ids=question_ids,
+            async_enabled=async_enabled,
+            progress_callback=progress_callback,
+        )
+        if store:
+            results_dict: dict[str, VerificationResult] = {}
+            for idx, row in enumerate(merged.results):
+                md = row.metadata
+                key = f"{md.question_id}_{md.answering_model}_{md.parsing_model}"
+                if md.replicate is not None:
+                    key += f"_rep{md.replicate}"
+                if md.timestamp:
+                    key += f"_{md.timestamp}"
+                if key in results_dict:
+                    key += f"_{idx}"
+                results_dict[key] = row
+            effective_run_name = merged.results[0].metadata.run_name if merged.results else run_name
+            self._results_manager.store_verification_results(results_dict, effective_run_name)
+        return merged
+
     # ── Results management ───────────────────────────────────────────────
 
     def store_verification_results(

--- a/src/karenina/benchmark/verification/__init__.py
+++ b/src/karenina/benchmark/verification/__init__.py
@@ -11,7 +11,7 @@ from .executor import (
     get_async_portal,
     set_async_portal,
 )
-from .extension import extend_verification_run
+from .extension import extend_template_run
 from .stages import (
     export_verification_results_csv,
     export_verification_results_json,
@@ -26,7 +26,7 @@ __all__ = [
     "execute_task",
     "auto_save_results",
     # Extension
-    "extend_verification_run",
+    "extend_template_run",
     # Executor
     "VerificationExecutor",
     "ExecutorConfig",

--- a/src/karenina/benchmark/verification/__init__.py
+++ b/src/karenina/benchmark/verification/__init__.py
@@ -11,6 +11,7 @@ from .executor import (
     get_async_portal,
     set_async_portal,
 )
+from .extension import extend_verification_run
 from .stages import (
     export_verification_results_csv,
     export_verification_results_json,
@@ -24,6 +25,8 @@ __all__ = [
     "generate_task_queue",
     "execute_task",
     "auto_save_results",
+    # Extension
+    "extend_verification_run",
     # Executor
     "VerificationExecutor",
     "ExecutorConfig",

--- a/src/karenina/benchmark/verification/batch_runner.py
+++ b/src/karenina/benchmark/verification/batch_runner.py
@@ -93,6 +93,10 @@ def generate_task_queue(
         List of task dictionaries with all arguments for verification
     """
     tasks = []
+    skip_triples = config.skip_triples
+    n_skipped = 0
+    if skip_triples is not None:
+        from karenina.schemas.verification.model_identity import ModelIdentity
 
     for template in templates:
         # Prepare rubric for this question
@@ -117,6 +121,13 @@ def generate_task_queue(
                 for rep in range(1, config.replicate_count + 1):
                     # For single replicate, don't include replicate numbers
                     replicate = None if config.replicate_count == 1 else rep
+
+                    if skip_triples is not None:
+                        ans_key = ModelIdentity.from_model_config(ans_model, role="answering").canonical_key
+                        parse_key = ModelIdentity.from_model_config(parse_model, role="parsing").canonical_key
+                        if (template.question_id, ans_key, parse_key, replicate) in skip_triples:
+                            n_skipped += 1
+                            continue
 
                     task = {
                         # Core
@@ -151,6 +162,9 @@ def generate_task_queue(
                     if workspace_root is not None:
                         task["workspace_root"] = workspace_root
                     tasks.append(task)
+
+    if skip_triples is not None and n_skipped:
+        logger.info("generate_task_queue: skipped %d tasks covered by prior_results", n_skipped)
 
     return tasks
 

--- a/src/karenina/benchmark/verification/extension.py
+++ b/src/karenina/benchmark/verification/extension.py
@@ -1,9 +1,10 @@
-"""Extend a prior verification run with additional parsing models via replay.
+"""Extend a prior verification run along three axes: judges, answerers, replicates.
 
-Mirrors the error-analysis facade pattern: result-set-in, result-set-out. The
-heavy lifting is delegated to the existing batch runner through
-``Benchmark.run_verification`` with a ``VerificationConfig.replay_store`` set
-to a store built from the prior results, so answering is never re-executed.
+Mirrors the error-analysis facade pattern: result-set-in, result-set-out. A
+``ReplayStore`` built from the prior results serves the answering stage for
+triples already covered; new answerers or replicates miss and run live.
+``VerificationConfig.skip_triples`` tells the batch runner to drop tasks
+already present in ``prior_results`` so those rows pass through verbatim.
 """
 
 from __future__ import annotations
@@ -34,14 +35,22 @@ def extend_verification_run(
     async_enabled: bool | None = None,
     progress_callback: Callable[[float, str], None] | None = None,
 ) -> VerificationResultSet:
-    """Re-judge a prior verification run with additional parsing models.
+    """Extend a prior verification run along any combination of three axes.
 
-    Builds a :class:`~karenina.replay.ReplayStore` from ``prior_results`` and
-    attaches it to a clone of ``config`` so that the answering stage is served
-    from replay. The parsing stages run live against ``config.parsing_models``
-    (the new judges). The returned set merges the original results with the
-    newly produced ones, stamped with a single ``run_name`` so its shape
-    matches a joint ``parsing_models=[j1, j2]`` run.
+    The axes, all optional and composable in a single call:
+
+    1. **Parsing models (judges)**: new judge(s) in ``config.parsing_models``.
+    2. **Answering models**: new answerer(s) in ``config.answering_models``.
+    3. **Replicates**: higher ``config.replicate_count`` than the prior fan-out.
+
+    A :class:`~karenina.replay.ReplayStore` is built from ``prior_results`` so
+    that prior ``(question, answerer, replicate)`` combinations serve the
+    answering stage from replay. New answerers, new replicates, or any
+    combination thereof miss the store and run answering live. Parsing
+    always runs live. Triples already covered by ``prior_results`` are
+    filtered out of the task queue so prior rows pass through the merge
+    verbatim. The returned set matches the shape of a joint run with the
+    full ``(answerers × judges × replicates)`` matrix.
 
     Args:
         benchmark: The :class:`Benchmark` whose questions and templates the
@@ -49,14 +58,17 @@ def extend_verification_run(
             on this benchmark.
         prior_results: Result set from an earlier ``run_verification`` call
             to extend. Must be non-empty.
-        config: Verification configuration for the extension. Must carry:
+        config: Verification configuration for the extension. Must describe
+            the **final** state (full union, not deltas):
 
-            - ``parsing_models`` = the new judge(s) to run (not the original).
-            - ``answering_models`` = the same answering model(s) used for
-              ``prior_results`` (identity is compared via
+            - ``parsing_models`` = every judge you want in the merged output
+              (old judges from ``prior_results`` + any new judges).
+            - ``answering_models`` = every answerer you want in the merged
+              output. Must be a superset of the answering identities in
+              ``prior_results`` (compared via
               :meth:`ModelIdentity.from_model_config`).
-            - ``replicate_count`` = the number of replicates present in
-              ``prior_results``.
+            - ``replicate_count`` = the final number of replicates. Must be
+              ``>=`` the fan-out observed in ``prior_results``.
             - ``replay_store`` must be ``None`` (the extension owns that slot).
         run_name: Optional override for the merged run name. Defaults to the
             run name carried by ``prior_results`` when all rows agree; raises
@@ -98,7 +110,31 @@ def extend_verification_run(
         len(prior_results.results),
     )
 
-    extended_config = config.model_copy(update={"replay_store": replay_store})
+    skip_triples = frozenset(
+        (
+            r.metadata.question_id,
+            r.metadata.answering.canonical_key,
+            r.metadata.parsing.canonical_key,
+            r.metadata.replicate,
+        )
+        for r in prior_results.results
+    )
+
+    observed_replicates = _observed_replicate_count(prior_results)
+    prior_answering_keys: set[str] = {r.metadata.answering.canonical_key for r in prior_results.results}
+    new_answering_keys = sorted(
+        {ModelIdentity.from_model_config(m, role="answering").canonical_key for m in config.answering_models}
+        - prior_answering_keys
+    )
+    added_replicates = config.replicate_count - observed_replicates
+    logger.info(
+        "extend_judgment: new answerers=%s, added replicates=%d, skip_triples=%d",
+        new_answering_keys or "[]",
+        added_replicates,
+        len(skip_triples),
+    )
+
+    extended_config = config.model_copy(update={"replay_store": replay_store, "skip_triples": skip_triples})
 
     new_results = benchmark.run_verification(
         config=extended_config,
@@ -168,13 +204,7 @@ def _validate_answering_identity(
         )
 
 
-def _validate_replicate_count(
-    prior_results: VerificationResultSet,
-    config: VerificationConfig,
-) -> None:
-    # For each (question_id, answering_identity, parsing_identity) triple, how many
-    # distinct replicate values exist? Expect the max across triples to equal
-    # config.replicate_count so the new judge reproduces the same replicate fan-out.
+def _observed_replicate_count(prior_results: VerificationResultSet) -> int:
     counts_per_triple: Counter[tuple[str, str, str]] = Counter()
     replicate_values: dict[tuple[str, str, str], set[int | None]] = {}
     for r in prior_results.results:
@@ -186,13 +216,23 @@ def _validate_replicate_count(
         replicate_values.setdefault(key, set()).add(r.metadata.replicate)
     for key, values in replicate_values.items():
         counts_per_triple[key] = len(values)
+    return max(counts_per_triple.values()) if counts_per_triple else 0
 
-    observed = max(counts_per_triple.values()) if counts_per_triple else 0
-    if observed != config.replicate_count:
+
+def _validate_replicate_count(
+    prior_results: VerificationResultSet,
+    config: VerificationConfig,
+) -> None:
+    # config.replicate_count must be >= the replicate fan-out observed in
+    # prior_results. Equal => pure judge/answerer extension; greater => also
+    # adds replicates. Less is rejected: replicate reduction is out of scope.
+    observed = _observed_replicate_count(prior_results)
+    if config.replicate_count < observed:
         raise ValueError(
-            f"config.replicate_count={config.replicate_count} does not match the "
-            f"replicate fan-out observed in prior_results (={observed}). The extended "
-            "run must match the original replicate count so replay keys line up."
+            f"config.replicate_count={config.replicate_count} is lower than the "
+            f"replicate fan-out observed in prior_results (={observed}). Replicate "
+            "reduction is not supported by extend_judgment; pass "
+            f"replicate_count>={observed}."
         )
 
 

--- a/src/karenina/benchmark/verification/extension.py
+++ b/src/karenina/benchmark/verification/extension.py
@@ -5,6 +5,14 @@ Mirrors the error-analysis facade pattern: result-set-in, result-set-out. A
 triples already covered; new answerers or replicates miss and run live.
 ``VerificationConfig.skip_triples`` tells the batch runner to drop tasks
 already present in ``prior_results`` so those rows pass through verbatim.
+
+This module also hosts :func:`extend_rubric_run`, a sibling facade for
+attaching a new rubric to a prior run. Unlike the judge/answerer/replicate
+extension, rubric extension enriches prior rows in-place: answering is
+replayed, template parsing and verification are skipped
+(``evaluation_mode="rubric_only"``), and the resulting rubric scores are
+merged trait-by-trait onto the prior rows. Shape and row count are
+preserved; same-name trait collisions raise.
 """
 
 from __future__ import annotations
@@ -16,11 +24,19 @@ from typing import TYPE_CHECKING, Any
 
 from karenina.replay import capture_from_result_set
 from karenina.schemas.results import VerificationResultSet
-from karenina.schemas.verification import VerificationConfig
+from karenina.schemas.verification import VerificationConfig, VerificationResult
 from karenina.schemas.verification.model_identity import ModelIdentity
 
 if TYPE_CHECKING:
     from karenina.benchmark import Benchmark
+    from karenina.schemas.entities.rubric import (
+        AgenticRubricTrait,
+        CallableRubricTrait,
+        LLMRubricTrait,
+        MetricRubricTrait,
+        RegexRubricTrait,
+        Rubric,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -276,3 +292,367 @@ def _merge(
         scenario_results=scenario_results,
         errors=errors,
     )
+
+
+# ----------------------------------------------------------------------
+# Rubric extension: attach a new rubric to an existing run
+# ----------------------------------------------------------------------
+
+
+_RUBRIC_TRAIT_BUCKETS: tuple[str, ...] = (
+    "llm_trait_scores",
+    "llm_trait_labels",
+    "regex_trait_scores",
+    "callable_trait_scores",
+    "agentic_trait_scores",
+    "agentic_trait_investigation_traces",
+)
+
+
+def extend_rubric_run(
+    benchmark: Benchmark,
+    prior_results: VerificationResultSet,
+    config: VerificationConfig,
+    *,
+    run_name: str | None = None,
+    question_ids: list[str] | None = None,
+    async_enabled: bool | None = None,
+    progress_callback: Callable[[float, str], None] | None = None,
+) -> VerificationResultSet:
+    """Attach a new rubric to an existing verification run.
+
+    The caller sets the new rubric on ``benchmark`` (global and/or
+    per-question) *before* invoking this helper. A replay store built
+    from ``prior_results`` serves the answering stage, the pipeline
+    runs in ``evaluation_mode="rubric_only"`` (template verification
+    skipped), and the resulting rubric scores are merged
+    trait-by-trait onto copies of the prior rows. Row count is
+    preserved: the merged set has exactly ``len(prior_results.results)``
+    entries.
+
+    Args:
+        benchmark: The :class:`Benchmark` carrying the new rubric(s).
+        prior_results: Result set from an earlier ``run_verification``
+            call. Must be non-empty.
+        config: Verification configuration describing the **same shape**
+            as ``prior_results`` (``answering_models``,
+            ``parsing_models``, ``replicate_count`` must equal the
+            observed prior shape). ``replay_store`` must be ``None``;
+            the helper owns that slot. ``evaluation_mode`` must be
+            either the default ``"template_only"`` or ``"rubric_only"``
+            (the helper rewrites it internally).
+        run_name: Optional override for the merged run name. Defaults
+            to the run name carried by ``prior_results``.
+        question_ids: Optional subset of question IDs. Defaults to every
+            question present in ``prior_results``.
+        async_enabled: Forwarded to ``run_verification``.
+        progress_callback: Forwarded to ``run_verification``.
+
+    Returns:
+        ``VerificationResultSet`` of enriched prior rows (same count as
+        ``prior_results.results``) carrying the new rubric scores.
+
+    Raises:
+        ValueError: On any input validation failure (empty prior set,
+            shape mismatch, pre-populated ``replay_store``, unsupported
+            ``evaluation_mode``, no rubric attached, metric traits
+            present, inconsistent run names without override, trait
+            name collision, or shape corruption at merge time).
+    """
+    _validate_rubric_extension(benchmark, prior_results, config, run_name)
+
+    effective_run_name = run_name or _infer_run_name(prior_results)
+    effective_question_ids = (
+        list(question_ids)
+        if question_ids is not None
+        else sorted({r.metadata.question_id for r in prior_results.results})
+    )
+
+    replay_store = capture_from_result_set(
+        prior_results,
+        include_parsed=False,
+        include_agent_traces=True,
+        only_successful=False,
+        replicate_selector="all",
+    )
+    logger.info(
+        "extend_rubric: captured replay store with %d entries from %d prior results",
+        len(replay_store.entries),
+        len(prior_results.results),
+    )
+
+    extended_config = config.model_copy(update={"replay_store": replay_store, "evaluation_mode": "rubric_only"})
+
+    new_results = benchmark.run_verification(
+        config=extended_config,
+        question_ids=effective_question_ids,
+        run_name=effective_run_name,
+        async_enabled=async_enabled,
+        progress_callback=progress_callback,
+    )
+
+    enriched = _enrich_with_rubric(prior_results, new_results, effective_run_name)
+    logger.info(
+        "extend_rubric: enriched %d prior rows under run_name=%r",
+        len(enriched.results),
+        effective_run_name,
+    )
+    return enriched
+
+
+def _validate_rubric_extension(
+    benchmark: Benchmark,
+    prior_results: VerificationResultSet,
+    config: VerificationConfig,
+    run_name_override: str | None,
+) -> None:
+    if not prior_results.results:
+        raise ValueError("prior_results must contain at least one VerificationResult")
+
+    if not config.answering_models:
+        raise ValueError("config.answering_models must be non-empty")
+
+    if not config.parsing_models:
+        raise ValueError("config.parsing_models must be non-empty")
+
+    if config.replay_store is not None:
+        raise ValueError(
+            "config.replay_store must be None; extend_rubric builds the replay store internally from prior_results"
+        )
+
+    if config.evaluation_mode not in ("template_only", "rubric_only"):
+        raise ValueError(
+            "config.evaluation_mode must be 'template_only' or 'rubric_only' for extend_rubric "
+            f"(got {config.evaluation_mode!r}); the helper rewrites it to 'rubric_only' internally"
+        )
+
+    _validate_answering_identity(prior_results, config)
+    _validate_parsing_identity(prior_results, config)
+    _validate_replicate_count_equals(prior_results, config)
+
+    rubric = _collect_active_rubric(benchmark, prior_results)
+    if rubric is None:
+        raise ValueError(
+            "benchmark has no rubric attached (global or per-question) for any question in prior_results; "
+            "set a rubric before calling extend_rubric"
+        )
+    if rubric.metric_traits:
+        raise ValueError(
+            "Metric traits are not supported by extend_rubric in v1; "
+            "remove them from the rubric or use template_and_rubric on a fresh run"
+        )
+
+    if run_name_override is None:
+        _infer_run_name(prior_results)
+
+
+def _validate_parsing_identity(
+    prior_results: VerificationResultSet,
+    config: VerificationConfig,
+) -> None:
+    prior_parsing: set[str] = {r.metadata.parsing.canonical_key for r in prior_results.results}
+    configured_parsing: set[str] = {
+        ModelIdentity.from_model_config(m, role="parsing").canonical_key for m in config.parsing_models
+    }
+    if prior_parsing != configured_parsing:
+        raise ValueError(
+            "config.parsing_models does not match the parsing identities in prior_results. "
+            f"Configured: {sorted(configured_parsing)}. Observed in prior: {sorted(prior_parsing)}."
+        )
+
+
+def _validate_replicate_count_equals(
+    prior_results: VerificationResultSet,
+    config: VerificationConfig,
+) -> None:
+    observed = _observed_replicate_count(prior_results)
+    if observed == 0:
+        return
+    if config.replicate_count != observed:
+        raise ValueError(
+            f"config.replicate_count={config.replicate_count} does not match the replicate "
+            f"fan-out observed in prior_results (={observed}). extend_rubric preserves the "
+            "prior shape; pass replicate_count equal to the observed count."
+        )
+
+
+def _collect_active_rubric(
+    benchmark: Benchmark,
+    prior_results: VerificationResultSet,
+) -> Rubric | None:
+    """Return a synthetic Rubric merging every trait that will run under extend_rubric.
+
+    Combines the global rubric with every per-question rubric bound to a
+    question appearing in ``prior_results``. The result is used only for
+    validation (presence check + metric-trait rejection); the pipeline
+    still resolves rubrics per-question at runtime.
+    """
+    from karenina.schemas.entities import Rubric
+
+    llm: list[LLMRubricTrait] = []
+    regex: list[RegexRubricTrait] = []
+    callbl: list[CallableRubricTrait] = []
+    metric: list[MetricRubricTrait] = []
+    agentic: list[AgenticRubricTrait] = []
+
+    global_rubric = benchmark._rubric_manager.get_global_rubric()
+    if global_rubric is not None:
+        llm.extend(global_rubric.llm_traits)
+        regex.extend(global_rubric.regex_traits)
+        callbl.extend(global_rubric.callable_traits)
+        metric.extend(global_rubric.metric_traits)
+        agentic.extend(global_rubric.agentic_traits)
+
+    qids = {r.metadata.question_id for r in prior_results.results}
+    for qid in qids:
+        try:
+            qrubric = benchmark._rubric_manager.get_merged_rubric_for_question(qid)
+        except Exception:  # noqa: BLE001
+            qrubric = None
+        if qrubric is None:
+            continue
+        # merged_rubric already includes the global traits; extend from a
+        # fresh view to avoid duplicate collection. We only pick up
+        # question-specific additions by diffing trait names.
+        all_current: list[
+            LLMRubricTrait | RegexRubricTrait | CallableRubricTrait | MetricRubricTrait | AgenticRubricTrait
+        ] = [
+            *llm,
+            *regex,
+            *callbl,
+            *metric,
+            *agentic,
+        ]
+        global_names = {trait.name for trait in all_current}
+        for lt in qrubric.llm_traits:
+            if lt.name not in global_names:
+                llm.append(lt)
+        for rt in qrubric.regex_traits:
+            if rt.name not in global_names:
+                regex.append(rt)
+        for ct in qrubric.callable_traits:
+            if ct.name not in global_names:
+                callbl.append(ct)
+        for mt in qrubric.metric_traits:
+            if mt.name not in global_names:
+                metric.append(mt)
+        for at in qrubric.agentic_traits:
+            if at.name not in global_names:
+                agentic.append(at)
+
+    if not (llm or regex or callbl or metric or agentic):
+        return None
+
+    return Rubric(
+        llm_traits=llm,
+        regex_traits=regex,
+        callable_traits=callbl,
+        metric_traits=metric,
+        agentic_traits=agentic,
+    )
+
+
+def _enrich_with_rubric(
+    prior_results: VerificationResultSet,
+    new_results: VerificationResultSet,
+    run_name: str,
+) -> VerificationResultSet:
+    new_by_triple: dict[tuple[str, str, str, int | None], VerificationResult] = {}
+    for row in new_results.results:
+        key = (
+            row.metadata.question_id,
+            row.metadata.answering.canonical_key,
+            row.metadata.parsing.canonical_key,
+            row.metadata.replicate,
+        )
+        if key in new_by_triple:
+            raise ValueError(
+                f"extend_rubric: rubric-only run produced duplicate rows for triple {key}; shape corruption"
+            )
+        new_by_triple[key] = row
+
+    enriched_rows: list[VerificationResult] = []
+    for prior_row in prior_results.results:
+        key = (
+            prior_row.metadata.question_id,
+            prior_row.metadata.answering.canonical_key,
+            prior_row.metadata.parsing.canonical_key,
+            prior_row.metadata.replicate,
+        )
+        if key not in new_by_triple:
+            raise ValueError(f"extend_rubric: no rubric-only row produced for prior triple {key}; shape corruption")
+        merged_row = prior_row.model_copy(deep=True)
+        if merged_row.rubric is None:
+            from karenina.schemas.verification.result_components import VerificationResultRubric
+
+            merged_row.rubric = VerificationResultRubric()
+        _merge_rubric_onto_row(merged_row, new_by_triple[key])
+        if merged_row.metadata.run_name != run_name:
+            merged_row.metadata.run_name = run_name
+        enriched_rows.append(merged_row)
+
+    return VerificationResultSet(
+        results=enriched_rows,
+        scenario_results=list(prior_results.scenario_results) if prior_results.scenario_results else None,
+        errors=list(prior_results.errors) if prior_results.errors else None,
+    )
+
+
+def _merge_rubric_onto_row(target: VerificationResult, source: VerificationResult) -> None:
+    """Union source.rubric.* trait dicts onto target.rubric.* in place.
+
+    Raises ValueError on same-name trait collision within a bucket.
+    """
+    src_rubric = source.rubric
+    dst_rubric = target.rubric
+    if src_rubric is None or dst_rubric is None:
+        return
+
+    # Mark that rubric evaluation has now been performed on this row.
+    if src_rubric.rubric_evaluation_performed:
+        dst_rubric.rubric_evaluation_performed = True
+    if src_rubric.rubric_evaluation_strategy is not None:
+        dst_rubric.rubric_evaluation_strategy = src_rubric.rubric_evaluation_strategy
+
+    for bucket in _RUBRIC_TRAIT_BUCKETS:
+        src_dict = getattr(src_rubric, bucket)
+        if not src_dict:
+            continue
+        dst_dict = getattr(dst_rubric, bucket)
+        if dst_dict is None:
+            setattr(dst_rubric, bucket, dict(src_dict))
+            continue
+        collisions = set(dst_dict) & set(src_dict)
+        if collisions:
+            raise ValueError(
+                f"extend_rubric: trait name collision in {bucket} for traits "
+                f"{sorted(collisions)}; rename or remove the colliding trait"
+            )
+        merged = dict(dst_dict)
+        merged.update(src_dict)
+        setattr(dst_rubric, bucket, merged)
+
+    # Dynamic-rubric metadata: union with collision rejection on skipped-trait names.
+    if src_rubric.dynamic_rubric_skipped_traits:
+        dst_skipped = dst_rubric.dynamic_rubric_skipped_traits or {}
+        collisions = set(dst_skipped) & set(src_rubric.dynamic_rubric_skipped_traits)
+        if collisions:
+            raise ValueError(
+                f"extend_rubric: trait name collision in dynamic_rubric_skipped_traits for traits {sorted(collisions)}"
+            )
+        merged_skipped = dict(dst_skipped)
+        merged_skipped.update(src_rubric.dynamic_rubric_skipped_traits)
+        dst_rubric.dynamic_rubric_skipped_traits = merged_skipped
+
+    if src_rubric.dynamic_rubric_promoted_traits:
+        existing = list(dst_rubric.dynamic_rubric_promoted_traits or [])
+        for t in src_rubric.dynamic_rubric_promoted_traits:
+            if t not in existing:
+                existing.append(t)
+        dst_rubric.dynamic_rubric_promoted_traits = existing
+
+    if src_rubric.trait_provenance:
+        dst_prov = dst_rubric.trait_provenance or {}
+        merged_prov = dict(dst_prov)
+        merged_prov.update(src_rubric.trait_provenance)
+        dst_rubric.trait_provenance = merged_prov

--- a/src/karenina/benchmark/verification/extension.py
+++ b/src/karenina/benchmark/verification/extension.py
@@ -1,0 +1,238 @@
+"""Extend a prior verification run with additional parsing models via replay.
+
+Mirrors the error-analysis facade pattern: result-set-in, result-set-out. The
+heavy lifting is delegated to the existing batch runner through
+``Benchmark.run_verification`` with a ``VerificationConfig.replay_store`` set
+to a store built from the prior results, so answering is never re-executed.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from karenina.replay import capture_from_result_set
+from karenina.schemas.results import VerificationResultSet
+from karenina.schemas.verification import VerificationConfig
+from karenina.schemas.verification.model_identity import ModelIdentity
+
+if TYPE_CHECKING:
+    from karenina.benchmark import Benchmark
+
+logger = logging.getLogger(__name__)
+
+
+def extend_verification_run(
+    benchmark: Benchmark,
+    prior_results: VerificationResultSet,
+    config: VerificationConfig,
+    *,
+    run_name: str | None = None,
+    question_ids: list[str] | None = None,
+    async_enabled: bool | None = None,
+    progress_callback: Callable[[float, str], None] | None = None,
+) -> VerificationResultSet:
+    """Re-judge a prior verification run with additional parsing models.
+
+    Builds a :class:`~karenina.replay.ReplayStore` from ``prior_results`` and
+    attaches it to a clone of ``config`` so that the answering stage is served
+    from replay. The parsing stages run live against ``config.parsing_models``
+    (the new judges). The returned set merges the original results with the
+    newly produced ones, stamped with a single ``run_name`` so its shape
+    matches a joint ``parsing_models=[j1, j2]`` run.
+
+    Args:
+        benchmark: The :class:`Benchmark` whose questions and templates the
+            prior run evaluated. Question IDs on ``prior_results`` must exist
+            on this benchmark.
+        prior_results: Result set from an earlier ``run_verification`` call
+            to extend. Must be non-empty.
+        config: Verification configuration for the extension. Must carry:
+
+            - ``parsing_models`` = the new judge(s) to run (not the original).
+            - ``answering_models`` = the same answering model(s) used for
+              ``prior_results`` (identity is compared via
+              :meth:`ModelIdentity.from_model_config`).
+            - ``replicate_count`` = the number of replicates present in
+              ``prior_results``.
+            - ``replay_store`` must be ``None`` (the extension owns that slot).
+        run_name: Optional override for the merged run name. Defaults to the
+            run name carried by ``prior_results`` when all rows agree; raises
+            ``ValueError`` on disagreement when no override is supplied.
+        question_ids: Optional subset of question IDs to re-judge. Defaults
+            to every question in ``prior_results``.
+        async_enabled: Forwarded to ``run_verification``.
+        progress_callback: Forwarded to ``run_verification``.
+
+    Returns:
+        Merged ``VerificationResultSet`` with ``len(prior_results.results)
+        + len(new.results)`` rows, all stamped with the effective ``run_name``.
+
+    Raises:
+        ValueError: On any input validation failure (empty prior set, missing
+            parsing models, answering identity mismatch, replicate count
+            mismatch, pre-populated ``replay_store``, or inconsistent run
+            names without an override).
+    """
+    _validate(prior_results, config, run_name)
+
+    effective_run_name = run_name or _infer_run_name(prior_results)
+    effective_question_ids = (
+        list(question_ids)
+        if question_ids is not None
+        else sorted({r.metadata.question_id for r in prior_results.results})
+    )
+
+    replay_store = capture_from_result_set(
+        prior_results,
+        include_parsed=False,
+        include_agent_traces=True,
+        only_successful=False,
+        replicate_selector="all",
+    )
+    logger.info(
+        "extend_judgment: captured replay store with %d entries from %d prior results",
+        len(replay_store.entries),
+        len(prior_results.results),
+    )
+
+    extended_config = config.model_copy(update={"replay_store": replay_store})
+
+    new_results = benchmark.run_verification(
+        config=extended_config,
+        question_ids=effective_question_ids,
+        run_name=effective_run_name,
+        async_enabled=async_enabled,
+        progress_callback=progress_callback,
+    )
+
+    merged = _merge(prior_results, new_results, effective_run_name)
+    logger.info(
+        "extend_judgment: merged %d prior + %d new = %d total results under run_name=%r",
+        len(prior_results.results),
+        len(new_results.results),
+        len(merged.results),
+        effective_run_name,
+    )
+    return merged
+
+
+# ----------------------------------------------------------------------
+# Validation
+# ----------------------------------------------------------------------
+
+
+def _validate(
+    prior_results: VerificationResultSet,
+    config: VerificationConfig,
+    run_name_override: str | None,
+) -> None:
+    if not prior_results.results:
+        raise ValueError("prior_results must contain at least one VerificationResult")
+
+    if not config.parsing_models:
+        raise ValueError("config.parsing_models must be non-empty (supply the new judges)")
+
+    if not config.answering_models:
+        raise ValueError("config.answering_models must be non-empty")
+
+    if config.replay_store is not None:
+        raise ValueError(
+            "config.replay_store must be None; extend_judgment builds the replay store internally from prior_results"
+        )
+
+    _validate_answering_identity(prior_results, config)
+    _validate_replicate_count(prior_results, config)
+
+    if run_name_override is None:
+        # Probe run_name consistency early; _infer_run_name will raise the real error.
+        _infer_run_name(prior_results)
+
+
+def _validate_answering_identity(
+    prior_results: VerificationResultSet,
+    config: VerificationConfig,
+) -> None:
+    prior_answering: set[str] = {r.metadata.answering.canonical_key for r in prior_results.results}
+    configured_answering: set[str] = {
+        ModelIdentity.from_model_config(m, role="answering").canonical_key for m in config.answering_models
+    }
+    missing = prior_answering - configured_answering
+    if missing:
+        raise ValueError(
+            "config.answering_models does not cover the answering identities in "
+            f"prior_results. Missing keys: {sorted(missing)}. Configured keys: "
+            f"{sorted(configured_answering)}."
+        )
+
+
+def _validate_replicate_count(
+    prior_results: VerificationResultSet,
+    config: VerificationConfig,
+) -> None:
+    # For each (question_id, answering_identity, parsing_identity) triple, how many
+    # distinct replicate values exist? Expect the max across triples to equal
+    # config.replicate_count so the new judge reproduces the same replicate fan-out.
+    counts_per_triple: Counter[tuple[str, str, str]] = Counter()
+    replicate_values: dict[tuple[str, str, str], set[int | None]] = {}
+    for r in prior_results.results:
+        key = (
+            r.metadata.question_id,
+            r.metadata.answering.canonical_key,
+            r.metadata.parsing.canonical_key,
+        )
+        replicate_values.setdefault(key, set()).add(r.metadata.replicate)
+    for key, values in replicate_values.items():
+        counts_per_triple[key] = len(values)
+
+    observed = max(counts_per_triple.values()) if counts_per_triple else 0
+    if observed != config.replicate_count:
+        raise ValueError(
+            f"config.replicate_count={config.replicate_count} does not match the "
+            f"replicate fan-out observed in prior_results (={observed}). The extended "
+            "run must match the original replicate count so replay keys line up."
+        )
+
+
+def _infer_run_name(prior_results: VerificationResultSet) -> str:
+    names: set[str] = {r.metadata.run_name for r in prior_results.results if r.metadata.run_name is not None}
+    if len(names) == 0:
+        raise ValueError("prior_results rows have no run_name; pass run_name= explicitly to extend_judgment")
+    if len(names) > 1:
+        raise ValueError(
+            f"prior_results rows carry inconsistent run_names ({sorted(names)}); "
+            "pass run_name= explicitly to extend_judgment"
+        )
+    return next(iter(names))
+
+
+# ----------------------------------------------------------------------
+# Merge
+# ----------------------------------------------------------------------
+
+
+def _merge(
+    prior_results: VerificationResultSet,
+    new_results: VerificationResultSet,
+    run_name: str,
+) -> VerificationResultSet:
+    merged_rows = list(prior_results.results) + list(new_results.results)
+    for row in merged_rows:
+        if row.metadata.run_name != run_name:
+            row.metadata.run_name = run_name
+
+    scenario_results: list[Any] | None = None
+    if prior_results.scenario_results or new_results.scenario_results:
+        scenario_results = list(prior_results.scenario_results or []) + list(new_results.scenario_results or [])
+
+    errors: list[tuple[str, BaseException]] | None = None
+    if prior_results.errors or new_results.errors:
+        errors = list(prior_results.errors or []) + list(new_results.errors or [])
+
+    return VerificationResultSet(
+        results=merged_rows,
+        scenario_results=scenario_results,
+        errors=errors,
+    )

--- a/src/karenina/benchmark/verification/extension.py
+++ b/src/karenina/benchmark/verification/extension.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def extend_verification_run(
+def extend_template_run(
     benchmark: Benchmark,
     prior_results: VerificationResultSet,
     config: VerificationConfig,
@@ -121,7 +121,7 @@ def extend_verification_run(
         replicate_selector="all",
     )
     logger.info(
-        "extend_judgment: captured replay store with %d entries from %d prior results",
+        "extend_template: captured replay store with %d entries from %d prior results",
         len(replay_store.entries),
         len(prior_results.results),
     )
@@ -144,7 +144,7 @@ def extend_verification_run(
     )
     added_replicates = config.replicate_count - observed_replicates
     logger.info(
-        "extend_judgment: new answerers=%s, added replicates=%d, skip_triples=%d",
+        "extend_template: new answerers=%s, added replicates=%d, skip_triples=%d",
         new_answering_keys or "[]",
         added_replicates,
         len(skip_triples),
@@ -162,7 +162,7 @@ def extend_verification_run(
 
     merged = _merge(prior_results, new_results, effective_run_name)
     logger.info(
-        "extend_judgment: merged %d prior + %d new = %d total results under run_name=%r",
+        "extend_template: merged %d prior + %d new = %d total results under run_name=%r",
         len(prior_results.results),
         len(new_results.results),
         len(merged.results),
@@ -192,7 +192,7 @@ def _validate(
 
     if config.replay_store is not None:
         raise ValueError(
-            "config.replay_store must be None; extend_judgment builds the replay store internally from prior_results"
+            "config.replay_store must be None; extend_template builds the replay store internally from prior_results"
         )
 
     _validate_answering_identity(prior_results, config)
@@ -247,7 +247,7 @@ def _validate_replicate_count(
         raise ValueError(
             f"config.replicate_count={config.replicate_count} is lower than the "
             f"replicate fan-out observed in prior_results (={observed}). Replicate "
-            "reduction is not supported by extend_judgment; pass "
+            "reduction is not supported by extend_template; pass "
             f"replicate_count>={observed}."
         )
 
@@ -255,11 +255,11 @@ def _validate_replicate_count(
 def _infer_run_name(prior_results: VerificationResultSet) -> str:
     names: set[str] = {r.metadata.run_name for r in prior_results.results if r.metadata.run_name is not None}
     if len(names) == 0:
-        raise ValueError("prior_results rows have no run_name; pass run_name= explicitly to extend_judgment")
+        raise ValueError("prior_results rows have no run_name; pass run_name= explicitly to extend_template")
     if len(names) > 1:
         raise ValueError(
             f"prior_results rows carry inconsistent run_names ({sorted(names)}); "
-            "pass run_name= explicitly to extend_judgment"
+            "pass run_name= explicitly to extend_template"
         )
     return next(iter(names))
 

--- a/src/karenina/schemas/verification/config.py
+++ b/src/karenina/schemas/verification/config.py
@@ -286,6 +286,13 @@ class VerificationConfig(BaseModel):
     replay_store: Any = Field(default=None, exclude=True)
     replay_parse_on_hydration_mismatch: Literal["fall_through", "strict"] = "fall_through"
 
+    # Internal plumbing for Benchmark.extend_judgment: set of
+    # (question_id, answering canonical_key, parsing canonical_key, replicate)
+    # tuples already covered by prior_results. The batch runner skips these
+    # during task-queue expansion so prior rows pass through verbatim.
+    # Not part of the public surface; always None for standard verification runs.
+    skip_triples: frozenset[tuple[str, str, str, int | None]] | None = Field(default=None, exclude=True, repr=False)
+
     @model_validator(mode="after")
     def _validate_custom_mode_has_config(self) -> "VerificationConfig":
         """Validate that custom mode has the required config.

--- a/src/karenina/schemas/verification/config.py
+++ b/src/karenina/schemas/verification/config.py
@@ -286,7 +286,7 @@ class VerificationConfig(BaseModel):
     replay_store: Any = Field(default=None, exclude=True)
     replay_parse_on_hydration_mismatch: Literal["fall_through", "strict"] = "fall_through"
 
-    # Internal plumbing for Benchmark.extend_judgment: set of
+    # Internal plumbing for Benchmark.extend_template: set of
     # (question_id, answering canonical_key, parsing canonical_key, replicate)
     # tuples already covered by prior_results. The batch runner skips these
     # during task-queue expansion so prior rows pass through verbatim.

--- a/tests/test_benchmark_extend_judgment.py
+++ b/tests/test_benchmark_extend_judgment.py
@@ -148,11 +148,16 @@ class _FakeVerifyRecorder:
             [None] if config.replicate_count <= 1 else list(range(1, config.replicate_count + 1))
         )
 
+        skip = config.skip_triples or frozenset()
         rows: list[VerificationResult] = []
         for qid in effective_qids:
             for ans_model in config.answering_models:
+                ans_key = ModelIdentity.from_model_config(ans_model, role="answering").canonical_key
                 for parse_model in config.parsing_models:
+                    parse_key = ModelIdentity.from_model_config(parse_model, role="parsing").canonical_key
                     for rep in replicate_slots:
+                        if (qid, ans_key, parse_key, rep) in skip:
+                            continue
                         rows.append(
                             _make_result(
                                 question_id=qid,
@@ -271,6 +276,105 @@ class TestExtendJudgmentMultipleAnsweringModels:
 
 
 @pytest.mark.unit
+class TestExtendJudgmentAddAnsweringModel:
+    def test_new_answerer_rows_added_prior_rows_kept(self, recorder: _FakeVerifyRecorder) -> None:
+        bench = _make_bench()
+        prior = _make_prior_set(run_name="add-ans", question_ids=["q1", "q2"])
+
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL, OTHER_ANSWERING_MODEL],
+            parsing_models=[JUDGE_A],
+            evaluation_mode="template_only",
+        )
+
+        merged = bench.extend_judgment(prior, config, store=False)
+
+        assert len(merged.results) == 4, "2 prior (A1 x JA) + 2 new (A2 x JA) = 4"
+
+        # Every (question, answering) pair exists exactly once.
+        pairs: set[tuple[str, str]] = {
+            (r.metadata.question_id, r.metadata.answering.canonical_key) for r in merged.results
+        }
+        assert len(pairs) == 4
+        assert {p[0] for p in pairs} == {"q1", "q2"}
+
+        # Recorder only saw the new answerer (skip filter removed A1xJA tasks).
+        saw_ans_keys = {
+            ModelIdentity.from_model_config(m, role="answering").canonical_key
+            for m in recorder.calls[-1]["config"].answering_models
+        }
+        assert len(saw_ans_keys) == 2
+        skip = recorder.calls[-1]["config"].skip_triples
+        assert skip is not None and len(skip) == 2
+
+
+@pytest.mark.unit
+class TestExtendJudgmentAddReplicate:
+    def test_added_replicate_runs_live_prior_replicates_kept(self, recorder: _FakeVerifyRecorder) -> None:  # noqa: ARG002
+        bench = _make_bench()
+        prior = _make_prior_set(
+            run_name="add-rep",
+            question_ids=["q1", "q2"],
+            replicates=[1, 2, 3],
+        )
+
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL],
+            parsing_models=[JUDGE_A],
+            evaluation_mode="template_only",
+            replicate_count=4,
+        )
+
+        merged = bench.extend_judgment(prior, config, store=False)
+
+        assert len(merged.results) == 8, "6 prior (reps 1..3) + 2 new (rep 4) = 8"
+
+        rep_counts: dict[int | None, int] = {}
+        for r in merged.results:
+            rep_counts[r.metadata.replicate] = rep_counts.get(r.metadata.replicate, 0) + 1
+        assert rep_counts == {1: 2, 2: 2, 3: 2, 4: 2}
+
+
+@pytest.mark.unit
+class TestExtendJudgmentAddAllAxes:
+    def test_full_symmetric_matrix(self, recorder: _FakeVerifyRecorder) -> None:
+        bench = _make_bench()
+        prior = _make_prior_set(
+            run_name="all-axes",
+            question_ids=["q1", "q2"],
+            replicates=[1, 2, 3],
+        )
+
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL, OTHER_ANSWERING_MODEL],
+            parsing_models=[JUDGE_A, JUDGE_B],
+            evaluation_mode="template_only",
+            replicate_count=4,
+        )
+
+        merged = bench.extend_judgment(prior, config, store=False)
+
+        # Full joint matrix: 2 questions x 2 answerers x 2 judges x 4 replicates = 32
+        assert len(merged.results) == 32
+
+        triples = {
+            (
+                r.metadata.question_id,
+                r.metadata.answering.canonical_key,
+                r.metadata.parsing.canonical_key,
+                r.metadata.replicate,
+            )
+            for r in merged.results
+        }
+        assert len(triples) == 32, "every (q, ans, parse, rep) triple is unique"
+
+        skip = recorder.calls[-1]["config"].skip_triples
+        assert skip is not None and len(skip) == 6
+        # The 6 skipped triples are exactly the prior rows.
+        assert triples.issuperset(skip)
+
+
+@pytest.mark.unit
 class TestExtendJudgmentValidation:
     def test_empty_prior_raises(self) -> None:
         bench = _make_bench()
@@ -285,7 +389,7 @@ class TestExtendJudgmentValidation:
         with pytest.raises(ValueError, match="answering_models does not cover"):
             extend_verification_run(bench, prior, config)
 
-    def test_replicate_count_mismatch_raises(self) -> None:
+    def test_replicate_count_reduction_raises(self) -> None:
         bench = _make_bench()
         prior = _make_prior_set(run_name="r", question_ids=["q1", "q2"], replicates=[1, 2])
         config = VerificationConfig(
@@ -293,7 +397,7 @@ class TestExtendJudgmentValidation:
             parsing_models=[JUDGE_B],
             replicate_count=1,
         )
-        with pytest.raises(ValueError, match="replicate_count"):
+        with pytest.raises(ValueError, match="Replicate reduction is not supported"):
             extend_verification_run(bench, prior, config)
 
     def test_replay_store_already_set_raises(self) -> None:

--- a/tests/test_benchmark_extend_judgment.py
+++ b/tests/test_benchmark_extend_judgment.py
@@ -1,0 +1,351 @@
+"""Unit tests for Benchmark.extend_judgment and extend_verification_run."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from karenina.benchmark import Benchmark
+from karenina.benchmark.verification.extension import extend_verification_run
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.results import VerificationResultSet
+from karenina.schemas.verification import VerificationConfig, VerificationResult
+from karenina.schemas.verification.model_identity import ModelIdentity
+from karenina.schemas.verification.result_components import (
+    VerificationResultMetadata,
+    VerificationResultTemplate,
+)
+
+ANSWERING_MODEL = ModelConfig(
+    id="primary",
+    model_name="primary-model",
+    interface="openai_endpoint",
+    endpoint_base_url="http://example.invalid:8000",
+    endpoint_api_key="EMPTY",
+    temperature=0.0,
+)
+JUDGE_A = ModelConfig(
+    id="judge-a",
+    model_name="judge-a",
+    interface="openai_endpoint",
+    endpoint_base_url="http://example.invalid:8000",
+    endpoint_api_key="EMPTY",
+    temperature=0.0,
+)
+JUDGE_B = ModelConfig(
+    id="judge-b",
+    model_name="judge-b",
+    interface="openai_endpoint",
+    endpoint_base_url="http://example.invalid:8000",
+    endpoint_api_key="EMPTY",
+    temperature=0.0,
+)
+OTHER_ANSWERING_MODEL = ModelConfig(
+    id="other",
+    model_name="other-model",
+    interface="openai_endpoint",
+    endpoint_base_url="http://example.invalid:8000",
+    endpoint_api_key="EMPTY",
+    temperature=0.0,
+)
+
+
+def _make_result(
+    *,
+    question_id: str,
+    run_name: str,
+    answering: ModelConfig = ANSWERING_MODEL,
+    parsing: ModelConfig = JUDGE_A,
+    replicate: int | None = None,
+    verify_result: bool = True,
+    raw_response: str = "answer-text",
+) -> VerificationResult:
+    ans_identity = ModelIdentity.from_model_config(answering, role="answering")
+    parse_identity = ModelIdentity.from_model_config(parsing, role="parsing")
+    timestamp = "2026-04-19T00:00:00Z"
+    result_id = VerificationResultMetadata.compute_result_id(
+        question_id=question_id,
+        answering=ans_identity,
+        parsing=parse_identity,
+        timestamp=timestamp,
+        replicate=replicate,
+    )
+    metadata = VerificationResultMetadata(
+        question_id=question_id,
+        template_id="no_template",
+        question_text=f"Q for {question_id}",
+        answering=ans_identity,
+        parsing=parse_identity,
+        execution_time=1.0,
+        timestamp=timestamp,
+        result_id=result_id,
+        run_name=run_name,
+        replicate=replicate,
+        evaluation_mode="template_only",
+    )
+    template = VerificationResultTemplate(
+        raw_llm_response=raw_response,
+        parsed_llm_response={"value": 42},
+        verify_result=verify_result,
+    )
+    return VerificationResult(metadata=metadata, template=template)
+
+
+def _make_prior_set(
+    *,
+    run_name: str,
+    question_ids: list[str],
+    replicates: list[int | None] | None = None,
+) -> VerificationResultSet:
+    replicates = replicates if replicates is not None else [None]
+    rows = [
+        _make_result(
+            question_id=qid,
+            run_name=run_name,
+            replicate=rep,
+            raw_response=f"raw-{qid}-{rep}",
+        )
+        for qid in question_ids
+        for rep in replicates
+    ]
+    return VerificationResultSet(results=rows)
+
+
+def _make_bench() -> Benchmark:
+    return Benchmark.create(name="unit-test-extend", version="0.0.1")
+
+
+class _FakeVerifyRecorder:
+    """Monkeypatch target for Benchmark.run_verification.
+
+    Records the call and returns a synthetic VerificationResultSet with one
+    row per (question_id, replicate) pair derived from the observed config.
+    """
+
+    def __init__(self, *, judge: ModelConfig = JUDGE_B) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.judge = judge
+
+    def __call__(
+        self,
+        config: VerificationConfig,
+        question_ids: list[str] | None = None,
+        run_name: str | None = None,
+        async_enabled: bool | None = None,
+        progress_callback: Any | None = None,  # noqa: ARG002 (kept to mirror real signature)
+    ) -> VerificationResultSet:
+        self.calls.append(
+            {
+                "config": config,
+                "question_ids": list(question_ids or []),
+                "run_name": run_name,
+                "async_enabled": async_enabled,
+            }
+        )
+        effective_qids = list(question_ids or [])
+        replicate_slots: list[int | None] = (
+            [None] if config.replicate_count <= 1 else list(range(1, config.replicate_count + 1))
+        )
+
+        rows: list[VerificationResult] = []
+        for qid in effective_qids:
+            for ans_model in config.answering_models:
+                for parse_model in config.parsing_models:
+                    for rep in replicate_slots:
+                        rows.append(
+                            _make_result(
+                                question_id=qid,
+                                run_name=run_name or "unnamed",
+                                answering=ans_model,
+                                parsing=parse_model,
+                                replicate=rep,
+                                raw_response=f"raw-{qid}-{ans_model.id}-{rep}",
+                                verify_result=True,
+                            )
+                        )
+        return VerificationResultSet(results=rows)
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> _FakeVerifyRecorder:
+    recorder = _FakeVerifyRecorder(judge=JUDGE_B)
+    monkeypatch.setattr(Benchmark, "run_verification", recorder)
+    return recorder
+
+
+@pytest.mark.unit
+class TestExtendJudgmentHappyPath:
+    def test_single_replicate_merges_and_stamps(self, recorder: _FakeVerifyRecorder) -> None:
+        bench = _make_bench()
+        prior = _make_prior_set(run_name="first", question_ids=["q1", "q2", "q3"])
+
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL],
+            parsing_models=[JUDGE_B],
+            evaluation_mode="template_only",
+        )
+
+        merged = bench.extend_judgment(prior, config, store=False)
+
+        assert len(merged.results) == 6, "3 prior + 3 new = 6"
+        run_names = {r.metadata.run_name for r in merged.results}
+        assert run_names == {"first"}
+
+        parsing_keys = {r.metadata.parsing.canonical_key for r in merged.results}
+        assert len(parsing_keys) == 2, "two distinct parsing identities (j1 and j2)"
+
+        call = recorder.calls[-1]
+        assert call["config"].replay_store is not None, "replay store must be attached"
+        assert call["run_name"] == "first"
+        assert sorted(call["question_ids"]) == ["q1", "q2", "q3"]
+
+    def test_multiple_replicates(self, recorder: _FakeVerifyRecorder) -> None:  # noqa: ARG002
+        bench = _make_bench()
+        prior = _make_prior_set(
+            run_name="rep-run",
+            question_ids=["q1", "q2"],
+            replicates=[1, 2, 3],
+        )
+
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL],
+            parsing_models=[JUDGE_B],
+            evaluation_mode="template_only",
+            replicate_count=3,
+        )
+
+        merged = bench.extend_judgment(prior, config, store=False)
+
+        assert len(merged.results) == 2 * 2 * 3, "2 questions x 2 judges x 3 replicates"
+        pairs: dict[tuple[str, int | None], int] = {}
+        for r in merged.results:
+            key = (r.metadata.question_id, r.metadata.replicate)
+            pairs[key] = pairs.get(key, 0) + 1
+        for key, count in pairs.items():
+            assert count == 2, f"expected 2 parsers per (qid, replicate) got {count} for {key}"
+
+
+@pytest.mark.unit
+class TestExtendJudgmentMultipleAnsweringModels:
+    def test_two_answerers_one_prior_judge_extended_with_one_new_judge(self, recorder: _FakeVerifyRecorder) -> None:
+        bench = _make_bench()
+        # Prior run: 2 questions x 2 answerers x 1 judge => 4 rows.
+        prior_rows = [
+            _make_result(
+                question_id=qid,
+                run_name="multi-ans",
+                answering=ans,
+                parsing=JUDGE_A,
+                raw_response=f"raw-{qid}-{ans.id}",
+            )
+            for qid in ("q1", "q2")
+            for ans in (ANSWERING_MODEL, OTHER_ANSWERING_MODEL)
+        ]
+        prior = VerificationResultSet(results=prior_rows)
+
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL, OTHER_ANSWERING_MODEL],
+            parsing_models=[JUDGE_B],
+            evaluation_mode="template_only",
+        )
+
+        merged = bench.extend_judgment(prior, config, store=False)
+
+        assert len(merged.results) == 2 * 2 * 2, "2 questions x 2 answerers x 2 judges"
+
+        # Every (question, answering) pair should have exactly 2 parsers.
+        pairs: dict[tuple[str, str], set[str]] = {}
+        for r in merged.results:
+            key = (r.metadata.question_id, r.metadata.answering.canonical_key)
+            pairs.setdefault(key, set()).add(r.metadata.parsing.canonical_key)
+        assert len(pairs) == 4
+        for key, parsers in pairs.items():
+            assert len(parsers) == 2, f"expected both judges for {key}, got {parsers}"
+
+        # Replay store was attached to the extension call.
+        call = recorder.calls[-1]
+        assert call["config"].replay_store is not None
+        # The captured store must carry one entry per (question, answering) pair.
+        assert len(call["config"].replay_store.entries) == 4
+
+
+@pytest.mark.unit
+class TestExtendJudgmentValidation:
+    def test_empty_prior_raises(self) -> None:
+        bench = _make_bench()
+        config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[JUDGE_B])
+        with pytest.raises(ValueError, match="at least one VerificationResult"):
+            extend_verification_run(bench, VerificationResultSet(results=[]), config)
+
+    def test_answering_mismatch_raises(self) -> None:
+        bench = _make_bench()
+        prior = _make_prior_set(run_name="r", question_ids=["q1"])
+        config = VerificationConfig(answering_models=[OTHER_ANSWERING_MODEL], parsing_models=[JUDGE_B])
+        with pytest.raises(ValueError, match="answering_models does not cover"):
+            extend_verification_run(bench, prior, config)
+
+    def test_replicate_count_mismatch_raises(self) -> None:
+        bench = _make_bench()
+        prior = _make_prior_set(run_name="r", question_ids=["q1", "q2"], replicates=[1, 2])
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL],
+            parsing_models=[JUDGE_B],
+            replicate_count=1,
+        )
+        with pytest.raises(ValueError, match="replicate_count"):
+            extend_verification_run(bench, prior, config)
+
+    def test_replay_store_already_set_raises(self) -> None:
+        from karenina.replay import ReplayStore
+
+        bench = _make_bench()
+        prior = _make_prior_set(run_name="r", question_ids=["q1"])
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL],
+            parsing_models=[JUDGE_B],
+            replay_store=ReplayStore(),
+        )
+        with pytest.raises(ValueError, match="replay_store must be None"):
+            extend_verification_run(bench, prior, config)
+
+    def test_inconsistent_run_names_raises(self) -> None:
+        bench = _make_bench()
+        prior_a = _make_prior_set(run_name="one", question_ids=["q1"])
+        prior_b = _make_prior_set(run_name="two", question_ids=["q2"])
+        merged_prior = VerificationResultSet(results=list(prior_a.results) + list(prior_b.results))
+        config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[JUDGE_B])
+        with pytest.raises(ValueError, match="inconsistent run_names"):
+            extend_verification_run(bench, merged_prior, config)
+
+
+@pytest.mark.unit
+class TestExtendJudgmentRunNameOverride:
+    def test_override_stamps_all_rows(self, recorder: _FakeVerifyRecorder) -> None:  # noqa: ARG002
+        bench = _make_bench()
+        prior = _make_prior_set(run_name="original", question_ids=["q1"])
+        config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[JUDGE_B])
+        merged = bench.extend_judgment(prior, config, run_name="custom", store=False)
+
+        run_names = {r.metadata.run_name for r in merged.results}
+        assert run_names == {"custom"}
+
+
+@pytest.mark.unit
+class TestExtendJudgmentStoreFlag:
+    def test_store_true_populates_results_manager(self, recorder: _FakeVerifyRecorder) -> None:  # noqa: ARG002
+        bench = _make_bench()
+        prior = _make_prior_set(run_name="stored", question_ids=["q1", "q2"])
+        config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[JUDGE_B])
+        bench.extend_judgment(prior, config, store=True)
+
+        fetched = bench.get_verification_results(run_name="stored")
+        assert len(fetched) == 4
+
+    def test_store_false_leaves_manager_empty(self, recorder: _FakeVerifyRecorder) -> None:  # noqa: ARG002
+        bench = _make_bench()
+        prior = _make_prior_set(run_name="not-stored", question_ids=["q1"])
+        config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[JUDGE_B])
+        bench.extend_judgment(prior, config, store=False)
+
+        assert "not-stored" not in bench._results_manager._in_memory_results

--- a/tests/test_benchmark_extend_rubric.py
+++ b/tests/test_benchmark_extend_rubric.py
@@ -1,0 +1,444 @@
+"""Unit tests for Benchmark.extend_rubric and extend_rubric_run."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from karenina.benchmark import Benchmark
+from karenina.benchmark.verification.extension import extend_rubric_run
+from karenina.replay import ReplayStore
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.entities import (
+    LLMRubricTrait,
+    MetricRubricTrait,
+    RegexRubricTrait,
+    Rubric,
+)
+from karenina.schemas.results import VerificationResultSet
+from karenina.schemas.verification import VerificationConfig, VerificationResult
+from karenina.schemas.verification.model_identity import ModelIdentity
+from karenina.schemas.verification.result_components import (
+    VerificationResultMetadata,
+    VerificationResultRubric,
+    VerificationResultTemplate,
+)
+
+ANSWERING_MODEL = ModelConfig(
+    id="primary",
+    model_name="primary-model",
+    interface="openai_endpoint",
+    endpoint_base_url="http://example.invalid:8000",
+    endpoint_api_key="EMPTY",
+    temperature=0.0,
+)
+JUDGE_A = ModelConfig(
+    id="judge-a",
+    model_name="judge-a",
+    interface="openai_endpoint",
+    endpoint_base_url="http://example.invalid:8000",
+    endpoint_api_key="EMPTY",
+    temperature=0.0,
+)
+OTHER_ANSWERING_MODEL = ModelConfig(
+    id="other",
+    model_name="other-model",
+    interface="openai_endpoint",
+    endpoint_base_url="http://example.invalid:8000",
+    endpoint_api_key="EMPTY",
+    temperature=0.0,
+)
+
+
+def _make_result(
+    *,
+    question_id: str,
+    run_name: str,
+    answering: ModelConfig = ANSWERING_MODEL,
+    parsing: ModelConfig = JUDGE_A,
+    replicate: int | None = None,
+    raw_response: str = "answer-text",
+    rubric: VerificationResultRubric | None = None,
+) -> VerificationResult:
+    ans_identity = ModelIdentity.from_model_config(answering, role="answering")
+    parse_identity = ModelIdentity.from_model_config(parsing, role="parsing")
+    timestamp = "2026-04-19T00:00:00Z"
+    result_id = VerificationResultMetadata.compute_result_id(
+        question_id=question_id,
+        answering=ans_identity,
+        parsing=parse_identity,
+        timestamp=timestamp,
+        replicate=replicate,
+    )
+    metadata = VerificationResultMetadata(
+        question_id=question_id,
+        template_id="no_template",
+        question_text=f"Q for {question_id}",
+        answering=ans_identity,
+        parsing=parse_identity,
+        execution_time=1.0,
+        timestamp=timestamp,
+        result_id=result_id,
+        run_name=run_name,
+        replicate=replicate,
+        evaluation_mode="template_only",
+    )
+    template = VerificationResultTemplate(
+        raw_llm_response=raw_response,
+        parsed_llm_response={"value": 42},
+        verify_result=True,
+    )
+    return VerificationResult(
+        metadata=metadata,
+        template=template,
+        rubric=rubric or VerificationResultRubric(),
+    )
+
+
+def _make_prior_set(
+    *,
+    run_name: str,
+    question_ids: list[str],
+    replicates: list[int | None] | None = None,
+    rubric_factory: Any | None = None,
+) -> VerificationResultSet:
+    replicates = replicates if replicates is not None else [None]
+    rows: list[VerificationResult] = []
+    for qid in question_ids:
+        for rep in replicates:
+            rows.append(
+                _make_result(
+                    question_id=qid,
+                    run_name=run_name,
+                    replicate=rep,
+                    raw_response=f"raw-{qid}-{rep}",
+                    rubric=rubric_factory(qid, rep) if rubric_factory else None,
+                )
+            )
+    return VerificationResultSet(results=rows)
+
+
+def _make_bench() -> Benchmark:
+    bench = Benchmark.create(name="unit-test-extend-rubric", version="0.0.1")
+    # Attach a couple of questions so per-question rubric operations work.
+    bench.add_question("Q for q1", raw_answer="a1", question_id="q1")
+    bench.add_question("Q for q2", raw_answer="a2", question_id="q2")
+    return bench
+
+
+def _rubric_payload_for(benchmark: Benchmark, question_id: str) -> VerificationResultRubric:
+    """Build a stub rubric result matching the benchmark's rubric for the question."""
+    merged = benchmark._rubric_manager.get_merged_rubric_for_question(question_id)
+    payload = VerificationResultRubric(rubric_evaluation_performed=True, rubric_evaluation_strategy="batch")
+    if merged is None:
+        return payload
+    if merged.llm_traits:
+        payload.llm_trait_scores = {t.name: 4 for t in merged.llm_traits}
+    if merged.regex_traits:
+        payload.regex_trait_scores = {t.name: True for t in merged.regex_traits}
+    if merged.callable_traits:
+        payload.callable_trait_scores = {t.name: True for t in merged.callable_traits}
+    if merged.agentic_traits:
+        payload.agentic_trait_scores = {t.name: "fake-agentic" for t in merged.agentic_traits}
+    return payload
+
+
+class _FakeRubricRecorder:
+    """Monkeypatch target for Benchmark.run_verification in rubric-only mode.
+
+    Produces one row per (qid, answering, parsing, replicate) triple,
+    with rubric fields derived from the benchmark's attached rubric.
+    Template fields are left empty (mirrors how rubric_only mode would
+    behave on replay).
+    """
+
+    def __init__(self, benchmark: Benchmark) -> None:
+        self.bench = benchmark
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(
+        self,
+        config: VerificationConfig,
+        question_ids: list[str] | None = None,
+        run_name: str | None = None,
+        async_enabled: bool | None = None,
+        progress_callback: Any | None = None,  # noqa: ARG002
+    ) -> VerificationResultSet:
+        self.calls.append(
+            {
+                "config": config,
+                "question_ids": list(question_ids or []),
+                "run_name": run_name,
+                "async_enabled": async_enabled,
+            }
+        )
+        effective_qids = list(question_ids or [])
+        replicate_slots: list[int | None] = (
+            [None] if config.replicate_count <= 1 else list(range(1, config.replicate_count + 1))
+        )
+        rows: list[VerificationResult] = []
+        for qid in effective_qids:
+            for ans_model in config.answering_models:
+                for parse_model in config.parsing_models:
+                    for rep in replicate_slots:
+                        rows.append(
+                            _make_result(
+                                question_id=qid,
+                                run_name=run_name or "unnamed",
+                                answering=ans_model,
+                                parsing=parse_model,
+                                replicate=rep,
+                                raw_response=f"raw-{qid}-{ans_model.id}-{rep}",
+                                rubric=_rubric_payload_for(self.bench, qid),
+                            )
+                        )
+        return VerificationResultSet(results=rows)
+
+
+@pytest.fixture
+def bench_and_recorder(monkeypatch: pytest.MonkeyPatch) -> tuple[Benchmark, _FakeRubricRecorder]:
+    bench = _make_bench()
+    recorder = _FakeRubricRecorder(bench)
+    monkeypatch.setattr(Benchmark, "run_verification", recorder)
+    return bench, recorder
+
+
+@pytest.mark.unit
+class TestExtendRubricEnrichment:
+    def test_prior_rows_enriched_in_place(self, bench_and_recorder: tuple[Benchmark, _FakeRubricRecorder]) -> None:
+        bench, recorder = bench_and_recorder
+        prior = _make_prior_set(run_name="first", question_ids=["q1", "q2"])
+
+        bench.set_global_rubric(
+            Rubric(
+                llm_traits=[
+                    LLMRubricTrait(name="clarity", description="clear?", kind="score", min_score=1, max_score=5)
+                ],
+                regex_traits=[RegexRubricTrait(name="cite", description="cites?", pattern=r"\bref\b")],
+            )
+        )
+
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL],
+            parsing_models=[JUDGE_A],
+            evaluation_mode="template_only",
+        )
+        merged = bench.extend_rubric(prior, config, store=False)
+
+        assert len(merged.results) == 2, "row count preserved"
+
+        for r in merged.results:
+            assert r.rubric.llm_trait_scores == {"clarity": 4}
+            assert r.rubric.regex_trait_scores == {"cite": True}
+            # Template fields left untouched.
+            assert r.template.verify_result is True
+            assert r.template.raw_llm_response.startswith("raw-")
+
+        # The replay store was attached and evaluation_mode rewritten.
+        call = recorder.calls[-1]
+        assert call["config"].replay_store is not None
+        assert call["config"].evaluation_mode == "rubric_only"
+
+
+@pytest.mark.unit
+class TestExtendRubricUnion:
+    def test_new_traits_unioned_with_prior(self, bench_and_recorder: tuple[Benchmark, _FakeRubricRecorder]) -> None:
+        bench, _ = bench_and_recorder
+
+        def prior_rubric(qid: str, rep: int | None) -> VerificationResultRubric:  # noqa: ARG001
+            return VerificationResultRubric(
+                rubric_evaluation_performed=True,
+                llm_trait_scores={"coherence": 4},
+            )
+
+        prior = _make_prior_set(run_name="union", question_ids=["q1"], rubric_factory=prior_rubric)
+        bench.set_global_rubric(
+            Rubric(
+                llm_traits=[
+                    LLMRubricTrait(name="clarity", description="clear?", kind="score", min_score=1, max_score=5)
+                ]
+            )
+        )
+
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL],
+            parsing_models=[JUDGE_A],
+        )
+        merged = bench.extend_rubric(prior, config, store=False)
+
+        assert len(merged.results) == 1
+        scores = merged.results[0].rubric.llm_trait_scores
+        assert scores == {"coherence": 4, "clarity": 4}
+
+
+@pytest.mark.unit
+class TestExtendRubricCollision:
+    def test_same_trait_name_collision_raises(self, bench_and_recorder: tuple[Benchmark, _FakeRubricRecorder]) -> None:
+        bench, _ = bench_and_recorder
+
+        def prior_rubric(qid: str, rep: int | None) -> VerificationResultRubric:  # noqa: ARG001
+            return VerificationResultRubric(
+                rubric_evaluation_performed=True,
+                llm_trait_scores={"clarity": 3},
+            )
+
+        prior = _make_prior_set(run_name="collide", question_ids=["q1"], rubric_factory=prior_rubric)
+        bench.set_global_rubric(
+            Rubric(
+                llm_traits=[
+                    LLMRubricTrait(name="clarity", description="clear?", kind="score", min_score=1, max_score=5)
+                ]
+            )
+        )
+
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL],
+            parsing_models=[JUDGE_A],
+        )
+        with pytest.raises(ValueError, match="collision in llm_trait_scores"):
+            bench.extend_rubric(prior, config, store=False)
+
+
+@pytest.mark.unit
+class TestExtendRubricPerQuestion:
+    def test_question_specific_trait_applies_only_to_that_question(
+        self, bench_and_recorder: tuple[Benchmark, _FakeRubricRecorder]
+    ) -> None:
+        bench, _ = bench_and_recorder
+        prior = _make_prior_set(run_name="per-q", question_ids=["q1", "q2"])
+
+        bench.set_global_rubric(
+            Rubric(llm_traits=[LLMRubricTrait(name="trait_g", description="g", kind="score", min_score=1, max_score=5)])
+        )
+        bench.set_question_rubric(
+            "q1",
+            Rubric(
+                llm_traits=[LLMRubricTrait(name="trait_q1", description="q1", kind="score", min_score=1, max_score=5)]
+            ),
+        )
+
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL],
+            parsing_models=[JUDGE_A],
+        )
+        merged = bench.extend_rubric(prior, config, store=False)
+
+        by_q = {r.metadata.question_id: r for r in merged.results}
+        assert set(by_q["q1"].rubric.llm_trait_scores or {}) == {"trait_g", "trait_q1"}
+        assert set(by_q["q2"].rubric.llm_trait_scores or {}) == {"trait_g"}
+
+
+@pytest.mark.unit
+class TestExtendRubricValidation:
+    def _make_rubric_bench(self) -> Benchmark:
+        bench = _make_bench()
+        bench.set_global_rubric(
+            Rubric(llm_traits=[LLMRubricTrait(name="trait_g", description="g", kind="score", min_score=1, max_score=5)])
+        )
+        return bench
+
+    def test_empty_prior_raises(self) -> None:
+        bench = self._make_rubric_bench()
+        config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[JUDGE_A])
+        with pytest.raises(ValueError, match="at least one VerificationResult"):
+            extend_rubric_run(bench, VerificationResultSet(results=[]), config)
+
+    def test_replay_store_already_set_raises(self) -> None:
+        bench = self._make_rubric_bench()
+        prior = _make_prior_set(run_name="r", question_ids=["q1"])
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL],
+            parsing_models=[JUDGE_A],
+            replay_store=ReplayStore(),
+        )
+        with pytest.raises(ValueError, match="replay_store must be None"):
+            extend_rubric_run(bench, prior, config)
+
+    def test_unsupported_evaluation_mode_raises(self) -> None:
+        bench = self._make_rubric_bench()
+        prior = _make_prior_set(run_name="r", question_ids=["q1"])
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL],
+            parsing_models=[JUDGE_A],
+            evaluation_mode="template_and_rubric",
+        )
+        with pytest.raises(ValueError, match="evaluation_mode must be"):
+            extend_rubric_run(bench, prior, config)
+
+    def test_missing_rubric_raises(self) -> None:
+        bench = _make_bench()  # no rubric
+        prior = _make_prior_set(run_name="r", question_ids=["q1"])
+        config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[JUDGE_A])
+        with pytest.raises(ValueError, match="benchmark has no rubric attached"):
+            extend_rubric_run(bench, prior, config)
+
+    def test_metric_trait_rejected(self) -> None:
+        bench = _make_bench()
+        bench.set_global_rubric(
+            Rubric(
+                metric_traits=[
+                    MetricRubricTrait(
+                        name="coverage",
+                        description="coverage metric",
+                        metrics=["precision"],
+                        tp_instructions=["must mention X"],
+                    )
+                ]
+            )
+        )
+        prior = _make_prior_set(run_name="r", question_ids=["q1"])
+        config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[JUDGE_A])
+        with pytest.raises(ValueError, match="Metric traits are not supported"):
+            extend_rubric_run(bench, prior, config)
+
+    def test_parsing_model_mismatch_raises(self) -> None:
+        bench = self._make_rubric_bench()
+        prior = _make_prior_set(run_name="r", question_ids=["q1"])
+
+        other_judge = ModelConfig(
+            id="judge-z",
+            model_name="judge-z",
+            interface="openai_endpoint",
+            endpoint_base_url="http://example.invalid:8000",
+            endpoint_api_key="EMPTY",
+            temperature=0.0,
+        )
+        config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[other_judge])
+        with pytest.raises(ValueError, match="parsing_models does not match"):
+            extend_rubric_run(bench, prior, config)
+
+    def test_answering_model_mismatch_raises(self) -> None:
+        bench = self._make_rubric_bench()
+        prior = _make_prior_set(run_name="r", question_ids=["q1"])
+        config = VerificationConfig(answering_models=[OTHER_ANSWERING_MODEL], parsing_models=[JUDGE_A])
+        with pytest.raises(ValueError, match="answering_models does not cover"):
+            extend_rubric_run(bench, prior, config)
+
+    def test_replicate_count_mismatch_raises(self) -> None:
+        bench = self._make_rubric_bench()
+        prior = _make_prior_set(run_name="r", question_ids=["q1", "q2"], replicates=[1, 2])
+        config = VerificationConfig(
+            answering_models=[ANSWERING_MODEL],
+            parsing_models=[JUDGE_A],
+            replicate_count=3,
+        )
+        with pytest.raises(ValueError, match="does not match the replicate fan-out"):
+            extend_rubric_run(bench, prior, config)
+
+
+@pytest.mark.unit
+class TestExtendRubricStoreFlag:
+    def test_store_true_populates_results_manager(
+        self, bench_and_recorder: tuple[Benchmark, _FakeRubricRecorder]
+    ) -> None:
+        bench, _ = bench_and_recorder
+        prior = _make_prior_set(run_name="stored", question_ids=["q1", "q2"])
+        bench.set_global_rubric(
+            Rubric(llm_traits=[LLMRubricTrait(name="ok", description="ok", kind="score", min_score=1, max_score=5)])
+        )
+        config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[JUDGE_A])
+        bench.extend_rubric(prior, config, store=True)
+
+        fetched = bench.get_verification_results(run_name="stored")
+        assert len(fetched) == 2

--- a/tests/test_benchmark_extend_template.py
+++ b/tests/test_benchmark_extend_template.py
@@ -1,4 +1,4 @@
-"""Unit tests for Benchmark.extend_judgment and extend_verification_run."""
+"""Unit tests for Benchmark.extend_template and extend_template_run."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from karenina.benchmark import Benchmark
-from karenina.benchmark.verification.extension import extend_verification_run
+from karenina.benchmark.verification.extension import extend_template_run
 from karenina.schemas.config import ModelConfig
 from karenina.schemas.results import VerificationResultSet
 from karenina.schemas.verification import VerificationConfig, VerificationResult
@@ -180,7 +180,7 @@ def recorder(monkeypatch: pytest.MonkeyPatch) -> _FakeVerifyRecorder:
 
 
 @pytest.mark.unit
-class TestExtendJudgmentHappyPath:
+class TestExtendTemplateHappyPath:
     def test_single_replicate_merges_and_stamps(self, recorder: _FakeVerifyRecorder) -> None:
         bench = _make_bench()
         prior = _make_prior_set(run_name="first", question_ids=["q1", "q2", "q3"])
@@ -191,7 +191,7 @@ class TestExtendJudgmentHappyPath:
             evaluation_mode="template_only",
         )
 
-        merged = bench.extend_judgment(prior, config, store=False)
+        merged = bench.extend_template(prior, config, store=False)
 
         assert len(merged.results) == 6, "3 prior + 3 new = 6"
         run_names = {r.metadata.run_name for r in merged.results}
@@ -220,7 +220,7 @@ class TestExtendJudgmentHappyPath:
             replicate_count=3,
         )
 
-        merged = bench.extend_judgment(prior, config, store=False)
+        merged = bench.extend_template(prior, config, store=False)
 
         assert len(merged.results) == 2 * 2 * 3, "2 questions x 2 judges x 3 replicates"
         pairs: dict[tuple[str, int | None], int] = {}
@@ -232,7 +232,7 @@ class TestExtendJudgmentHappyPath:
 
 
 @pytest.mark.unit
-class TestExtendJudgmentMultipleAnsweringModels:
+class TestExtendTemplateMultipleAnsweringModels:
     def test_two_answerers_one_prior_judge_extended_with_one_new_judge(self, recorder: _FakeVerifyRecorder) -> None:
         bench = _make_bench()
         # Prior run: 2 questions x 2 answerers x 1 judge => 4 rows.
@@ -255,7 +255,7 @@ class TestExtendJudgmentMultipleAnsweringModels:
             evaluation_mode="template_only",
         )
 
-        merged = bench.extend_judgment(prior, config, store=False)
+        merged = bench.extend_template(prior, config, store=False)
 
         assert len(merged.results) == 2 * 2 * 2, "2 questions x 2 answerers x 2 judges"
 
@@ -276,7 +276,7 @@ class TestExtendJudgmentMultipleAnsweringModels:
 
 
 @pytest.mark.unit
-class TestExtendJudgmentAddAnsweringModel:
+class TestExtendTemplateAddAnsweringModel:
     def test_new_answerer_rows_added_prior_rows_kept(self, recorder: _FakeVerifyRecorder) -> None:
         bench = _make_bench()
         prior = _make_prior_set(run_name="add-ans", question_ids=["q1", "q2"])
@@ -287,7 +287,7 @@ class TestExtendJudgmentAddAnsweringModel:
             evaluation_mode="template_only",
         )
 
-        merged = bench.extend_judgment(prior, config, store=False)
+        merged = bench.extend_template(prior, config, store=False)
 
         assert len(merged.results) == 4, "2 prior (A1 x JA) + 2 new (A2 x JA) = 4"
 
@@ -309,7 +309,7 @@ class TestExtendJudgmentAddAnsweringModel:
 
 
 @pytest.mark.unit
-class TestExtendJudgmentAddReplicate:
+class TestExtendTemplateAddReplicate:
     def test_added_replicate_runs_live_prior_replicates_kept(self, recorder: _FakeVerifyRecorder) -> None:  # noqa: ARG002
         bench = _make_bench()
         prior = _make_prior_set(
@@ -325,7 +325,7 @@ class TestExtendJudgmentAddReplicate:
             replicate_count=4,
         )
 
-        merged = bench.extend_judgment(prior, config, store=False)
+        merged = bench.extend_template(prior, config, store=False)
 
         assert len(merged.results) == 8, "6 prior (reps 1..3) + 2 new (rep 4) = 8"
 
@@ -336,7 +336,7 @@ class TestExtendJudgmentAddReplicate:
 
 
 @pytest.mark.unit
-class TestExtendJudgmentAddAllAxes:
+class TestExtendTemplateAddAllAxes:
     def test_full_symmetric_matrix(self, recorder: _FakeVerifyRecorder) -> None:
         bench = _make_bench()
         prior = _make_prior_set(
@@ -352,7 +352,7 @@ class TestExtendJudgmentAddAllAxes:
             replicate_count=4,
         )
 
-        merged = bench.extend_judgment(prior, config, store=False)
+        merged = bench.extend_template(prior, config, store=False)
 
         # Full joint matrix: 2 questions x 2 answerers x 2 judges x 4 replicates = 32
         assert len(merged.results) == 32
@@ -375,19 +375,19 @@ class TestExtendJudgmentAddAllAxes:
 
 
 @pytest.mark.unit
-class TestExtendJudgmentValidation:
+class TestExtendTemplateValidation:
     def test_empty_prior_raises(self) -> None:
         bench = _make_bench()
         config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[JUDGE_B])
         with pytest.raises(ValueError, match="at least one VerificationResult"):
-            extend_verification_run(bench, VerificationResultSet(results=[]), config)
+            extend_template_run(bench, VerificationResultSet(results=[]), config)
 
     def test_answering_mismatch_raises(self) -> None:
         bench = _make_bench()
         prior = _make_prior_set(run_name="r", question_ids=["q1"])
         config = VerificationConfig(answering_models=[OTHER_ANSWERING_MODEL], parsing_models=[JUDGE_B])
         with pytest.raises(ValueError, match="answering_models does not cover"):
-            extend_verification_run(bench, prior, config)
+            extend_template_run(bench, prior, config)
 
     def test_replicate_count_reduction_raises(self) -> None:
         bench = _make_bench()
@@ -398,7 +398,7 @@ class TestExtendJudgmentValidation:
             replicate_count=1,
         )
         with pytest.raises(ValueError, match="Replicate reduction is not supported"):
-            extend_verification_run(bench, prior, config)
+            extend_template_run(bench, prior, config)
 
     def test_replay_store_already_set_raises(self) -> None:
         from karenina.replay import ReplayStore
@@ -411,7 +411,7 @@ class TestExtendJudgmentValidation:
             replay_store=ReplayStore(),
         )
         with pytest.raises(ValueError, match="replay_store must be None"):
-            extend_verification_run(bench, prior, config)
+            extend_template_run(bench, prior, config)
 
     def test_inconsistent_run_names_raises(self) -> None:
         bench = _make_bench()
@@ -420,28 +420,28 @@ class TestExtendJudgmentValidation:
         merged_prior = VerificationResultSet(results=list(prior_a.results) + list(prior_b.results))
         config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[JUDGE_B])
         with pytest.raises(ValueError, match="inconsistent run_names"):
-            extend_verification_run(bench, merged_prior, config)
+            extend_template_run(bench, merged_prior, config)
 
 
 @pytest.mark.unit
-class TestExtendJudgmentRunNameOverride:
+class TestExtendTemplateRunNameOverride:
     def test_override_stamps_all_rows(self, recorder: _FakeVerifyRecorder) -> None:  # noqa: ARG002
         bench = _make_bench()
         prior = _make_prior_set(run_name="original", question_ids=["q1"])
         config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[JUDGE_B])
-        merged = bench.extend_judgment(prior, config, run_name="custom", store=False)
+        merged = bench.extend_template(prior, config, run_name="custom", store=False)
 
         run_names = {r.metadata.run_name for r in merged.results}
         assert run_names == {"custom"}
 
 
 @pytest.mark.unit
-class TestExtendJudgmentStoreFlag:
+class TestExtendTemplateStoreFlag:
     def test_store_true_populates_results_manager(self, recorder: _FakeVerifyRecorder) -> None:  # noqa: ARG002
         bench = _make_bench()
         prior = _make_prior_set(run_name="stored", question_ids=["q1", "q2"])
         config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[JUDGE_B])
-        bench.extend_judgment(prior, config, store=True)
+        bench.extend_template(prior, config, store=True)
 
         fetched = bench.get_verification_results(run_name="stored")
         assert len(fetched) == 4
@@ -450,6 +450,6 @@ class TestExtendJudgmentStoreFlag:
         bench = _make_bench()
         prior = _make_prior_set(run_name="not-stored", question_ids=["q1"])
         config = VerificationConfig(answering_models=[ANSWERING_MODEL], parsing_models=[JUDGE_B])
-        bench.extend_judgment(prior, config, store=False)
+        bench.extend_template(prior, config, store=False)
 
         assert "not-stored" not in bench._results_manager._in_memory_results


### PR DESCRIPTION
## Summary

Adds two first-class facades on `Benchmark` for extending a prior verification run by reusing captured traces: `extend_template` (add judges, answerers, replicates) and `extend_rubric` (attach a rubric to an existing run). Both are QA-only in v1 and rely on the existing `ReplayStore` plus targeted config overrides (`skip_triples`, `evaluation_mode="rubric_only"`).

## Changes Made

### `Benchmark.extend_template`
- `extend_template(prior_results, config, *, run_name=None, question_ids=None, ...)`: composable across three axes (new judges, new answerers, more replicates).
- Caller expresses the FINAL shape in the config; helper diffs against `prior_results`.
- Internal: new `VerificationConfig.skip_triples` field (excluded from repr, plumbing only); `batch_runner.generate_task_queue` filters matching tasks.
- Validation: rejects empty prior, pre-populated `replay_store`, missing answerer identities, replicate reduction, run_name mismatch.

### `Benchmark.extend_rubric`
- `extend_rubric(prior_results, config, *, run_name=None, ...)`: attaches a benchmark rubric (global and/or per-question) and scores every prior trace without re-answering or re-parsing.
- Row count preserved; merge is a per-bucket trait-name union. Collision raises `ValueError` naming the bucket and trait.
- Internal: captures replay with `include_parsed=False, include_agent_traces=True`, clones config with `evaluation_mode=\"rubric_only\"`; orchestrator keeps GenerateAnswer + rubric + finalize.
- Supports LLM, regex, callable, agentic traits and `DynamicRubric`. Metric traits rejected (v1).

### Rename: `extend_judgment` -> `extend_template`
- Coherence with the sibling `extend_rubric` facade. Public method, helper function, test file, and daily notes all updated.

### Files touched
- `src/karenina/benchmark/benchmark.py`: two new facade methods.
- `src/karenina/benchmark/verification/extension.py`: `extend_template_run`, `extend_rubric_run`, validators, `_enrich_with_rubric`, `_merge_rubric_onto_row`.
- `src/karenina/benchmark/verification/batch_runner.py`: `skip_triples` filter.
- `src/karenina/schemas/verification/config.py`: `skip_triples` field.
- `docs/core_concepts/extending-runs.md` (+ paired notebook): new concept page documenting both facades.

## Testing

- `tests/test_benchmark_extend_template.py`: 14 tests (add-judge, add-answerer, add-replicates, all-axes full-matrix, validators).
- `tests/test_benchmark_extend_rubric.py`: 13 tests (enrichment, trait union, collision, per-question rubric, 8 validation cases, store flag).
- Full regression passing locally.

## Live verification (paper_examples/QA)

- `replay_rejudge_demo.py`: ~80x speedup (504s live vs 6.4s replay, single answerer/judge).
- `replay_rejudge_demo_all_axes.py`: 36-row full matrix, 6 passthrough + 30 new, exercises `skip_triples`.
- `replay_extend_rubric_demo.py`: 3 rows enriched in 10.1s vs 173.4s phase A (~17x).

## Additional Context

- **Scope (v1)**: QA only. Scenarios deferred: see `daily_notes/karenina_daily/2026-04-19/2026-04-19-extending-scenario-runs-entry-point.md` for the entry-point scoping document.
- **Out of scope**: metric-trait rubrics, replicate reduction, removing answerers/judges, persisting `VerificationConfig` with results, composing both facades in a single call (workaround: call `extend_template` then `extend_rubric` on the merged result).
- No breaking changes to existing `run_verification` callers. `skip_triples` is an internal config field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)