### PR TITLE
feat(verification): add runtime retry autofail stage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.0.0",
-    "numpy<2.3",  # pandas 2.3.0 incompatible with numpy 2.3.x (groupby/reindex crash)
+    "numpy<2.3", # pandas 2.3.0 incompatible with numpy 2.3.x (groupby/reindex crash)
     "pandas>=2.0.0",
     "openpyxl>=3.0.0", # For Excel file support
     "aiohttp>=3.8.0",
@@ -33,8 +33,8 @@ dependencies = [
     "tenacity>=8.0.0",
     "httpx>=0.24.0",
     "tiktoken>=0.5.0",
-    "anthropic>=0.76.0",  # For beta.messages.parse and tool_runner
-    "mcp>=1.25.0,<2",  # MCP client for HTTP/SSE transport
+    "anthropic>=0.76.0", # For beta.messages.parse and tool_runner
+    "mcp>=1.25.0,<2", # MCP client for HTTP/SSE transport
     "langchain>=1.1.0",
     "langchain-openai>=0.3.25",
     "langchain-core>=1.2.28",
@@ -54,6 +54,7 @@ dependencies = [
     "litellm>=1.83.0",
     "python-dateutil>=2.8.0",
     "claude-agent-sdk>=0.1.48",
+    "pyarrow>=24.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/karenina/adapters/langchain/mcp.py
+++ b/src/karenina/adapters/langchain/mcp.py
@@ -90,7 +90,7 @@ async def acreate_mcp_client_and_tools(
 
     try:
         # Create client and fetch tools with timeout
-        client = MultiServerMCPClient(server_config)  # type: ignore[arg-type]
+        client = MultiServerMCPClient(server_config)
 
         # Add timeout to prevent hanging
         tools = await asyncio.wait_for(client.get_tools(), timeout=30.0)

--- a/src/karenina/adapters/langchain/middleware.py
+++ b/src/karenina/adapters/langchain/middleware.py
@@ -423,6 +423,10 @@ def build_agent_middleware(
     )
 
     # 3. Model retry middleware (replaces tenacity for agent path)
+    # ToolRetryMiddleware accepts "raise" via upstream back-compat, but
+    # ModelRetryMiddleware checks `on_failure == "error"` directly. Map here
+    # so the karenina-facing literal `["continue", "raise"]` propagates correctly.
+    _model_retry_on_failure = "error" if config.model_retry.on_failure == "raise" else config.model_retry.on_failure
     middleware.append(
         ModelRetryMiddleware(
             max_retries=config.model_retry.max_retries,
@@ -430,7 +434,7 @@ def build_agent_middleware(
             initial_delay=config.model_retry.initial_delay,
             max_delay=config.model_retry.max_delay,
             jitter=config.model_retry.jitter,
-            on_failure=config.model_retry.on_failure,  # type: ignore[arg-type]
+            on_failure=_model_retry_on_failure,  # type: ignore[arg-type]
         )
     )
 

--- a/src/karenina/adapters/langchain_deep_agents/mcp.py
+++ b/src/karenina/adapters/langchain_deep_agents/mcp.py
@@ -95,7 +95,7 @@ async def convert_mcp_to_tools(
 
     from langchain_mcp_adapters.client import MultiServerMCPClient
 
-    client = MultiServerMCPClient(server_params)  # type: ignore[arg-type]
-    await exit_stack.enter_async_context(client)  # type: ignore[arg-type]
+    client = MultiServerMCPClient(server_params)
+    await exit_stack.enter_async_context(client)
     tools: list[Any] = await client.get_tools()
     return tools

--- a/src/karenina/benchmark/verification/failure_classifier.py
+++ b/src/karenina/benchmark/verification/failure_classifier.py
@@ -27,6 +27,12 @@ _AUTOFAIL_STAGE_TO_CATEGORY: dict[str, FailureCategory] = {
     "TraceValidationAutoFail": FailureCategory.TRACE_VALIDATION,
     "DeepJudgmentAutoFail": FailureCategory.DEEP_JUDGMENT,
     "DeepJudgmentRubricAutoFail": FailureCategory.DEEP_JUDGMENT_RUBRIC,
+    # PlaceholderRetryAutoFail fires when LangChain's ModelRetryMiddleware
+    # emits its exhaustion placeholder ("Model call failed after ..."). The
+    # underlying cause is always an infrastructure failure that exhausted the
+    # in-agent retry budget, so we map it to CONNECTION (which lives in the
+    # RETRY_EXHAUSTED FailureGroup).
+    "PlaceholderRetryAutoFail": FailureCategory.CONNECTION,
 }
 
 _ERROR_CATEGORY_TO_FAILURE: dict[ErrorCategory, FailureCategory] = {

--- a/src/karenina/benchmark/verification/stages/core/orchestrator.py
+++ b/src/karenina/benchmark/verification/stages/core/orchestrator.py
@@ -21,6 +21,7 @@ from ..pipeline.embedding_check import EmbeddingCheckStage
 from ..pipeline.finalize_result import FinalizeResultStage
 from ..pipeline.generate_answer import GenerateAnswerStage
 from ..pipeline.parse_template import ParseTemplateStage
+from ..pipeline.placeholder_retry_autofail import PlaceholderRetryAutoFailStage
 from ..pipeline.recursion_limit_autofail import RecursionLimitAutoFailStage
 from ..pipeline.rubric_evaluation import RubricEvaluationStage
 from ..pipeline.sufficiency_check import SufficiencyCheckStage
@@ -195,6 +196,9 @@ class StageOrchestrator:
             # Auto-fail if trace doesn't end with AI message
             stages.append(TraceValidationAutoFailStage())
 
+            # Auto-fail if trace is solely a ModelRetryMiddleware exhaustion placeholder
+            stages.append(PlaceholderRetryAutoFailStage())
+
             # Optional abstention check (can run on raw response)
             if abstention_enabled:
                 stages.append(AbstentionCheckStage())
@@ -232,6 +236,7 @@ class StageOrchestrator:
                     GenerateAnswerStage(),
                     RecursionLimitAutoFailStage(),  # Auto-fail if recursion limit hit
                     TraceValidationAutoFailStage(),  # Auto-fail if trace doesn't end with AI message
+                    PlaceholderRetryAutoFailStage(),  # Auto-fail on ModelRetryMiddleware placeholder
                 ]
             )
 

--- a/src/karenina/benchmark/verification/stages/pipeline/__init__.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/__init__.py
@@ -30,6 +30,7 @@ from .embedding_check import EmbeddingCheckStage
 from .finalize_result import FinalizeResultStage
 from .generate_answer import GenerateAnswerStage
 from .parse_template import ParseTemplateStage
+from .placeholder_retry_autofail import PlaceholderRetryAutoFailStage
 from .recursion_limit_autofail import RecursionLimitAutoFailStage
 from .rubric_evaluation import RubricEvaluationStage
 from .sufficiency_check import SufficiencyCheckStage
@@ -42,6 +43,7 @@ __all__ = [
     "GenerateAnswerStage",
     "RecursionLimitAutoFailStage",
     "TraceValidationAutoFailStage",
+    "PlaceholderRetryAutoFailStage",
     "AbstentionCheckStage",
     "SufficiencyCheckStage",
     "ParseTemplateStage",

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -136,6 +136,7 @@ class GenerateAnswerStage(BaseVerificationStage):
             ArtifactKeys.ANSWERING_MODEL_STR,
             ArtifactKeys.ANSWERING_MCP_SERVERS,
             ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL,
+            ArtifactKeys.TRACE_MESSAGES,
         ]
 
     def should_run(self, context: VerificationContext) -> bool:

--- a/src/karenina/benchmark/verification/stages/pipeline/placeholder_retry_autofail.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/placeholder_retry_autofail.py
@@ -1,0 +1,123 @@
+"""Placeholder model-retry auto-fail stage.
+
+LangChain's ``ModelRetryMiddleware``, when configured with
+``on_failure="continue"``, swallows exceptions on retry exhaustion and emits
+a placeholder ``AIMessage`` whose content begins with
+``"Model call failed after "``. Without an early guard the placeholder reaches
+``parse_template``, the judge dutifully extracts default-False fields, and the
+row is recorded as a content failure when the root cause is an infrastructure
+connection failure. See daily note
+``2026-04-25-mcp-connection-error-misclassification.md``.
+
+With the karenina adapter mapping ``ModelRetryConfig.on_failure="raise"`` to
+LangChain's ``"error"``, the underlying exception propagates and this stage
+never fires. This stage exists as a structural guarantee against future
+regressions: leftover ``"continue"`` callers, alternative middleware paths, or
+upstream changes to the placeholder format will still be caught here.
+"""
+
+import logging
+from typing import Any
+
+from karenina.utils.errors import ErrorCategory
+
+from ..core.base import ArtifactKeys, BaseVerificationStage, VerificationContext
+
+logger = logging.getLogger(__name__)
+
+PLACEHOLDER_PREFIX = "Model call failed after "
+
+
+class PlaceholderRetryAutoFailStage(BaseVerificationStage):
+    """Auto-fails when the agent trace ends with a model-retry placeholder.
+
+    The placeholder fingerprint is: the LAST assistant message in the trace
+    has text content starting with ``"Model call failed after "``. This catches
+    both:
+    - The trivial case (trace = [single placeholder]) when the very first
+      model call exhausts retries.
+    - The mid-trace case (trace = [tool_call, tool_result, ..., placeholder])
+      when the model successfully runs tools but the final synthesis call
+      hits a connection error.
+
+    Either way the model never produced a real final answer; parsing the
+    placeholder against ground truth produces meaningless content failures.
+
+    On match, the stage marks the context as a connection-category error
+    (so downstream stages skip via the default ``should_run`` check) and
+    sets ``FAILED_STAGE`` so ``classify_failure`` resolves the result to
+    ``Failure(category=CONNECTION, ...)`` via the autofail rule.
+    """
+
+    @property
+    def name(self) -> str:
+        return "PlaceholderRetryAutoFail"
+
+    @property
+    def requires(self) -> list[str]:
+        return [ArtifactKeys.TRACE_MESSAGES]
+
+    def should_run(self, context: VerificationContext) -> bool:
+        if not super().should_run(context):
+            return False
+        return context.has_artifact(ArtifactKeys.TRACE_MESSAGES)
+
+    def execute(self, context: VerificationContext) -> None:
+        msgs = context.get_artifact(ArtifactKeys.TRACE_MESSAGES) or []
+        if not msgs:
+            return
+
+        last = msgs[-1]
+        if not _is_assistant(last):
+            return
+
+        text = _extract_text(last)
+        if not text.startswith(PLACEHOLDER_PREFIX):
+            return
+
+        truncated = text[:500]
+        logger.warning(
+            "PlaceholderRetryAutoFail for question %s: detected ModelRetryMiddleware "
+            "exhaustion placeholder at end of %d-message trace; reclassifying as "
+            "connection failure. Placeholder: %s",
+            context.question_id,
+            len(msgs),
+            truncated,
+        )
+
+        context.set_artifact(ArtifactKeys.VERIFY_RESULT, False)
+        context.set_artifact(ArtifactKeys.FIELD_VERIFICATION_RESULT, False)
+        context.set_result_field(ArtifactKeys.VERIFY_RESULT, False)
+
+        if not context.get_result_field(ArtifactKeys.FAILED_STAGE):
+            context.set_result_field(ArtifactKeys.FAILED_STAGE, self.name)
+
+        context.mark_error(
+            f"Model retry exhausted in agent loop: {truncated}",
+            category=ErrorCategory.CONNECTION,
+            stage="generate_answer",
+        )
+
+
+def _is_assistant(message: Any) -> bool:
+    role = getattr(message, "role", None)
+    if role is not None:
+        role_value = role.value if hasattr(role, "value") else role
+        return bool(role_value == "assistant")
+    if isinstance(message, dict):
+        return message.get("role") == "assistant"
+    return False
+
+
+def _extract_text(message: Any) -> str:
+    """Extract textual content from a Message (port type) or trace dict."""
+    if hasattr(message, "text"):
+        text = message.text
+        return text if isinstance(text, str) else ""
+    if isinstance(message, dict):
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            return " ".join(block.get("text", "") for block in content if isinstance(block, dict))
+    return ""

--- a/src/karenina/schemas/config/models.py
+++ b/src/karenina/schemas/config/models.py
@@ -218,6 +218,7 @@ BUILTIN_INTERFACES: frozenset[str] = frozenset(
         INTERFACE_LANGCHAIN_DEEP_AGENTS,
     }
 )
+DEFAULT_MAX_TOKENS = 16_384
 
 
 class QuestionFewShotConfig(BaseModel):
@@ -550,7 +551,7 @@ class ModelConfig(BaseModel):
     model_provider: str | None = None  # Optional - only required for langchain interface
     model_name: str | None = None  # Optional - defaults to "manual" for manual interface
     temperature: float = 0.1
-    max_tokens: int = 8192  # Maximum tokens for model response
+    max_tokens: int = DEFAULT_MAX_TOKENS  # Maximum tokens for model response
     interface: str = "langchain"
     system_prompt: str | None = None  # Optional - defaults applied based on context (answering/parsing)
     max_retries: int = 2  # Optional max retries for template generation

--- a/tests/unit/adapters/langchain/test_model_retry_on_failure_mapping.py
+++ b/tests/unit/adapters/langchain/test_model_retry_on_failure_mapping.py
@@ -1,0 +1,50 @@
+"""Tests for ModelRetryMiddleware on_failure mapping in build_agent_middleware.
+
+karenina's ModelRetryConfig exposes ``on_failure: Literal["continue", "raise"]``
+but LangChain's ModelRetryMiddleware checks ``on_failure == "error"`` and treats
+anything else as ``"continue"``. ToolRetryMiddleware has back-compat mapping for
+``"raise"`` upstream; ModelRetryMiddleware does not. Without translation in the
+karenina adapter, ``on_failure="raise"`` silently falls through to continue,
+producing the AIMessage placeholder ("Model call failed after N attempts ...")
+instead of propagating the exception. See daily note
+``2026-04-25-mcp-connection-error-misclassification.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from karenina.adapters.langchain.middleware import build_agent_middleware
+from karenina.schemas.config import AgentMiddlewareConfig
+
+
+def _build_config(on_failure: str) -> AgentMiddlewareConfig:
+    cfg = AgentMiddlewareConfig()
+    cfg.summarization.enabled = False
+    cfg.model_retry.on_failure = on_failure
+    return cfg
+
+
+def _extract_model_retry(middleware: list[Any]) -> Any:
+    from langchain.agents.middleware import ModelRetryMiddleware
+
+    instances = [m for m in middleware if isinstance(m, ModelRetryMiddleware)]
+    assert len(instances) == 1, f"expected 1 ModelRetryMiddleware, got {len(instances)}"
+    return instances[0]
+
+
+@pytest.mark.unit
+class TestModelRetryOnFailureMapping:
+    """build_agent_middleware must translate karenina's "raise" into LangChain's "error"."""
+
+    def test_raise_is_translated_to_error(self) -> None:
+        middleware = build_agent_middleware(config=_build_config("raise"))
+        retry = _extract_model_retry(middleware)
+        assert retry.on_failure == "error"
+
+    def test_continue_is_passed_through(self) -> None:
+        middleware = build_agent_middleware(config=_build_config("continue"))
+        retry = _extract_model_retry(middleware)
+        assert retry.on_failure == "continue"

--- a/tests/unit/benchmark/verification/stages/test_placeholder_retry_autofail.py
+++ b/tests/unit/benchmark/verification/stages/test_placeholder_retry_autofail.py
@@ -1,0 +1,171 @@
+"""Unit tests for PlaceholderRetryAutoFailStage.
+
+The stage detects LangChain ModelRetryMiddleware exhaustion placeholders that
+would otherwise be parsed as content failures, and reclassifies them as
+connection failures via the autofail rule path. See daily note
+``2026-04-25-mcp-connection-error-misclassification.md`` for the original bug.
+"""
+
+import pytest
+
+from karenina.benchmark.verification.failure_classifier import classify_failure
+from karenina.benchmark.verification.stages.core.base import (
+    ArtifactKeys,
+    VerificationContext,
+)
+from karenina.benchmark.verification.stages.pipeline.placeholder_retry_autofail import (
+    PlaceholderRetryAutoFailStage,
+)
+from karenina.ports.messages import Message
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.results.failure import FailureCategory, FailureGroup
+from karenina.utils.errors import ErrorCategory
+
+
+@pytest.fixture
+def model_config() -> ModelConfig:
+    return ModelConfig(
+        id="test-model",
+        model_provider="anthropic",
+        model_name="claude-haiku-4-5",
+        temperature=0.0,
+    )
+
+
+@pytest.fixture
+def context(model_config: ModelConfig) -> VerificationContext:
+    return VerificationContext(
+        question_id="q-1",
+        template_id="t-1",
+        question_text="Q?",
+        template_code="class Answer(BaseAnswer): ...",
+        answering_model=model_config,
+        parsing_model=model_config,
+    )
+
+
+@pytest.fixture
+def stage() -> PlaceholderRetryAutoFailStage:
+    return PlaceholderRetryAutoFailStage()
+
+
+@pytest.mark.unit
+class TestPlaceholderRetryAutoFail:
+    def test_placeholder_message_triggers_reclassification(
+        self, stage: PlaceholderRetryAutoFailStage, context: VerificationContext
+    ) -> None:
+        placeholder = Message.assistant("Model call failed after 3 attempts with APIConnectionError: Connection error.")
+        context.set_artifact(ArtifactKeys.TRACE_MESSAGES, [placeholder])
+
+        stage.execute(context)
+
+        assert context.error is not None
+        assert context.error_category is ErrorCategory.CONNECTION
+        assert context.error_stage == "generate_answer"
+        assert context.get_result_field(ArtifactKeys.FAILED_STAGE) == "PlaceholderRetryAutoFail"
+        assert context.get_artifact(ArtifactKeys.VERIFY_RESULT) is False
+        assert context.get_result_field(ArtifactKeys.VERIFY_RESULT) is False
+
+    def test_placeholder_classifies_as_connection_failure(
+        self, stage: PlaceholderRetryAutoFailStage, context: VerificationContext
+    ) -> None:
+        placeholder = Message.assistant("Model call failed after 3 attempts with APIConnectionError: Connection error.")
+        context.set_artifact(ArtifactKeys.TRACE_MESSAGES, [placeholder])
+
+        stage.execute(context)
+        failure = classify_failure(context)
+
+        assert failure is not None
+        assert failure.category is FailureCategory.CONNECTION
+        assert failure.group is FailureGroup.RETRY_EXHAUSTED
+        assert failure.stage == "PlaceholderRetryAutoFail"
+
+    def test_placeholder_dict_form_also_triggers(
+        self, stage: PlaceholderRetryAutoFailStage, context: VerificationContext
+    ) -> None:
+        # Post-serialization (e.g. when loaded from a stored result), trace messages
+        # are dicts shaped like Message.to_dict(). The detector must handle both.
+        placeholder = {
+            "role": "assistant",
+            "content": "Model call failed after 3 attempts with APIConnectionError: Connection error.",
+            "block_index": 0,
+        }
+        context.set_artifact(ArtifactKeys.TRACE_MESSAGES, [placeholder])
+
+        stage.execute(context)
+
+        assert context.error_category is ErrorCategory.CONNECTION
+        assert context.get_result_field(ArtifactKeys.FAILED_STAGE) == "PlaceholderRetryAutoFail"
+
+    def test_normal_assistant_message_does_not_trigger(
+        self, stage: PlaceholderRetryAutoFailStage, context: VerificationContext
+    ) -> None:
+        normal = Message.assistant("BCL-2 is the drug target. The mechanism is well-studied.")
+        context.set_artifact(ArtifactKeys.TRACE_MESSAGES, [normal])
+
+        stage.execute(context)
+
+        assert context.error is None
+        assert context.error_category is None
+        assert context.get_result_field(ArtifactKeys.FAILED_STAGE) is None
+
+    def test_multi_message_trace_with_placeholder_last_triggers(
+        self, stage: PlaceholderRetryAutoFailStage, context: VerificationContext
+    ) -> None:
+        # Mid-trace failure: model successfully ran tools, then the final
+        # synthesis call exhausted retries. The placeholder lands as the last
+        # AIMessage. The model never produced a real final answer.
+        msgs = [
+            Message.user("What proteins interact with BRCA1?"),
+            Message.assistant("Let me query Open Targets."),
+            Message.assistant("Model call failed after 3 attempts with APIConnectionError: Connection error."),
+        ]
+        context.set_artifact(ArtifactKeys.TRACE_MESSAGES, msgs)
+
+        stage.execute(context)
+
+        assert context.error_category is ErrorCategory.CONNECTION
+        assert context.get_result_field(ArtifactKeys.FAILED_STAGE) == "PlaceholderRetryAutoFail"
+
+    def test_placeholder_not_at_end_does_not_trigger(
+        self, stage: PlaceholderRetryAutoFailStage, context: VerificationContext
+    ) -> None:
+        # If the placeholder is somewhere mid-trace but the agent recovered and
+        # produced a real final answer, this is not a terminal failure. (This
+        # path is unlikely in practice with on_failure="continue" because the
+        # placeholder usually ends the loop, but the detector must not fire on
+        # it just in case.)
+        msgs = [
+            Message.assistant("Model call failed after 3 attempts with APIConnectionError: ..."),
+            Message.assistant("Recovered. The answer is BCL-2."),
+        ]
+        context.set_artifact(ArtifactKeys.TRACE_MESSAGES, msgs)
+
+        stage.execute(context)
+
+        assert context.error is None
+        assert context.get_result_field(ArtifactKeys.FAILED_STAGE) is None
+
+    def test_empty_trace_does_not_trigger(
+        self, stage: PlaceholderRetryAutoFailStage, context: VerificationContext
+    ) -> None:
+        context.set_artifact(ArtifactKeys.TRACE_MESSAGES, [])
+
+        stage.execute(context)
+
+        assert context.error is None
+        assert context.get_result_field(ArtifactKeys.FAILED_STAGE) is None
+
+    def test_should_run_returns_false_when_trace_messages_missing(
+        self, stage: PlaceholderRetryAutoFailStage, context: VerificationContext
+    ) -> None:
+        # No trace_messages artifact set
+        assert stage.should_run(context) is False
+
+    def test_should_run_returns_false_when_context_already_has_error(
+        self, stage: PlaceholderRetryAutoFailStage, context: VerificationContext
+    ) -> None:
+        context.set_artifact(ArtifactKeys.TRACE_MESSAGES, [Message.assistant("x")])
+        context.mark_error("prior failure", category=ErrorCategory.PERMANENT)
+
+        assert stage.should_run(context) is False

--- a/uv.lock
+++ b/uv.lock
@@ -1874,6 +1874,7 @@ dependencies = [
     { name = "numpy" },
     { name = "openpyxl" },
     { name = "pandas" },
+    { name = "pyarrow" },
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
@@ -1983,6 +1984,7 @@ requires-dist = [
     { name = "openpyxl", specifier = ">=3.0.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "pyarrow", specifier = ">=24.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
@@ -3494,6 +3496,56 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842 },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/c9/a47ab7ece0d86cbe6678418a0fbd1ac4bb493b9184a3891dfa0e7f287ae0/pyarrow-24.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74", size = 35068898 },
+    { url = "https://files.pythonhosted.org/packages/d1/bc/8db86617a9a58008acf8913d6fed68ea2a46acb6de928db28d724c891a68/pyarrow-24.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3", size = 36679915 },
+    { url = "https://files.pythonhosted.org/packages/eb/8e/fb178720400ef69db251eb4a9c3ccf4af269bc1feb5055529b8fc87170d1/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868", size = 45697931 },
+    { url = "https://files.pythonhosted.org/packages/f3/27/99c42abe8e21b44f4917f62631f3aa31404882a2c41d8a4cd5c110e13d52/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e", size = 48837449 },
+    { url = "https://files.pythonhosted.org/packages/36/b6/333749e2666e9032891125bf9c691146e92901bece62030ac1430e2e7c88/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57", size = 49395949 },
+    { url = "https://files.pythonhosted.org/packages/17/25/c5201706a2dd374e8ba6ee3fd7a8c89fb7ffc16eed5217a91fd2bd7f7626/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c", size = 51912986 },
+    { url = "https://files.pythonhosted.org/packages/f8/d2/4d1bbba65320b21a49678d6fbdc6ff7c649251359fdcfc03568c4136231d/pyarrow-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:35405aecb474e683fb36af650618fd5340ee5471fc65a21b36076a18bbc6c981", size = 27255371 },
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559 },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654 },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394 },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122 },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032 },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490 },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660 },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759 },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471 },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981 },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172 },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733 },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335 },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748 },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554 },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301 },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929 },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365 },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819 },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252 },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127 },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997 },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720 },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852 },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852 },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207 },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117 },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155 },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387 },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102 },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118 },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765 },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890 },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250 },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Adds a verification stage that can autofail unresolved placeholder retries at runtime.

## Changes
- Adds PlaceholderRetryAutoFail stage support.
- Maps ModelRetryConfig raise behavior to LangChain error handling.
- Raises the default max token budget through DEFAULT_MAX_TOKENS.
- Adds pyarrow as a runtime dependency.
- Cleans up stale MCP adapter typing suppressions.

## Test plan
- Targeted non-optional pytest suite: 83 passed locally.