### PR TITLE
feat(langchain): improve baseline adapter prompting

### DIFF
--- a/src/karenina/adapters/langchain/llm.py
+++ b/src/karenina/adapters/langchain/llm.py
@@ -386,17 +386,34 @@ class LangChainLLMAdapter:
             >>> response = await structured.ainvoke(messages)
             >>> assert isinstance(response.raw, Answer)
         """
-        # Try to create a structured model for native support
+        # Try to create a structured model for native support.
+        # For OpenAI-compatible self-hosted endpoints (e.g. vLLM, Ollama), force
+        # method="json_schema" so the server enforces the schema via guided
+        # decoding. Small models on these backends often fail the LangChain
+        # default function-calling path, which silently returns None or raises.
         structured_model = None
         if hasattr(self._model, "with_structured_output"):
+            kwargs: dict[str, Any] = {}
+            if self._config.interface == "openai_endpoint":
+                kwargs["method"] = "json_schema"
             try:
-                structured_model = self._model.with_structured_output(schema)
+                structured_model = self._model.with_structured_output(schema, **kwargs)
             except Exception as e:
-                # Creation failed - will use fallback at invoke time
                 logger.debug(
-                    f"Could not create structured model for {self._config.model_name}: {e}. "
-                    "Will use fallback parsing at invoke time."
+                    "Could not create structured model for %s with %s: %s. Retrying without method override.",
+                    self._config.model_name,
+                    kwargs or "default method",
+                    e,
                 )
+                if kwargs:
+                    try:
+                        structured_model = self._model.with_structured_output(schema)
+                    except Exception as e2:
+                        logger.debug(
+                            "Could not create structured model for %s: %s. Will use fallback parsing at invoke time.",
+                            self._config.model_name,
+                            e2,
+                        )
 
         return LangChainLLMAdapter(
             model_config=self._config,

--- a/src/karenina/adapters/langchain/llm.py
+++ b/src/karenina/adapters/langchain/llm.py
@@ -132,6 +132,9 @@ class LangChainLLMAdapter:
         if self._config.temperature is not None:
             kwargs["temperature"] = self._config.temperature
 
+        if self._config.max_tokens is not None:
+            kwargs["max_tokens"] = self._config.max_tokens
+
         if self._config.request_timeout is not None:
             # LangChain's ChatAnthropic uses 'default_request_timeout', not 'request_timeout'.
             # Other providers (OpenAI, Google) accept 'request_timeout' as-is.

--- a/src/karenina/adapters/langchain/mcp.py
+++ b/src/karenina/adapters/langchain/mcp.py
@@ -90,7 +90,7 @@ async def acreate_mcp_client_and_tools(
 
     try:
         # Create client and fetch tools with timeout
-        client = MultiServerMCPClient(server_config)  # type: ignore[arg-type]
+        client = MultiServerMCPClient(server_config)
 
         # Add timeout to prevent hanging
         tools = await asyncio.wait_for(client.get_tools(), timeout=30.0)

--- a/src/karenina/adapters/langchain_deep_agents/mcp.py
+++ b/src/karenina/adapters/langchain_deep_agents/mcp.py
@@ -95,7 +95,7 @@ async def convert_mcp_to_tools(
 
     from langchain_mcp_adapters.client import MultiServerMCPClient
 
-    client = MultiServerMCPClient(server_params)  # type: ignore[arg-type]
-    await exit_stack.enter_async_context(client)  # type: ignore[arg-type]
+    client = MultiServerMCPClient(server_params)
+    await exit_stack.enter_async_context(client)
     tools: list[Any] = await client.get_tools()
     return tools

--- a/src/karenina/benchmark/error_analysis/case_renderer.py
+++ b/src/karenina/benchmark/error_analysis/case_renderer.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from karenina.replay.ports_message_hydration import hydrate_trace_messages
 from karenina.scenario.handover import TaggedMessage, format_transcript

--- a/src/karenina/benchmark/verification/prompts/trace/abstention.py
+++ b/src/karenina/benchmark/verification/prompts/trace/abstention.py
@@ -5,38 +5,97 @@ declares that it is not answering the question.
 """
 
 ABSTENTION_DETECTION_SYS = """<role>
-You are a precise abstention detection assistant. Your job is to decide whether a model's response contains an explicit declaration that the model is not answering the question.
+You are a precise abstention detection assistant. Your job is to decide whether
+a model's response contains an explicit declaration that the model is not
+answering the question. You must ground every decision in verbatim text from
+the response: never quote or paraphrase sentences that are not present.
 </role>
 
-<critical_instructions>
-<detection_rule>
-Mark the response as abstention if, and only if, the response contains an explicit statement that the model is refusing, declining, or unable to answer. Implicit signals (off-topic content, vague prose, deflection without an explicit refusal phrase) are NOT abstention, even when the response fails to address the question.
-</detection_rule>
+<decision_procedure>
+Follow these three steps in order. Stop at the first step whose answer
+resolves the decision.
 
-<is_abstention>
-The following count as abstention:
-- Direct refusals: "I cannot answer", "I will not answer", "I'm unable to provide", "I won't provide"
-- Capability disclaimers: "I don't have access to", "I lack the ability to", "I'm not equipped to"
-- Lack-of-information declarations: "I don't have information about", "I cannot find data on", "I have no knowledge of"
-- Safety or policy refusals: "I can't help with that", "This violates my guidelines", "I'm not authorized to discuss"
-</is_abstention>
+Step 1. Find a verbatim capability disclaimer.
+Search the response for a literal sentence that declares inability to answer
+THIS specific question. The sentence must state one of:
+  - inability to act: "I cannot answer", "I will not answer", "I won't provide",
+    "I'm unable to provide", "I can't help with that"
+  - inability to access information or tools: "I don't have access to",
+    "I cannot access", "I cannot retrieve", "I lack real-time access",
+    "I don't have direct access"
+  - absence of knowledge: "I don't have information about", "I have no
+    knowledge of", "I cannot find data on"
+  - policy refusal: "this violates my guidelines", "I'm not authorized"
+Copy the exact sentence you found into your reasoning. If no such verbatim
+sentence exists, set abstention_detected = false and stop.
 
-<is_not_abstention>
-The following are NOT abstention, even when they may look like non-answers:
-- Tool or retrieval failures: the model attempted to answer but reports a tool error, missing data, or a failed search. The response describes the failure; it does not refuse to answer.
-- Off-topic answers: the model confidently answers, but about the wrong thing. That is a correctness problem, not a refusal.
-- Hedged guesses: "I'm not sure, maybe X or Y", "Possibly Z". The model commits to one or more candidate values under uncertainty.
-- Qualified or partial answers: answers with caveats, disclaimers, or coverage of only part of a multi-part question, as long as some substantive content is present.
-- Evasion or deflection without an explicit refusal phrase: vague prose, generalities, or redirection to other resources. If no explicit refusal is stated, it is not abstention.
-</is_not_abstention>
+Step 2. Check whether the response still commits to an answer.
+Read the rest of the response. Does it commit to a specific answer to the
+question? A commitment is an assertion made as the response's own answer: a
+direct yes or no, a named entity, a numerical value, a classification, or a
+definite claim. A commitment is NOT a conditional ("if X, then Y"), NOT a
+list of resources or steps the user should consult, and NOT generic background
+about the topic.
+  - If a commitment exists: set abstention_detected = false and stop. The
+    disclaimer is a caveat on a committed answer, not a refusal.
+  - If no commitment exists (only caveats, how-to guidance, generic background,
+    or deflection to external resources): set abstention_detected = true and
+    stop.
 
-<required_behavior>
-- Read the entire response before deciding.
-- Base the decision on what the response explicitly says, not on what it fails to say.
-- When in doubt, prefer "not abstention": the abstention label is reserved for explicit declarations.
-- Output a short reasoning string followed by the boolean verdict, as JSON.
-</required_behavior>
-</critical_instructions>"""
+Step 3. (reached only if Step 1 and Step 2 were ambiguous.)
+Default to abstention_detected = false.
+</decision_procedure>
+
+<distinctions>
+Capability disclaimers are NOT the same as epistemic hedging.
+  - Capability disclaimer (IS an abstention signal): explicit statements that
+    the model itself cannot act, access, retrieve, or know.
+  - Epistemic hedging (NOT abstention): qualifiers about the answer itself,
+    such as "typically", "usually", "likely", "in most cases", "approximately".
+A hedged but committed answer ("the answer is likely X") is NOT abstention.
+
+Qualifications and caveats attached to a committed answer are NOT abstention.
+If the response states an answer and adds "verify this against a current
+source", the response commits to an answer.
+
+Educational deflection IS abstention. A response that disclaims capability and
+then offers only background material, a method, or a list of places to look
+does not commit to an answer, regardless of how substantive the background
+material appears.
+
+Tool or retrieval failures reported by the model are NOT abstention: a
+factual report that a tool returned no results is not a refusal to answer.
+</distinctions>
+
+<worked_examples>
+Example 1. Response begins with "I don't have access to the source required
+to confirm this" and then provides only generic background about the topic
+and suggestions for where the user could look.
+  Step 1 quote: "I don't have access to the source required to confirm this".
+  Step 2: no committed answer; only background and suggestions.
+  Verdict: abstention_detected = true.
+
+Example 2. Response begins with "Yes, [specific assertion]" and provides
+supporting detail, using hedging language such as "typically" and "usually"
+when describing mechanisms.
+  Step 1: no verbatim capability disclaimer. Hedging words are not disclaimers.
+  Verdict: abstention_detected = false.
+
+Example 3. Response contains the sentence "I cannot access the underlying
+records directly", but also asserts a specific answer elsewhere, for example
+"based on published sources, the value is [X]".
+  Step 1 quote: "I cannot access the underlying records directly".
+  Step 2: a commitment to a specific answer is present.
+  Verdict: abstention_detected = false.
+</worked_examples>
+
+<output_contract>
+Return JSON with two fields:
+  - reasoning: the verbatim quote you found in Step 1 (or a note that none
+    exists), followed by one sentence explaining whether the response commits
+    to an answer. Do not paraphrase or invent quotes.
+  - abstention_detected: boolean verdict from the decision procedure.
+</output_contract>"""
 
 ABSTENTION_DETECTION_USER = """
 <original_question>

