### PR TITLE
feat(verification): add answerer concurrency controls

### DIFF
--- a/docs/core_concepts/verification-pipeline.md
+++ b/docs/core_concepts/verification-pipeline.md
@@ -433,6 +433,28 @@ for i, s in enumerate(orch.stages, 1):
     print(f"  {i:2d}. {s.name}")
 ```
 
+## Scheduling across multiple inference endpoints
+
+`VerificationConfig` offers two knobs for multi-endpoint deployments (for example several vLLM servers, each hosting one answering model):
+
+1. **`task_ordering`** controls the order in which expanded tasks are handed to the executor. The default `"auto"` picks `"distribute_answerers"` when the configured `answering_models` span more than one distinct `ModelIdentity.canonical_key`, and `"prefix_cache"` otherwise. `"distribute_answerers"` round-robins tasks across answerer identities while preserving prefix-cache locality inside each answerer group, so consecutive tasks target different inference endpoints and no single server is serialized. The other values (`"prefix_cache"`, `"generation_order"`, `"random"`) remain available for manual pinning.
+
+2. **`answerer_concurrency_limits`** caps how many tasks may be in flight on a given answerer at once. Pass an `int` to apply the same cap to every configured answerer; pass a `dict[str, int]` keyed by `ModelConfig.id` for per-model caps. Answerers not present in the dict run uncapped. `None` (the default) disables caps.
+
+Ordering and caps compose. Ordering smooths the steady state so the cap rarely engages; caps guarantee the ceiling under retry bursts or cache-hit cascades. Example for a run with three vLLM hosts and `async_max_workers=48`:
+
+```python
+VerificationConfig(
+    answering_models=[qwen_a, qwen_b, qwen_c],
+    parsing_models=[...],
+    async_max_workers=48,
+    answerer_concurrency_limits=16,  # every answerer capped at 16
+    # task_ordering defaults to "auto" -> distribute_answerers
+)
+```
+
+The cap is applied at task start (around the whole pipeline run for each task), so when the same endpoint hosts both the answerer and the parser the cap implicitly covers both phases. Stage-level caps are not currently supported.
+
 ## 10. Next Steps
 
 - [Evaluation Modes](../evaluation-modes/): how the three modes shape which stages run

--- a/src/karenina/adapters/langchain/llm.py
+++ b/src/karenina/adapters/langchain/llm.py
@@ -386,17 +386,34 @@ class LangChainLLMAdapter:
             >>> response = await structured.ainvoke(messages)
             >>> assert isinstance(response.raw, Answer)
         """
-        # Try to create a structured model for native support
+        # Try to create a structured model for native support.
+        # For OpenAI-compatible self-hosted endpoints (e.g. vLLM, Ollama), force
+        # method="json_schema" so the server enforces the schema via guided
+        # decoding. Small models on these backends often fail the LangChain
+        # default function-calling path, which silently returns None or raises.
         structured_model = None
         if hasattr(self._model, "with_structured_output"):
+            kwargs: dict[str, Any] = {}
+            if self._config.interface == "openai_endpoint":
+                kwargs["method"] = "json_schema"
             try:
-                structured_model = self._model.with_structured_output(schema)
+                structured_model = self._model.with_structured_output(schema, **kwargs)
             except Exception as e:
-                # Creation failed - will use fallback at invoke time
                 logger.debug(
-                    f"Could not create structured model for {self._config.model_name}: {e}. "
-                    "Will use fallback parsing at invoke time."
+                    "Could not create structured model for %s with %s: %s. Retrying without method override.",
+                    self._config.model_name,
+                    kwargs or "default method",
+                    e,
                 )
+                if kwargs:
+                    try:
+                        structured_model = self._model.with_structured_output(schema)
+                    except Exception as e2:
+                        logger.debug(
+                            "Could not create structured model for %s: %s. Will use fallback parsing at invoke time.",
+                            self._config.model_name,
+                            e2,
+                        )
 
         return LangChainLLMAdapter(
             model_config=self._config,

--- a/src/karenina/adapters/langchain/llm.py
+++ b/src/karenina/adapters/langchain/llm.py
@@ -132,6 +132,9 @@ class LangChainLLMAdapter:
         if self._config.temperature is not None:
             kwargs["temperature"] = self._config.temperature
 
+        if self._config.max_tokens is not None:
+            kwargs["max_tokens"] = self._config.max_tokens
+
         if self._config.request_timeout is not None:
             # LangChain's ChatAnthropic uses 'default_request_timeout', not 'request_timeout'.
             # Other providers (OpenAI, Google) accept 'request_timeout' as-is.

--- a/src/karenina/adapters/langchain/mcp.py
+++ b/src/karenina/adapters/langchain/mcp.py
@@ -90,7 +90,7 @@ async def acreate_mcp_client_and_tools(
 
     try:
         # Create client and fetch tools with timeout
-        client = MultiServerMCPClient(server_config)  # type: ignore[arg-type]
+        client = MultiServerMCPClient(server_config)
 
         # Add timeout to prevent hanging
         tools = await asyncio.wait_for(client.get_tools(), timeout=30.0)

--- a/src/karenina/adapters/langchain_deep_agents/mcp.py
+++ b/src/karenina/adapters/langchain_deep_agents/mcp.py
@@ -95,7 +95,7 @@ async def convert_mcp_to_tools(
 
     from langchain_mcp_adapters.client import MultiServerMCPClient
 
-    client = MultiServerMCPClient(server_params)  # type: ignore[arg-type]
-    await exit_stack.enter_async_context(client)  # type: ignore[arg-type]
+    client = MultiServerMCPClient(server_params)
+    await exit_stack.enter_async_context(client)
     tools: list[Any] = await client.get_tools()
     return tools

--- a/src/karenina/benchmark/error_analysis/case_renderer.py
+++ b/src/karenina/benchmark/error_analysis/case_renderer.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from karenina.replay.ports_message_hydration import hydrate_trace_messages
 from karenina.scenario.handover import TaggedMessage, format_transcript

--- a/src/karenina/benchmark/verification/batch_runner.py
+++ b/src/karenina/benchmark/verification/batch_runner.py
@@ -63,6 +63,33 @@ def _apply_retry_config(model: Any, retry_policy: Any | None) -> Any:
     return model
 
 
+def _normalize_answerer_limits(
+    value: int | dict[str, int] | None,
+    answering_models: list[Any],
+) -> dict[str, int] | None:
+    """Normalize ``VerificationConfig.answerer_concurrency_limits`` to a dict or None.
+
+    - ``None``: returned as ``None``.
+    - ``int``: broadcast to every model in ``answering_models`` that has an ``id``.
+    - ``dict``: returned as a shallow copy. Keys not present in
+      ``answering_models`` are still retained (in case the caller wants them)
+      but logged at WARNING so operator typos are visible.
+    """
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return {m.id: value for m in answering_models if getattr(m, "id", None)}
+
+    known_ids = {m.id for m in answering_models if getattr(m, "id", None)}
+    unknown = sorted(set(value) - known_ids)
+    if unknown:
+        logger.warning(
+            "answerer_concurrency_limits contains ids not in answering_models: %s",
+            unknown,
+        )
+    return dict(value)
+
+
 def _resolve_task_ordering(config: VerificationConfig) -> str:
     """Resolve ``task_ordering='auto'`` based on the number of distinct answerer identities.
 

--- a/src/karenina/benchmark/verification/batch_runner.py
+++ b/src/karenina/benchmark/verification/batch_runner.py
@@ -63,6 +63,62 @@ def _apply_retry_config(model: Any, retry_policy: Any | None) -> Any:
     return model
 
 
+def _resolve_task_ordering(config: VerificationConfig) -> str:
+    """Resolve ``task_ordering='auto'`` based on the number of distinct answerer identities.
+
+    Returns the resolved strategy name. Non-``auto`` values pass through
+    unchanged. A single INFO log records the resolution for operator
+    visibility.
+    """
+    if config.task_ordering != "auto":
+        return config.task_ordering
+
+    from karenina.schemas.verification.model_identity import ModelIdentity
+
+    answerer_keys = {
+        ModelIdentity.from_model_config(m, role="answering").canonical_key for m in config.answering_models
+    }
+    if len(answerer_keys) > 1:
+        logger.info(
+            "task_ordering=auto -> distribute_answerers (%d distinct answerer identities)",
+            len(answerer_keys),
+        )
+        return "distribute_answerers"
+
+    logger.info("task_ordering=auto -> prefix_cache (single answerer identity)")
+    return "prefix_cache"
+
+
+def _apply_task_ordering(task_queue: list[dict[str, Any]], strategy: str) -> list[dict[str, Any]]:
+    """Apply the given task-ordering strategy to ``task_queue`` and return the result.
+
+    Mutates the input list for in-place strategies (``prefix_cache``,
+    ``random``) and returns the same reference. Returns a new list for
+    ``distribute_answerers``. ``generation_order`` returns the input as-is.
+    """
+    from .utils.task_helpers import interleave_by_answerer, model_sort_key
+
+    if strategy == "prefix_cache":
+        task_queue.sort(
+            key=lambda t: (
+                model_sort_key(t["answering_model"]),
+                t["question_id"],
+                model_sort_key(t["parsing_model"]),
+                t.get("replicate") or 0,
+            )
+        )
+        return task_queue
+    if strategy == "distribute_answerers":
+        return interleave_by_answerer(task_queue)
+    if strategy == "random":
+        import random
+
+        random.shuffle(task_queue)
+        return task_queue
+    # "generation_order": no-op, preserve loop order
+    return task_queue
+
+
 # ============================================================================
 # Task Queue Generation
 # ============================================================================
@@ -434,22 +490,8 @@ def run_verification_batch(
         progress_callback = _sink_progress_adapter
 
     # Apply task ordering strategy
-    from .utils.task_helpers import model_sort_key
-
-    if config.task_ordering == "prefix_cache":
-        task_queue.sort(
-            key=lambda t: (
-                model_sort_key(t["answering_model"]),
-                t["question_id"],
-                model_sort_key(t["parsing_model"]),
-                t.get("replicate") or 0,
-            )
-        )
-    elif config.task_ordering == "random":
-        import random
-
-        random.shuffle(task_queue)
-    # "generation_order": no-op, preserve loop order
+    effective = _resolve_task_ordering(config)
+    task_queue = _apply_task_ordering(task_queue, effective)
 
     # Log execution plan
     logger.info(f"Starting verification: {len(task_queue)} tasks ({'parallel' if async_enabled else 'sequential'})")

--- a/src/karenina/benchmark/verification/batch_runner.py
+++ b/src/karenina/benchmark/verification/batch_runner.py
@@ -526,11 +526,18 @@ def run_verification_batch(
     # Execute tasks using the VerificationExecutor
     from .executor import ExecutorConfig, VerificationExecutor
 
+    answerer_limits = _normalize_answerer_limits(config.answerer_concurrency_limits, config.answering_models)
+    if answerer_limits:
+        logger.info(
+            "answerer_concurrency_limits active: %s",
+            answerer_limits,
+        )
     executor = VerificationExecutor(
         parallel=async_enabled,
         config=ExecutorConfig(
             max_workers=max_workers,
             max_requeue_count=config.max_requeue_count,
+            answerer_concurrency_limits=answerer_limits,
         ),
     )
 

--- a/src/karenina/benchmark/verification/executor.py
+++ b/src/karenina/benchmark/verification/executor.py
@@ -187,6 +187,32 @@ class VerificationExecutor:
                 self._endpoint_semaphores[ans_id] = existing
             return existing
 
+    def _execute_task_with_cap(
+        self,
+        task: dict[str, Any],
+        answer_cache: AnswerTraceCache | None,
+        cache_status: str | None,
+        cached_answer_data: dict[str, Any] | None,
+    ) -> tuple[str, VerificationResult]:
+        """Run ``execute_task`` with optional per-answerer concurrency capping.
+
+        Imports ``execute_task`` lazily to avoid circular imports.
+        """
+        from .batch_runner import execute_task
+
+        limits = self.config.answerer_concurrency_limits
+        if not limits:
+            return execute_task(task, answer_cache, cache_status, cached_answer_data)
+
+        ans_id: str | None = getattr(task["answering_model"], "id", None)
+        limit = limits.get(ans_id) if ans_id else None
+        if limit is None or ans_id is None:
+            return execute_task(task, answer_cache, cache_status, cached_answer_data)
+
+        sem = self._get_endpoint_semaphore(ans_id, limit)
+        with sem:
+            return execute_task(task, answer_cache, cache_status, cached_answer_data)
+
     def run_batch(
         self,
         tasks: list[dict[str, Any]],
@@ -231,7 +257,6 @@ class VerificationExecutor:
         """
         from karenina.exceptions import VerificationBatchError
 
-        from .batch_runner import execute_task
         from .utils.cache_helpers import log_cache_stats
         from .utils.task_helpers import create_preview_result
 
@@ -255,7 +280,7 @@ class VerificationExecutor:
 
                     try:
                         # Execute the task with answer cache
-                        result_key, result = execute_task(task, answer_cache)
+                        result_key, result = self._execute_task_with_cap(task, answer_cache, None, None)
                         results[result_key] = result
                     except Exception as e:
                         logger.error("Sequential task %s failed: %s", task["question_id"], e)
@@ -314,7 +339,6 @@ class VerificationExecutor:
         """
         from karenina.exceptions import VerificationBatchError
 
-        from .batch_runner import execute_task
         from .utils.cache_helpers import generate_answer_cache_key, log_cache_stats
         from .utils.task_helpers import create_preview_result
 
@@ -363,7 +387,7 @@ class VerificationExecutor:
                     progress_callback(completed_count[0] + 1, total, preview_result)
 
             if not answer_cache:
-                return idx, execute_task(task, answer_cache)
+                return idx, self._execute_task_with_cap(task, answer_cache, None, None)
 
             cache_key = generate_answer_cache_key(task)
             for attempt in range(max_requeue + 1):
@@ -388,11 +412,11 @@ class VerificationExecutor:
                     continue
 
                 # MISS or HIT: execute
-                return idx, execute_task(
+                return idx, self._execute_task_with_cap(
                     task,
                     answer_cache,
-                    cache_status=status,
-                    cached_answer_data=cached_answer_data,
+                    status,
+                    cached_answer_data,
                 )
 
             # Exceeded max requeue: force reset, generate fresh
@@ -402,7 +426,7 @@ class VerificationExecutor:
                 max_requeue,
             )
             answer_cache.force_reset(cache_key)
-            return idx, execute_task(task, answer_cache)
+            return idx, self._execute_task_with_cap(task, answer_cache, None, None)
 
         # Preserve incoming order (ordering is controlled by task_ordering config)
         indexed_tasks = list(enumerate(tasks))

--- a/src/karenina/benchmark/verification/executor.py
+++ b/src/karenina/benchmark/verification/executor.py
@@ -126,6 +126,11 @@ class ExecutorConfig:
         max_requeue_count: Maximum times a task can be requeued before forcing a
             fresh generation (default: 5). When exceeded, the cache entry is reset
             and the task restarts with retry_count=0.
+        answerer_concurrency_limits: Optional dict mapping answerer
+            ``ModelConfig.id`` to the max number of concurrent tasks allowed on
+            that answerer. Already normalized (the public int-or-dict form is
+            reduced to a plain dict by ``_normalize_answerer_limits``). ``None``
+            (the default) disables caps; every task runs unthrottled.
     """
 
     max_workers: int = DEFAULT_ASYNC_MAX_WORKERS
@@ -133,6 +138,7 @@ class ExecutorConfig:
     retry_wait_seconds: float = 5.0
     timeout_seconds: float | None = None
     max_requeue_count: int = 5
+    answerer_concurrency_limits: dict[str, int] | None = None
 
 
 # ============================================================================
@@ -161,6 +167,25 @@ class VerificationExecutor:
         """
         self.parallel = parallel
         self.config = config or ExecutorConfig()
+        self._endpoint_semaphores: dict[str, threading.Semaphore] = {}
+        self._endpoint_semaphores_lock = threading.Lock()
+
+    def _get_endpoint_semaphore(self, ans_id: str, limit: int) -> threading.Semaphore:
+        """Return the semaphore for ``ans_id``, creating it on first access.
+
+        Thread-safe: the mutation of ``self._endpoint_semaphores`` is guarded
+        by ``self._endpoint_semaphores_lock`` so that two workers racing for
+        the same unseen key share a single ``threading.Semaphore`` instance.
+        """
+        existing = self._endpoint_semaphores.get(ans_id)
+        if existing is not None:
+            return existing
+        with self._endpoint_semaphores_lock:
+            existing = self._endpoint_semaphores.get(ans_id)
+            if existing is None:
+                existing = threading.Semaphore(limit)
+                self._endpoint_semaphores[ans_id] = existing
+            return existing
 
     def run_batch(
         self,

--- a/src/karenina/benchmark/verification/prompts/trace/abstention.py
+++ b/src/karenina/benchmark/verification/prompts/trace/abstention.py
@@ -5,38 +5,97 @@ declares that it is not answering the question.
 """
 
 ABSTENTION_DETECTION_SYS = """<role>
-You are a precise abstention detection assistant. Your job is to decide whether a model's response contains an explicit declaration that the model is not answering the question.
+You are a precise abstention detection assistant. Your job is to decide whether
+a model's response contains an explicit declaration that the model is not
+answering the question. You must ground every decision in verbatim text from
+the response: never quote or paraphrase sentences that are not present.
 </role>
 
-<critical_instructions>
-<detection_rule>
-Mark the response as abstention if, and only if, the response contains an explicit statement that the model is refusing, declining, or unable to answer. Implicit signals (off-topic content, vague prose, deflection without an explicit refusal phrase) are NOT abstention, even when the response fails to address the question.
-</detection_rule>
+<decision_procedure>
+Follow these three steps in order. Stop at the first step whose answer
+resolves the decision.
 
-<is_abstention>
-The following count as abstention:
-- Direct refusals: "I cannot answer", "I will not answer", "I'm unable to provide", "I won't provide"
-- Capability disclaimers: "I don't have access to", "I lack the ability to", "I'm not equipped to"
-- Lack-of-information declarations: "I don't have information about", "I cannot find data on", "I have no knowledge of"
-- Safety or policy refusals: "I can't help with that", "This violates my guidelines", "I'm not authorized to discuss"
-</is_abstention>
+Step 1. Find a verbatim capability disclaimer.
+Search the response for a literal sentence that declares inability to answer
+THIS specific question. The sentence must state one of:
+  - inability to act: "I cannot answer", "I will not answer", "I won't provide",
+    "I'm unable to provide", "I can't help with that"
+  - inability to access information or tools: "I don't have access to",
+    "I cannot access", "I cannot retrieve", "I lack real-time access",
+    "I don't have direct access"
+  - absence of knowledge: "I don't have information about", "I have no
+    knowledge of", "I cannot find data on"
+  - policy refusal: "this violates my guidelines", "I'm not authorized"
+Copy the exact sentence you found into your reasoning. If no such verbatim
+sentence exists, set abstention_detected = false and stop.
 
-<is_not_abstention>
-The following are NOT abstention, even when they may look like non-answers:
-- Tool or retrieval failures: the model attempted to answer but reports a tool error, missing data, or a failed search. The response describes the failure; it does not refuse to answer.
-- Off-topic answers: the model confidently answers, but about the wrong thing. That is a correctness problem, not a refusal.
-- Hedged guesses: "I'm not sure, maybe X or Y", "Possibly Z". The model commits to one or more candidate values under uncertainty.
-- Qualified or partial answers: answers with caveats, disclaimers, or coverage of only part of a multi-part question, as long as some substantive content is present.
-- Evasion or deflection without an explicit refusal phrase: vague prose, generalities, or redirection to other resources. If no explicit refusal is stated, it is not abstention.
-</is_not_abstention>
+Step 2. Check whether the response still commits to an answer.
+Read the rest of the response. Does it commit to a specific answer to the
+question? A commitment is an assertion made as the response's own answer: a
+direct yes or no, a named entity, a numerical value, a classification, or a
+definite claim. A commitment is NOT a conditional ("if X, then Y"), NOT a
+list of resources or steps the user should consult, and NOT generic background
+about the topic.
+  - If a commitment exists: set abstention_detected = false and stop. The
+    disclaimer is a caveat on a committed answer, not a refusal.
+  - If no commitment exists (only caveats, how-to guidance, generic background,
+    or deflection to external resources): set abstention_detected = true and
+    stop.
 
-<required_behavior>
-- Read the entire response before deciding.
-- Base the decision on what the response explicitly says, not on what it fails to say.
-- When in doubt, prefer "not abstention": the abstention label is reserved for explicit declarations.
-- Output a short reasoning string followed by the boolean verdict, as JSON.
-</required_behavior>
-</critical_instructions>"""
+Step 3. (reached only if Step 1 and Step 2 were ambiguous.)
+Default to abstention_detected = false.
+</decision_procedure>
+
+<distinctions>
+Capability disclaimers are NOT the same as epistemic hedging.
+  - Capability disclaimer (IS an abstention signal): explicit statements that
+    the model itself cannot act, access, retrieve, or know.
+  - Epistemic hedging (NOT abstention): qualifiers about the answer itself,
+    such as "typically", "usually", "likely", "in most cases", "approximately".
+A hedged but committed answer ("the answer is likely X") is NOT abstention.
+
+Qualifications and caveats attached to a committed answer are NOT abstention.
+If the response states an answer and adds "verify this against a current
+source", the response commits to an answer.
+
+Educational deflection IS abstention. A response that disclaims capability and
+then offers only background material, a method, or a list of places to look
+does not commit to an answer, regardless of how substantive the background
+material appears.
+
+Tool or retrieval failures reported by the model are NOT abstention: a
+factual report that a tool returned no results is not a refusal to answer.
+</distinctions>
+
+<worked_examples>
+Example 1. Response begins with "I don't have access to the source required
+to confirm this" and then provides only generic background about the topic
+and suggestions for where the user could look.
+  Step 1 quote: "I don't have access to the source required to confirm this".
+  Step 2: no committed answer; only background and suggestions.
+  Verdict: abstention_detected = true.
+
+Example 2. Response begins with "Yes, [specific assertion]" and provides
+supporting detail, using hedging language such as "typically" and "usually"
+when describing mechanisms.
+  Step 1: no verbatim capability disclaimer. Hedging words are not disclaimers.
+  Verdict: abstention_detected = false.
+
+Example 3. Response contains the sentence "I cannot access the underlying
+records directly", but also asserts a specific answer elsewhere, for example
+"based on published sources, the value is [X]".
+  Step 1 quote: "I cannot access the underlying records directly".
+  Step 2: a commitment to a specific answer is present.
+  Verdict: abstention_detected = false.
+</worked_examples>
+
+<output_contract>
+Return JSON with two fields:
+  - reasoning: the verbatim quote you found in Step 1 (or a note that none
+    exists), followed by one sentence explaining whether the response commits
+    to an answer. Do not paraphrase or invent quotes.
+  - abstention_detected: boolean verdict from the decision procedure.
+</output_contract>"""
 
 ABSTENTION_DETECTION_USER = """
 <original_question>

--- a/src/karenina/benchmark/verification/utils/task_helpers.py
+++ b/src/karenina/benchmark/verification/utils/task_helpers.py
@@ -5,6 +5,7 @@ few-shot resolution, and preview result creation.
 """
 
 import logging
+from itertools import zip_longest
 from typing import Any
 
 from karenina.schemas.entities import Rubric
@@ -33,6 +34,46 @@ def model_sort_key(model: Any) -> str:
         A string suitable for use as a sort key.
     """
     return getattr(model, "id", None) or getattr(model, "model_name", None) or ""
+
+
+def interleave_by_answerer(tasks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Round-robin tasks by answerer identity, prefix-cache-friendly within each group.
+
+    Groups the input tasks by the answerer's ``ModelIdentity.canonical_key``,
+    sorts each group using the prefix-cache-friendly key
+    ``(question_id, parse_key, replicate)``, then round-robins across groups
+    so consecutive tasks target different answerer identities when possible.
+
+    Group iteration order follows the insertion order of the input (first
+    appearance of each canonical key) to keep the output deterministic.
+
+    Args:
+        tasks: Task queue as produced by ``generate_task_queue``.
+
+    Returns:
+        A new list containing the same tasks in a re-ordered sequence. The
+        input is not mutated.
+    """
+    from karenina.schemas.verification.model_identity import ModelIdentity
+
+    if not tasks:
+        return []
+
+    groups: dict[str, list[dict[str, Any]]] = {}  # insertion-ordered (Python 3.7+)
+    for task in tasks:
+        key = ModelIdentity.from_model_config(task["answering_model"], role="answering").canonical_key
+        groups.setdefault(key, []).append(task)
+
+    for group in groups.values():
+        group.sort(
+            key=lambda t: (
+                t["question_id"],
+                model_sort_key(t["parsing_model"]),
+                t.get("replicate") or 0,
+            )
+        )
+
+    return [t for row in zip_longest(*groups.values()) for t in row if t is not None]
 
 
 def stamp_agentic_trait_overrides(

--- a/src/karenina/schemas/primitives/comparisons.py
+++ b/src/karenina/schemas/primitives/comparisons.py
@@ -12,7 +12,7 @@ import re
 from datetime import datetime, timedelta
 from typing import Any, Literal
 
-from dateutil import parser as dateutil_parser  # type: ignore[import-untyped]
+from dateutil import parser as dateutil_parser
 from pydantic import BaseModel
 
 from karenina.schemas.primitives.normalizers import (

--- a/src/karenina/schemas/verification/config.py
+++ b/src/karenina/schemas/verification/config.py
@@ -145,12 +145,33 @@ class VerificationConfig(BaseModel):
     )
 
     # Task ordering strategy for queue generation
-    task_ordering: Literal["prefix_cache", "generation_order", "random"] = Field(
-        default="prefix_cache",
+    task_ordering: Literal[
+        "auto",
+        "prefix_cache",
+        "distribute_answerers",
+        "generation_order",
+        "random",
+    ] = Field(
+        default="auto",
         description="Task queue ordering strategy. "
-        "'prefix_cache' (default) groups by answering model for KV cache hits. "
+        "'auto' (default) picks 'distribute_answerers' when answerers span "
+        "more than one distinct identity, else 'prefix_cache'. "
+        "'prefix_cache' groups by answering model for KV cache hits on a "
+        "single endpoint. "
+        "'distribute_answerers' round-robins across answerer identities to "
+        "spread load over multiple inference endpoints. "
         "'generation_order' preserves template-first loop order. "
         "'random' shuffles tasks.",
+    )
+
+    # Per-answerer concurrency caps (enforced at task start by the executor)
+    answerer_concurrency_limits: int | dict[str, int] | None = Field(
+        default=None,
+        description="Cap on concurrent tasks per answerer, enforced at task start. "
+        "Pass an int to apply the same cap to every entry in answering_models "
+        "(keyed by ModelConfig.id). Pass a dict keyed by ModelConfig.id for "
+        "per-model caps; answerers not in the dict run without a cap. "
+        "None disables caps (default).",
     )
 
     # Deep-judgment settings (multi-stage parsing with excerpts and reasoning)

--- a/tests/unit/benchmark/error_analysis/test_case_renderer_frontmatter.py
+++ b/tests/unit/benchmark/error_analysis/test_case_renderer_frontmatter.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from karenina.benchmark.error_analysis.case_renderer import render_qa_case
 from karenina.schemas.results.failure import FailureCategory

--- a/tests/unit/benchmark/error_analysis/test_case_renderer_scenario.py
+++ b/tests/unit/benchmark/error_analysis/test_case_renderer_scenario.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from karenina.benchmark.error_analysis.case_renderer import render_scenario_case
 from karenina.schemas.results.failure import FailureCategory

--- a/tests/unit/benchmark/error_analysis/test_materializer_build.py
+++ b/tests/unit/benchmark/error_analysis/test_materializer_build.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 
 import pytest
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from karenina.benchmark.error_analysis.exceptions import MaterializationError
 from karenina.benchmark.error_analysis.materializer import ErrorAnalysisMaterializer

--- a/tests/unit/benchmark/verification/test_batch_runner.py
+++ b/tests/unit/benchmark/verification/test_batch_runner.py
@@ -306,3 +306,83 @@ class TestNormalizeAnswererLimits:
 
         assert out == {"ghost": 5}
         assert any("ghost" in rec.message for rec in caplog.records)
+
+
+# =============================================================================
+# answerer_concurrency_limits -> ExecutorConfig plumbing
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestAnswererConcurrencyLimitsPlumbing:
+    """End-to-end plumbing: VerificationConfig -> normalization -> ExecutorConfig.
+
+    Uses a ``_FakeExecutor`` patched onto ``executor.VerificationExecutor`` so
+    the test intercepts the constructor before any tasks run. The patch target
+    is correct because ``run_verification_batch`` does a local
+    ``from .executor import VerificationExecutor`` at call time, which reads
+    ``executor.VerificationExecutor``.
+    """
+
+    def test_int_limit_reaches_executor_as_dict(self, monkeypatch) -> None:
+        from karenina.benchmark.verification import batch_runner as br_mod
+        from karenina.benchmark.verification import executor as exec_mod
+
+        captured: dict[str, object] = {}
+
+        class _FakeExecutor:
+            def __init__(self, parallel, config):  # noqa: ARG002
+                captured["parallel"] = parallel
+                captured["config"] = config
+
+            def run_batch(self, tasks, progress_callback=None):  # noqa: ARG002
+                return {}
+
+        monkeypatch.setattr(br_mod, "cleanup_resources", lambda: None)
+        monkeypatch.setattr(exec_mod, "VerificationExecutor", _FakeExecutor)
+
+        template = _make_template()
+        config = VerificationConfig(
+            answering_models=[HAIKU, SONNET],
+            parsing_models=[HAIKU],
+            answerer_concurrency_limits=16,
+            async_enabled=True,
+            async_max_workers=4,
+        )
+
+        br_mod.run_verification_batch(
+            templates=[template],
+            config=config,
+            run_name="plumb-test",
+        )
+
+        executor_config = captured["config"]
+        assert executor_config.answerer_concurrency_limits == {"haiku": 16, "sonnet": 16}
+
+    def test_none_limit_passes_none(self, monkeypatch) -> None:
+        from karenina.benchmark.verification import batch_runner as br_mod
+        from karenina.benchmark.verification import executor as exec_mod
+
+        captured: dict[str, object] = {}
+
+        class _FakeExecutor:
+            def __init__(self, parallel, config):  # noqa: ARG002
+                captured["config"] = config
+
+            def run_batch(self, tasks, progress_callback=None):  # noqa: ARG002
+                return {}
+
+        monkeypatch.setattr(br_mod, "cleanup_resources", lambda: None)
+        monkeypatch.setattr(exec_mod, "VerificationExecutor", _FakeExecutor)
+
+        template = _make_template()
+        config = VerificationConfig(
+            answering_models=[HAIKU],
+            parsing_models=[HAIKU],
+            async_enabled=True,
+            async_max_workers=4,
+        )
+
+        br_mod.run_verification_batch(templates=[template], config=config)
+
+        assert captured["config"].answerer_concurrency_limits is None

--- a/tests/unit/benchmark/verification/test_batch_runner.py
+++ b/tests/unit/benchmark/verification/test_batch_runner.py
@@ -161,3 +161,101 @@ class TestApplyRetryConfig:
         result = _apply_retry_config(model, retry_policy=None)
         assert result.retry_policy is None
         assert result is model  # Same object, no copy
+
+
+# =============================================================================
+# task_ordering resolution and dispatch
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestResolveTaskOrdering:
+    """Tests for _resolve_task_ordering (auto resolution + passthrough)."""
+
+    def _make_config(self, *, ordering: str, answerers: list[ModelConfig]) -> VerificationConfig:
+        return VerificationConfig(
+            answering_models=answerers,
+            parsing_models=[HAIKU],
+            task_ordering=ordering,
+        )
+
+    def test_auto_picks_prefix_cache_for_single_answerer(self) -> None:
+        from karenina.benchmark.verification.batch_runner import _resolve_task_ordering
+
+        config = self._make_config(ordering="auto", answerers=[HAIKU])
+        assert _resolve_task_ordering(config) == "prefix_cache"
+
+    def test_auto_picks_distribute_answerers_for_multiple_answerers(self) -> None:
+        from karenina.benchmark.verification.batch_runner import _resolve_task_ordering
+
+        config = self._make_config(ordering="auto", answerers=[HAIKU, SONNET])
+        assert _resolve_task_ordering(config) == "distribute_answerers"
+
+    def test_auto_picks_prefix_cache_when_duplicated_answerers_share_identity(self) -> None:
+        """Duplicate ModelConfigs with the same canonical_key count as one group."""
+        from karenina.benchmark.verification.batch_runner import _resolve_task_ordering
+
+        dup = _make_model("haiku")
+        config = self._make_config(ordering="auto", answerers=[HAIKU, dup])
+        assert _resolve_task_ordering(config) == "prefix_cache"
+
+    def test_passthrough_for_pinned_values(self) -> None:
+        from karenina.benchmark.verification.batch_runner import _resolve_task_ordering
+
+        for pinned in ("prefix_cache", "distribute_answerers", "generation_order", "random"):
+            config = self._make_config(ordering=pinned, answerers=[HAIKU, SONNET])
+            assert _resolve_task_ordering(config) == pinned
+
+
+@pytest.mark.unit
+class TestSortDispatch:
+    """Tests for the dispatch that applies the resolved ordering to the queue."""
+
+    def _tasks(self, answerers: list[str], questions: list[str]) -> list[dict]:
+        out: list[dict] = []
+        for ans in answerers:
+            for q in questions:
+                out.append(
+                    {
+                        "answering_model": _make_model(ans),
+                        "parsing_model": HAIKU,
+                        "question_id": q,
+                        "replicate": 1,
+                    }
+                )
+        return out
+
+    def test_distribute_answerers_produces_round_robin_head(self) -> None:
+        from karenina.benchmark.verification.batch_runner import _apply_task_ordering
+
+        tasks = self._tasks(["a", "b", "c"], ["q1", "q2", "q3"])
+        ordered = _apply_task_ordering(tasks, "distribute_answerers")
+
+        head = [t["answering_model"].id for t in ordered[:3]]
+        assert set(head) == {"a", "b", "c"}
+        assert len(ordered) == len(tasks)
+
+    def test_prefix_cache_groups_by_answerer(self) -> None:
+        from karenina.benchmark.verification.batch_runner import _apply_task_ordering
+
+        tasks = self._tasks(["b", "a"], ["q2", "q1"])
+        ordered = _apply_task_ordering(tasks, "prefix_cache")
+
+        answerer_run = [t["answering_model"].id for t in ordered]
+        assert answerer_run == ["a", "a", "b", "b"]
+
+    def test_generation_order_is_passthrough(self) -> None:
+        from karenina.benchmark.verification.batch_runner import _apply_task_ordering
+
+        tasks = self._tasks(["a", "b"], ["q1", "q2"])
+        assert _apply_task_ordering(list(tasks), "generation_order") == tasks
+
+    def test_random_preserves_task_count(self) -> None:
+        from karenina.benchmark.verification.batch_runner import _apply_task_ordering
+
+        tasks = self._tasks(["a", "b"], ["q1", "q2", "q3"])
+        ordered = _apply_task_ordering(list(tasks), "random")
+        assert len(ordered) == len(tasks)
+        ids = sorted((t["answering_model"].id, t["question_id"]) for t in ordered)
+        expected = sorted((t["answering_model"].id, t["question_id"]) for t in tasks)
+        assert ids == expected

--- a/tests/unit/benchmark/verification/test_batch_runner.py
+++ b/tests/unit/benchmark/verification/test_batch_runner.py
@@ -259,3 +259,50 @@ class TestSortDispatch:
         ids = sorted((t["answering_model"].id, t["question_id"]) for t in ordered)
         expected = sorted((t["answering_model"].id, t["question_id"]) for t in tasks)
         assert ids == expected
+
+
+# =============================================================================
+# _normalize_answerer_limits
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestNormalizeAnswererLimits:
+    """Tests for _normalize_answerer_limits (int broadcast, dict passthrough, warnings)."""
+
+    def test_none_returns_none(self) -> None:
+        from karenina.benchmark.verification.batch_runner import _normalize_answerer_limits
+
+        assert _normalize_answerer_limits(None, [HAIKU, SONNET]) is None
+
+    def test_int_broadcast(self) -> None:
+        from karenina.benchmark.verification.batch_runner import _normalize_answerer_limits
+
+        assert _normalize_answerer_limits(16, [HAIKU, SONNET]) == {
+            "haiku": 16,
+            "sonnet": 16,
+        }
+
+    def test_int_broadcast_skips_models_without_id(self) -> None:
+        from karenina.benchmark.verification.batch_runner import _normalize_answerer_limits
+
+        class _NoId:
+            id = None
+            model_name = "x"
+
+        assert _normalize_answerer_limits(5, [HAIKU, _NoId()]) == {"haiku": 5}
+
+    def test_dict_passthrough(self) -> None:
+        from karenina.benchmark.verification.batch_runner import _normalize_answerer_limits
+
+        out = _normalize_answerer_limits({"haiku": 10, "sonnet": 20}, [HAIKU, SONNET])
+        assert out == {"haiku": 10, "sonnet": 20}
+
+    def test_dict_with_unknown_id_warns_and_returns_dict(self, caplog) -> None:
+        from karenina.benchmark.verification.batch_runner import _normalize_answerer_limits
+
+        with caplog.at_level("WARNING"):
+            out = _normalize_answerer_limits({"ghost": 5}, [HAIKU])
+
+        assert out == {"ghost": 5}
+        assert any("ghost" in rec.message for rec in caplog.records)

--- a/tests/unit/benchmark/verification/test_executor.py
+++ b/tests/unit/benchmark/verification/test_executor.py
@@ -147,7 +147,7 @@ class TestSequentialErrorHandling:
         tasks = [_make_task("q1"), _make_task("q2"), _make_task("q3")]
         call_count = 0
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             nonlocal call_count
             call_count += 1
             if task["question_id"] == "q2":
@@ -181,7 +181,7 @@ class TestSequentialErrorHandling:
         """When all tasks succeed, sequential mode returns a normal dict (no exception)."""
         tasks = [_make_task("q1"), _make_task("q2")]
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             return (f"key_{task['question_id']}", _make_result(task["question_id"]))
 
         monkeypatch.setattr(
@@ -200,7 +200,7 @@ class TestSequentialErrorHandling:
         """When all tasks fail, the error has empty partial_results and all errors."""
         tasks = [_make_task("q1"), _make_task("q2")]
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             raise RuntimeError(f"fail_{task['question_id']}")
 
         monkeypatch.setattr(
@@ -232,7 +232,7 @@ class TestParallelDeadlockFix:
         (does not hang) and raises VerificationBatchError."""
         tasks = [_make_task("q1"), _make_task("q2"), _make_task("q3")]
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             if task["question_id"] == "q2":
                 raise RuntimeError("infrastructure failure")
             return (f"key_{task['question_id']}", _make_result(task["question_id"]))
@@ -260,7 +260,7 @@ class TestParallelDeadlockFix:
         """When all tasks succeed in parallel mode, returns a normal dict."""
         tasks = [_make_task("q1"), _make_task("q2")]
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             return (f"key_{task['question_id']}", _make_result(task["question_id"]))
 
         monkeypatch.setattr(
@@ -290,7 +290,7 @@ class TestErrorSymmetry:
         """Sequential and parallel modes raise VerificationBatchError for the same failure."""
         tasks = [_make_task("q1"), _make_task("q2")]
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             if task["question_id"] == "q2":
                 raise RuntimeError("boom")
             return (f"key_{task['question_id']}", _make_result(task["question_id"]))
@@ -340,7 +340,7 @@ class TestTimeoutSafetyNet:
         the timeout fires and raises VerificationBatchError."""
         tasks = [_make_task("q1")]
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             # This succeeds, but we'll patch the completion tracking to never fire
             return (f"key_{task['question_id']}", _make_result(task["question_id"]))
 
@@ -385,7 +385,7 @@ class TestErrorDetailQuality:
         """Error message reports how many tasks failed out of total."""
         tasks = [_make_task("q1"), _make_task("q2"), _make_task("q3")]
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             if task["question_id"] in ("q1", "q3"):
                 raise ValueError(f"bad_{task['question_id']}")
             return (f"key_{task['question_id']}", _make_result(task["question_id"]))
@@ -408,7 +408,7 @@ class TestErrorDetailQuality:
         """Each error entry has the original exception with its type and message."""
         tasks = [_make_task("q1"), _make_task("q2")]
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             if task["question_id"] == "q1":
                 raise TypeError("type mismatch in q1")
             return (f"key_{task['question_id']}", _make_result(task["question_id"]))
@@ -445,7 +445,12 @@ class TestSequentialPortalManagement:
 
         captured_portals: list = []
 
-        def mock_execute_task(task: dict, answer_cache: object) -> tuple[str, VerificationResult]:
+        def mock_execute_task(
+            task: dict,
+            answer_cache: object = None,
+            cache_status: str | None = None,
+            cached_answer_data: dict | None = None,
+        ) -> tuple[str, VerificationResult]:
             captured_portals.append(get_async_portal())
             return (task["question_id"], _make_result(task["question_id"]))
 
@@ -469,7 +474,12 @@ class TestSequentialPortalManagement:
         """Portal is cleared even when all tasks fail."""
         from karenina.benchmark.verification.executor import get_async_portal
 
-        def mock_execute_task(task: dict, answer_cache: object) -> tuple[str, VerificationResult]:
+        def mock_execute_task(
+            task: dict,
+            answer_cache: object = None,
+            cache_status: str | None = None,
+            cached_answer_data: dict | None = None,
+        ) -> tuple[str, VerificationResult]:
             raise RuntimeError("task failed")
 
         monkeypatch.setattr(
@@ -494,7 +504,12 @@ class TestSequentialPortalManagement:
         async def async_fn() -> str:
             return "ok"
 
-        def mock_execute_task(task: dict, answer_cache: object) -> tuple[str, VerificationResult]:
+        def mock_execute_task(
+            task: dict,
+            answer_cache: object = None,
+            cache_status: str | None = None,
+            cached_answer_data: dict | None = None,
+        ) -> tuple[str, VerificationResult]:
             portal = get_async_portal()
             async_results.append(portal.call(async_fn))
             return (task["question_id"], _make_result(task["question_id"]))
@@ -605,7 +620,7 @@ class TestPerWorkerPortals:
         worker_barrier = threading.Barrier(2, timeout=5.0)
         barrier_released = threading.Event()
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             if not barrier_released.is_set():
                 with contextlib.suppress(threading.BrokenBarrierError):
                     worker_barrier.wait()
@@ -662,7 +677,7 @@ class TestInFlightTasksNotSilentlyDropped:
         fast_ids = {"q0", "q1"}
         slow_delay = 0.8  # slow tasks finish ~0.5s after the batch timeout
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             if task["question_id"] not in fast_ids:
                 time.sleep(slow_delay)
             return (f"key_{task['question_id']}", _make_result(task["question_id"]))
@@ -704,7 +719,7 @@ class TestInFlightTasksNotSilentlyDropped:
         tasks = [_make_task(f"q{i}") for i in range(4)]
         fast_ids = {"q0", "q1"}
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             qid = task["question_id"]
             if qid not in fast_ids:
                 time.sleep(0.8)
@@ -784,7 +799,7 @@ class TestPreTeardownAclose:
                 with aclose_lock:
                     aclose_thread_ids.append(threading.get_ident())
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             # Run inside the worker thread: register an adapter so the
             # registry tracks it against this worker's portal.
             register_adapter(PortalAwareAdapter())
@@ -853,7 +868,7 @@ class TestPreTeardownAclose:
                 # Exceed the short timeout so the finally block must give up.
                 await asyncio.sleep(10.0)
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             register_adapter(StuckAdapter())
             return (f"key_{task['question_id']}", _make_result(task["question_id"]))
 
@@ -965,3 +980,183 @@ class TestAnswererConcurrencyLimitsPlumbing:
             t.join()
 
         assert len({id(s) for s in seen}) == 1
+
+
+# =============================================================================
+# _execute_task_with_cap and integration with run_batch
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestExecuteTaskWithCap:
+    """Direct unit tests for _execute_task_with_cap.
+
+    Note on monkeypatching: ``_execute_task_with_cap`` does a local
+    ``from .batch_runner import execute_task`` at call time, so we patch the
+    *source* attribute ``batch_runner.execute_task`` (not
+    ``executor.execute_task``, which does not exist as a module attribute).
+    """
+
+    def _stub_task(self, ans_id: str) -> dict:
+        class _M:
+            id = ans_id
+
+        return {"answering_model": _M(), "question_id": "q1", "replicate": None}
+
+    def test_no_limits_calls_through(self, monkeypatch) -> None:
+        from karenina.benchmark.verification import batch_runner as br_mod
+        from karenina.benchmark.verification.executor import (
+            ExecutorConfig,
+            VerificationExecutor,
+        )
+
+        calls: list[dict] = []
+
+        def _fake_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
+            calls.append(task)
+            return ("key", object())
+
+        monkeypatch.setattr(br_mod, "execute_task", _fake_execute_task)
+
+        ex = VerificationExecutor(parallel=False, config=ExecutorConfig())
+        key, _ = ex._execute_task_with_cap(self._stub_task("m1"), None, None, None)
+
+        assert key == "key"
+        assert len(calls) == 1
+        assert ex._endpoint_semaphores == {}
+
+    def test_matching_limit_acquires_semaphore(self, monkeypatch) -> None:
+        from karenina.benchmark.verification import batch_runner as br_mod
+        from karenina.benchmark.verification.executor import (
+            ExecutorConfig,
+            VerificationExecutor,
+        )
+
+        def _fake_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
+            return ("key", object())
+
+        monkeypatch.setattr(br_mod, "execute_task", _fake_execute_task)
+
+        ex = VerificationExecutor(
+            parallel=False,
+            config=ExecutorConfig(answerer_concurrency_limits={"m1": 2}),
+        )
+        ex._execute_task_with_cap(self._stub_task("m1"), None, None, None)
+        assert "m1" in ex._endpoint_semaphores
+
+    def test_unmatched_id_is_uncapped(self, monkeypatch) -> None:
+        from karenina.benchmark.verification import batch_runner as br_mod
+        from karenina.benchmark.verification.executor import (
+            ExecutorConfig,
+            VerificationExecutor,
+        )
+
+        def _fake_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
+            return ("key", object())
+
+        monkeypatch.setattr(br_mod, "execute_task", _fake_execute_task)
+
+        ex = VerificationExecutor(
+            parallel=False,
+            config=ExecutorConfig(answerer_concurrency_limits={"m1": 2}),
+        )
+        ex._execute_task_with_cap(self._stub_task("other"), None, None, None)
+        assert ex._endpoint_semaphores == {}
+
+    def test_missing_id_is_uncapped(self, monkeypatch) -> None:
+        """Answerers with ``id is None`` are not constrained by any cap."""
+        from karenina.benchmark.verification import batch_runner as br_mod
+        from karenina.benchmark.verification.executor import (
+            ExecutorConfig,
+            VerificationExecutor,
+        )
+
+        def _fake_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
+            return ("key", object())
+
+        monkeypatch.setattr(br_mod, "execute_task", _fake_execute_task)
+
+        class _NoId:
+            id = None
+
+        ex = VerificationExecutor(
+            parallel=False,
+            config=ExecutorConfig(answerer_concurrency_limits={"m1": 2}),
+        )
+        task = {"answering_model": _NoId(), "question_id": "q1", "replicate": None}
+        ex._execute_task_with_cap(task, None, None, None)
+        assert ex._endpoint_semaphores == {}
+
+    def test_exception_releases_semaphore(self, monkeypatch) -> None:
+        from karenina.benchmark.verification import batch_runner as br_mod
+        from karenina.benchmark.verification.executor import (
+            ExecutorConfig,
+            VerificationExecutor,
+        )
+
+        def _boom(task, answer_cache=None, cache_status=None, cached_answer_data=None):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(br_mod, "execute_task", _boom)
+
+        ex = VerificationExecutor(
+            parallel=False,
+            config=ExecutorConfig(answerer_concurrency_limits={"m1": 1}),
+        )
+
+        with pytest.raises(RuntimeError, match="boom"):
+            ex._execute_task_with_cap(self._stub_task("m1"), None, None, None)
+
+        sem = ex._endpoint_semaphores["m1"]
+        # After release, a cap-1 semaphore must have a slot available.
+        assert sem.acquire(blocking=False)
+        sem.release()
+
+
+@pytest.mark.unit
+class TestCapEnforcementUnderLoad:
+    """End-to-end concurrency assertion: counter never exceeds the cap."""
+
+    def test_concurrency_counter_never_exceeds_cap(self, monkeypatch) -> None:
+        import threading
+        import time
+
+        from karenina.benchmark.verification import batch_runner as br_mod
+        from karenina.benchmark.verification.executor import (
+            ExecutorConfig,
+            VerificationExecutor,
+        )
+
+        active = [0]
+        peak = [0]
+        lock = threading.Lock()
+
+        def _slow_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
+            with lock:
+                active[0] += 1
+                peak[0] = max(peak[0], active[0])
+            try:
+                time.sleep(0.05)
+            finally:
+                with lock:
+                    active[0] -= 1
+            return (f"key_{id(task)}", object())
+
+        monkeypatch.setattr(br_mod, "execute_task", _slow_execute_task)
+
+        class _M:
+            id = "m1"
+
+        tasks = [{"answering_model": _M(), "question_id": f"q{i}", "replicate": None} for i in range(10)]
+
+        ex = VerificationExecutor(
+            parallel=True,
+            config=ExecutorConfig(
+                max_workers=10,
+                enable_cache=False,
+                answerer_concurrency_limits={"m1": 3},
+            ),
+        )
+        ex.run_batch(tasks)
+
+        assert peak[0] <= 3

--- a/tests/unit/benchmark/verification/test_executor.py
+++ b/tests/unit/benchmark/verification/test_executor.py
@@ -894,3 +894,74 @@ class TestPreTeardownAclose:
             _active_adapters.clear()
         with _adapter_portal_lock:
             _adapter_portal_refs.clear()
+
+
+# =============================================================================
+# ExecutorConfig.answerer_concurrency_limits + _get_endpoint_semaphore
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestAnswererConcurrencyLimitsPlumbing:
+    """Config plumbing and lazy semaphore accessor on VerificationExecutor."""
+
+    def test_default_is_none(self) -> None:
+        from karenina.benchmark.verification.executor import ExecutorConfig
+
+        assert ExecutorConfig().answerer_concurrency_limits is None
+
+    def test_can_be_set(self) -> None:
+        from karenina.benchmark.verification.executor import ExecutorConfig
+
+        cfg = ExecutorConfig(answerer_concurrency_limits={"m1": 3})
+        assert cfg.answerer_concurrency_limits == {"m1": 3}
+
+    def test_get_endpoint_semaphore_caches(self) -> None:
+        from karenina.benchmark.verification.executor import (
+            ExecutorConfig,
+            VerificationExecutor,
+        )
+
+        executor = VerificationExecutor(
+            parallel=False,
+            config=ExecutorConfig(answerer_concurrency_limits={"m1": 2}),
+        )
+
+        sem_a = executor._get_endpoint_semaphore("m1", 2)
+        sem_b = executor._get_endpoint_semaphore("m1", 2)
+        assert sem_a is sem_b
+        # Duck-type check: a Semaphore exposes acquire/release. CPython's
+        # Semaphore is a factory, so isinstance checks against
+        # threading.Semaphore are brittle across versions.
+        assert hasattr(sem_a, "acquire") and hasattr(sem_a, "release")
+
+    def test_get_endpoint_semaphore_thread_safe_first_time(self) -> None:
+        import threading
+
+        from karenina.benchmark.verification.executor import (
+            ExecutorConfig,
+            VerificationExecutor,
+        )
+
+        executor = VerificationExecutor(
+            parallel=False,
+            config=ExecutorConfig(answerer_concurrency_limits={"m1": 2}),
+        )
+
+        barrier = threading.Barrier(8)
+        seen: list[object] = []
+        seen_lock = threading.Lock()
+
+        def _race() -> None:
+            barrier.wait()
+            sem = executor._get_endpoint_semaphore("m1", 2)
+            with seen_lock:
+                seen.append(sem)
+
+        threads = [threading.Thread(target=_race) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len({id(s) for s in seen}) == 1

--- a/tests/unit/benchmark/verification/test_executor_hang.py
+++ b/tests/unit/benchmark/verification/test_executor_hang.py
@@ -92,7 +92,7 @@ class TestVerificationBaseExceptionNoHang:
         """
         tasks = [_make_task("q1"), _make_task("q2"), _make_task("q3")]
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             if task["question_id"] == "q2":
                 raise KeyboardInterrupt()
             return (f"key_{task['question_id']}", _make_result(task["question_id"]))
@@ -119,7 +119,7 @@ class TestVerificationBaseExceptionNoHang:
         """A task raising SystemExit is collected as an error without hanging."""
         tasks = [_make_task("q1"), _make_task("q2")]
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             if task["question_id"] == "q2":
                 raise SystemExit(1)
             return (f"key_{task['question_id']}", _make_result(task["question_id"]))
@@ -148,7 +148,7 @@ class TestVerificationBaseExceptionNoHang:
         """
         tasks = [_make_task("q1"), _make_task("q2")]
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             raise KeyboardInterrupt()
 
         monkeypatch.setattr(
@@ -173,7 +173,7 @@ class TestVerificationBaseExceptionNoHang:
         """Mix of successful tasks and BaseException produces partial results."""
         tasks = [_make_task("q1"), _make_task("q2"), _make_task("q3"), _make_task("q4")]
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             if task["question_id"] == "q2":
                 raise KeyboardInterrupt()
             return (f"key_{task['question_id']}", _make_result(task["question_id"]))
@@ -254,7 +254,7 @@ class TestVerificationPortalCreationFailure:
             mock_start_blocking_portal,
         )
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             return (f"key_{task['question_id']}", _make_result(task["question_id"]))
 
         monkeypatch.setattr(
@@ -294,7 +294,7 @@ class TestVerificationTimeoutWithHangingWorkers:
 
         block_forever = threading.Event()
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             if task["question_id"] == "q2":
                 block_forever.wait(timeout=30.0)
                 return (f"key_{task['question_id']}", _make_result(task["question_id"]))
@@ -363,7 +363,7 @@ class TestCacheRetryCompletes:
         call_count = [0]
         call_lock = threading.Lock()
 
-        def mock_execute_task(task, answer_cache=None, **kwargs):
+        def mock_execute_task(task, answer_cache=None, cache_status=None, cached_answer_data=None):
             with call_lock:
                 call_count[0] += 1
             return (f"key_{task['question_id']}_{call_count[0]}", _make_result(task["question_id"]))

--- a/tests/unit/benchmark/verification/test_task_helpers.py
+++ b/tests/unit/benchmark/verification/test_task_helpers.py
@@ -436,3 +436,111 @@ class TestStampAgenticTraitOverrides:
         assert global_rubric.agentic_traits[0].model_override is override
         assert override.request_timeout is None
         assert override.retry_policy is None
+
+
+# =============================================================================
+# interleave_by_answerer
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestInterleaveByAnswerer:
+    """Tests for the interleave_by_answerer helper."""
+
+    def _task(self, ans_id: str, question_id: str, parser_id: str, replicate: int | None) -> dict:
+        return {
+            "answering_model": _make_model(ans_id),
+            "parsing_model": _make_model(parser_id),
+            "question_id": question_id,
+            "replicate": replicate,
+        }
+
+    def test_first_n_tasks_cover_all_answerers(self) -> None:
+        from karenina.benchmark.verification.utils.task_helpers import (
+            interleave_by_answerer,
+        )
+
+        tasks = []
+        for ans in ("a", "b", "c"):
+            for q in ("q1", "q2", "q3"):
+                for p in ("p1", "p2"):
+                    for rep in (1,):
+                        tasks.append(self._task(ans, q, p, rep))
+
+        out = interleave_by_answerer(tasks)
+        assert len(out) == len(tasks)
+
+        first_three_answerers = {t["answering_model"].id for t in out[:3]}
+        assert first_three_answerers == {"a", "b", "c"}
+
+    def test_within_group_sort_is_prefix_cache_friendly(self) -> None:
+        from karenina.benchmark.verification.utils.task_helpers import (
+            interleave_by_answerer,
+        )
+
+        tasks = [
+            self._task("a", "q2", "p2", 1),
+            self._task("a", "q1", "p1", 2),
+            self._task("a", "q1", "p1", 1),
+            self._task("b", "q1", "p1", 1),
+        ]
+        out = interleave_by_answerer(tasks)
+
+        group_a = [t for t in out if t["answering_model"].id == "a"]
+        # Mirror the helper's key exactly: None -> 0 coercion so the sort
+        # assertion does not rely on None vs int ordering.
+        keys = [(t["question_id"], t["parsing_model"].id, t.get("replicate") or 0) for t in group_a]
+        assert keys == sorted(keys)
+
+    def test_unequal_group_sizes_no_drops_no_duplicates(self) -> None:
+        from karenina.benchmark.verification.utils.task_helpers import (
+            interleave_by_answerer,
+        )
+
+        tasks = [
+            self._task("a", "q1", "p1", 1),
+            self._task("a", "q2", "p1", 1),
+            self._task("a", "q3", "p1", 1),
+            self._task("b", "q1", "p1", 1),
+        ]
+        out = interleave_by_answerer(tasks)
+
+        assert len(out) == 4
+        ids = sorted((t["answering_model"].id, t["question_id"]) for t in out)
+        expected = sorted((t["answering_model"].id, t["question_id"]) for t in tasks)
+        assert ids == expected
+
+    def test_single_answerer_passthrough(self) -> None:
+        from karenina.benchmark.verification.utils.task_helpers import (
+            interleave_by_answerer,
+        )
+
+        tasks = [
+            self._task("only", "q2", "p1", 1),
+            self._task("only", "q1", "p2", 1),
+            self._task("only", "q1", "p1", 1),
+        ]
+        out = interleave_by_answerer(tasks)
+
+        keys = [(t["question_id"], t["parsing_model"].id, t["replicate"]) for t in out]
+        assert keys == sorted(keys)
+
+    def test_empty_input(self) -> None:
+        from karenina.benchmark.verification.utils.task_helpers import (
+            interleave_by_answerer,
+        )
+
+        assert interleave_by_answerer([]) == []
+
+    def test_deterministic(self) -> None:
+        from karenina.benchmark.verification.utils.task_helpers import (
+            interleave_by_answerer,
+        )
+
+        tasks = [
+            self._task("a", "q1", "p1", 1),
+            self._task("b", "q1", "p1", 1),
+            self._task("a", "q2", "p1", 1),
+            self._task("b", "q2", "p1", 1),
+        ]
+        assert interleave_by_answerer(tasks) == interleave_by_answerer(list(tasks))

--- a/tests/unit/schemas/test_verification_config.py
+++ b/tests/unit/schemas/test_verification_config.py
@@ -1616,13 +1616,13 @@ class TestRetryConfigFields:
 class TestTaskOrdering:
     """Tests for the task_ordering field on VerificationConfig."""
 
-    def test_default_is_prefix_cache(self) -> None:
-        """Test that task_ordering defaults to 'prefix_cache'."""
+    def test_default_is_auto(self) -> None:
+        """Test that task_ordering defaults to 'auto'."""
         config = VerificationConfig(
             parsing_models=[ModelConfig(id="test", model_name="test", model_provider="openai")],
             parsing_only=True,
         )
-        assert config.task_ordering == "prefix_cache"
+        assert config.task_ordering == "auto"
 
     def test_accepts_generation_order(self) -> None:
         """Test that task_ordering accepts 'generation_order'."""
@@ -1650,3 +1650,79 @@ class TestTaskOrdering:
                 parsing_only=True,
                 task_ordering="invalid",
             )
+
+
+# =============================================================================
+# Multi-endpoint scheduling: task_ordering + answerer_concurrency_limits
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestTaskOrderingSchema:
+    """Tests for the extended task_ordering Literal and 'auto' default."""
+
+    def _minimal_config(self, **overrides) -> VerificationConfig:
+        parsing = ModelConfig(
+            id="parser",
+            model_name="parser",
+            model_provider="anthropic",
+            interface="langchain",
+            system_prompt="test",
+            temperature=0.1,
+        )
+        kwargs: dict = {"parsing_models": [parsing], "parsing_only": True}
+        kwargs.update(overrides)
+        return VerificationConfig(**kwargs)
+
+    def test_default_task_ordering_is_auto(self) -> None:
+        config = self._minimal_config()
+        assert config.task_ordering == "auto"
+
+    def test_distribute_answerers_is_accepted(self) -> None:
+        config = self._minimal_config(task_ordering="distribute_answerers")
+        assert config.task_ordering == "distribute_answerers"
+
+    def test_existing_strategies_still_accepted(self) -> None:
+        for value in ("prefix_cache", "generation_order", "random"):
+            config = self._minimal_config(task_ordering=value)
+            assert config.task_ordering == value
+
+    def test_unknown_task_ordering_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            self._minimal_config(task_ordering="nope")
+
+
+@pytest.mark.unit
+class TestAnswererConcurrencyLimitsSchema:
+    """Tests for the new answerer_concurrency_limits field."""
+
+    def _minimal_config(self, **overrides) -> VerificationConfig:
+        parsing = ModelConfig(
+            id="parser",
+            model_name="parser",
+            model_provider="anthropic",
+            interface="langchain",
+            system_prompt="test",
+            temperature=0.1,
+        )
+        kwargs: dict = {"parsing_models": [parsing], "parsing_only": True}
+        kwargs.update(overrides)
+        return VerificationConfig(**kwargs)
+
+    def test_default_is_none(self) -> None:
+        config = self._minimal_config()
+        assert config.answerer_concurrency_limits is None
+
+    def test_int_accepted(self) -> None:
+        config = self._minimal_config(answerer_concurrency_limits=16)
+        assert config.answerer_concurrency_limits == 16
+
+    def test_dict_accepted(self) -> None:
+        config = self._minimal_config(
+            answerer_concurrency_limits={"m1": 10, "m2": 20},
+        )
+        assert config.answerer_concurrency_limits == {"m1": 10, "m2": 20}
+
+    def test_unknown_types_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            self._minimal_config(answerer_concurrency_limits="sixteen")


### PR DESCRIPTION
## Summary
Adds controls for distributing verification work across answerers while bounding per-answerer concurrency.

## Changes
- Adds distribute_answerers and answerer_concurrency_limits configuration.
- Normalizes answerer limit input and creates lazy semaphores during execution.
- Adds interleaved task ordering by answerer.
- Documents the new verification controls.

## Test plan
- Targeted non-optional pytest suite: 83 passed locally.