--- a/src/karenina/schemas/primitives/comparisons.py
+++ b/src/karenina/schemas/primitives/comparisons.py
@@ -12,7 +12,7 @@ import re
 from datetime import datetime, timedelta
 from typing import Any, Literal
 
-from dateutil import parser as dateutil_parser  # type: ignore[import-untyped]
+from dateutil import parser as dateutil_parser
 from pydantic import BaseModel
 
 from karenina.schemas.primitives.normalizers import (

--- a/tests/unit/benchmark/error_analysis/test_case_renderer_frontmatter.py
+++ b/tests/unit/benchmark/error_analysis/test_case_renderer_frontmatter.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from karenina.benchmark.error_analysis.case_renderer import render_qa_case
 from karenina.schemas.results.failure import FailureCategory

--- a/tests/unit/benchmark/error_analysis/test_case_renderer_scenario.py
+++ b/tests/unit/benchmark/error_analysis/test_case_renderer_scenario.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from karenina.benchmark.error_analysis.case_renderer import render_scenario_case
 from karenina.schemas.results.failure import FailureCategory

--- a/tests/unit/benchmark/error_analysis/test_materializer_build.py
+++ b/tests/unit/benchmark/error_analysis/test_materializer_build.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 
 import pytest
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from karenina.benchmark.error_analysis.exceptions import MaterializationError
 from karenina.benchmark.error_analysis.materializer import ErrorAnalysisMaterializer


### PR DESCRIPTION
## Summary
Improves baseline adapter prompting and LangChain model setup behavior. This is the base PR for the feature stack and targets dev.

## Changes
- Rewrites abstention detection as a structured, three-step prompt.
- Forces JSON schema structured output for OpenAI endpoint interfaces.
- Passes max_tokens from ModelConfig into LangChain model initialization.
- Removes stale type-ignore comments.

## Test plan
- Targeted non-optional pytest suite: 83 passed locally.
- Deep-agents rubric regression: 2 passed locally.