### PR TITLE
fix(adapters): add lifecycle regressions

### DIFF
--- a/src/karenina/adapters/langchain/mcp.py
+++ b/src/karenina/adapters/langchain/mcp.py
@@ -17,9 +17,13 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import json
 import logging
 from contextlib import AsyncExitStack
-from typing import Any
+from typing import Any, cast
+
+from langchain_core.tools import BaseTool
+from pydantic import Field
 
 from karenina.exceptions import McpClientError, McpTimeoutError
 from karenina.ports.agent import MCPHttpServerConfig
@@ -35,6 +39,152 @@ __all__ = [
     "cleanup_mcp_client",
     "apply_tool_description_overrides",
 ]
+
+
+def _schema_dict(args_schema: Any) -> dict[str, Any] | None:
+    if args_schema is None:
+        return None
+    if isinstance(args_schema, dict):
+        return args_schema
+    if hasattr(args_schema, "model_json_schema"):
+        schema = args_schema.model_json_schema()
+        return cast(dict[str, Any], schema) if isinstance(schema, dict) else None
+    if hasattr(args_schema, "schema"):
+        schema = args_schema.schema()
+        return cast(dict[str, Any], schema) if isinstance(schema, dict) else None
+    return None
+
+
+def _resolve_schema_ref(schema: dict[str, Any], root: dict[str, Any]) -> dict[str, Any]:
+    ref = schema.get("$ref")
+    if not isinstance(ref, str) or not ref.startswith("#/"):
+        return schema
+
+    current: Any = root
+    for part in ref.removeprefix("#/").split("/"):
+        if not isinstance(current, dict):
+            return schema
+        current = current.get(part)
+    return current if isinstance(current, dict) else schema
+
+
+def _schema_accepts_type(schema: dict[str, Any], root: dict[str, Any], expected: str) -> bool:
+    schema = _resolve_schema_ref(schema, root)
+    schema_type = schema.get("type")
+    if schema_type == expected or (isinstance(schema_type, list) and expected in schema_type):
+        return True
+
+    for key in ("anyOf", "oneOf", "allOf"):
+        variants = schema.get(key)
+        if isinstance(variants, list) and any(
+            isinstance(item, dict) and _schema_accepts_type(item, root, expected) for item in variants
+        ):
+            return True
+    return False
+
+
+def _expected_json_container(
+    schema: dict[str, Any], root: dict[str, Any]
+) -> type[list[Any]] | type[dict[str, Any]] | None:
+    if _schema_accepts_type(schema, root, "array"):
+        return list
+    if _schema_accepts_type(schema, root, "object"):
+        return dict
+    return None
+
+
+def _coerce_json_string_tool_args(
+    tool_input: str | dict[str, Any], args_schema: Any, tool_name: str
+) -> str | dict[str, Any]:
+    """Decode JSON-looking strings only where the tool schema expects containers."""
+    if not isinstance(tool_input, dict):
+        return tool_input
+
+    schema = _schema_dict(args_schema)
+    if schema is None:
+        return tool_input
+
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return tool_input
+
+    coerced = dict(tool_input)
+    for name, value in tool_input.items():
+        if not isinstance(value, str):
+            continue
+
+        field_schema = properties.get(name)
+        if not isinstance(field_schema, dict):
+            continue
+
+        expected_type = _expected_json_container(field_schema, schema)
+        if expected_type is None:
+            continue
+
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            continue
+
+        if isinstance(parsed, expected_type):
+            coerced[name] = parsed
+            logger.debug(
+                "Coerced JSON string argument %s.%s to %s before tool validation",
+                tool_name,
+                name,
+                expected_type.__name__,
+            )
+
+    return coerced
+
+
+class _JsonStringCoercingTool(BaseTool):
+    wrapped_tool: Any = Field(exclude=True)
+
+    def _parse_input(
+        self,
+        tool_input: str | dict[str, Any],
+        tool_call_id: str | None,
+    ) -> str | dict[str, Any]:
+        coerced = _coerce_json_string_tool_args(tool_input, self.args_schema, self.name)
+        return super()._parse_input(coerced, tool_call_id)
+
+    def _tool_input_from_call(self, args: tuple[Any, ...], kwargs: dict[str, Any]) -> str | dict[str, Any]:
+        kwargs.pop("run_manager", None)
+        if args and not kwargs:
+            return cast(str | dict[str, Any], args[0])
+        if args:
+            return {"args": list(args), **kwargs}
+        return kwargs
+
+    def _run(self, *args: Any, **kwargs: Any) -> Any:
+        return self.wrapped_tool.invoke(self._tool_input_from_call(args, kwargs))
+
+    async def _arun(self, *args: Any, **kwargs: Any) -> Any:
+        return await self.wrapped_tool.ainvoke(self._tool_input_from_call(args, kwargs))
+
+
+def _wrap_json_string_args_tool(tool: Any) -> Any:
+    if isinstance(tool, _JsonStringCoercingTool) or not isinstance(tool, BaseTool):
+        return tool
+    return _JsonStringCoercingTool(
+        wrapped_tool=tool,
+        name=tool.name,
+        description=tool.description,
+        args_schema=tool.args_schema,
+        return_direct=tool.return_direct,
+        tags=tool.tags,
+        metadata=tool.metadata,
+        handle_tool_error=tool.handle_tool_error,
+        handle_validation_error=tool.handle_validation_error,
+        # The wrapped tool's public invoke/ainvoke returns final message
+        # content, not the internal content/artifact tuple.
+        response_format="content",
+    )
+
+
+def _wrap_json_string_args_tools(tools: list[Any]) -> list[Any]:
+    return [_wrap_json_string_args_tool(tool) for tool in tools]
 
 
 async def acreate_mcp_client_and_tools(
@@ -90,7 +240,7 @@ async def acreate_mcp_client_and_tools(
 
     try:
         # Create client and fetch tools with timeout
-        client = MultiServerMCPClient(server_config)
+        client = MultiServerMCPClient(cast(Any, server_config))
 
         # Add timeout to prevent hanging
         tools = await asyncio.wait_for(client.get_tools(), timeout=30.0)
@@ -108,6 +258,8 @@ async def acreate_mcp_client_and_tools(
         # Apply tool description overrides if provided (for GEPA optimization)
         if tool_description_overrides:
             tools = apply_tool_description_overrides(tools, tool_description_overrides)
+
+        tools = _wrap_json_string_args_tools(tools)
 
         return client, tools
 
@@ -195,6 +347,8 @@ async def acreate_persistent_mcp_tools(
     # Apply tool description overrides if provided
     if tool_description_overrides:
         all_tools = apply_tool_description_overrides(all_tools, tool_description_overrides)
+
+    all_tools = _wrap_json_string_args_tools(all_tools)
 
     logger.info(f"Created {len(all_tools)} persistent MCP tools across {len(mcp_urls_dict)} servers")
 

--- a/src/karenina/adapters/langchain_deep_agents/agent.py
+++ b/src/karenina/adapters/langchain_deep_agents/agent.py
@@ -262,7 +262,7 @@ class DeepAgentsAgentAdapter:
                 # Execute agent
                 async def execute_agent() -> None:
                     nonlocal result, limit_reached
-                    result = await agent.ainvoke(invoke_input, config=langgraph_config)  # type: ignore[call-overload]
+                    result = await agent.ainvoke(invoke_input, config=langgraph_config)
                     if result.get("is_last_step", False):
                         limit_reached = True
 

--- a/src/karenina/adapters/langchain_deep_agents/mcp.py
+++ b/src/karenina/adapters/langchain_deep_agents/mcp.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import AsyncExitStack
-from typing import Any
+from typing import Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +95,7 @@ async def convert_mcp_to_tools(
 
     from langchain_mcp_adapters.client import MultiServerMCPClient
 
-    client = MultiServerMCPClient(server_params)
-    await exit_stack.enter_async_context(client)
+    client = MultiServerMCPClient(cast(Any, server_params))
+    await exit_stack.enter_async_context(cast(Any, client))
     tools: list[Any] = await client.get_tools()
     return tools

--- a/src/karenina/adapters/llm_parallel.py
+++ b/src/karenina/adapters/llm_parallel.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from pydantic import BaseModel
 
 from ._parallel_base import get_max_workers, read_async_config, sync_invoke_via_portal
+from .registry import aclose_adapter
 
 if TYPE_CHECKING:
     from ..ports import LLMPort, LLMResponse, Message
@@ -236,6 +237,7 @@ class LLMParallelInvoker:
             messages, model_class = tasks[index]
 
             async with semaphore:
+                structured_llm: LLMPort | None = None
                 try:
                     # Create structured output adapter and invoke
                     structured_llm = self.llm.with_structured_output(model_class)
@@ -255,6 +257,8 @@ class LLMParallelInvoker:
                     logger.debug(f"LLMParallelInvoker: Task {index} failed: {e}")
                     return index, None, None, e
                 finally:
+                    if structured_llm is not None and structured_llm is not self.llm:
+                        await aclose_adapter(structured_llm)
                     # Update progress
                     if progress_callback:
                         async with progress_lock:

--- a/src/karenina/adapters/registry.py
+++ b/src/karenina/adapters/registry.py
@@ -26,6 +26,7 @@ import logging
 import threading
 import weakref
 from collections.abc import Callable
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import dataclass
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Any
@@ -37,6 +38,8 @@ if TYPE_CHECKING:
     from karenina.schemas.config import ModelConfig
 
 logger = logging.getLogger(__name__)
+
+ADAPTER_CLOSE_TIMEOUT = 10.0
 
 # ============================================================================
 # Adapter Instance Tracking for Resource Cleanup
@@ -136,6 +139,70 @@ def unregister_adapter(adapter: Any) -> None:
     with _adapters_lock:
         if adapter in _active_adapters:
             _active_adapters.remove(adapter)
+    with _adapter_portal_lock:
+        _adapter_portal_refs[:] = [
+            pair for pair in _adapter_portal_refs if (tracked := pair[0]()) is not None and tracked is not adapter
+        ]
+
+
+async def aclose_adapter(adapter: Any, *, unregister: bool = True) -> None:
+    """Close one adapter immediately and optionally remove it from tracking.
+
+    This is intended for adapters with a short, local lifetime. Batch-level
+    cleanup remains as a fallback for adapters that are intentionally shared or
+    whose close fails here.
+    """
+    aclose = getattr(adapter, "aclose", None)
+    if not callable(aclose):
+        if unregister:
+            unregister_adapter(adapter)
+        return
+
+    await aclose()
+    if unregister:
+        unregister_adapter(adapter)
+
+
+def close_adapter(adapter: Any, *, timeout: float = ADAPTER_CLOSE_TIMEOUT, unregister: bool = True) -> None:
+    """Synchronously close one adapter using the active worker portal when available."""
+    aclose = getattr(adapter, "aclose", None)
+    if not callable(aclose):
+        if unregister:
+            unregister_adapter(adapter)
+        return
+
+    try:
+        from karenina.benchmark.verification.executor import get_async_portal
+    except ImportError:
+        portal = None
+    else:
+        portal = get_async_portal()
+
+    try:
+        if portal is not None:
+            future = portal.start_task_soon(aclose)
+            future.result(timeout=timeout)
+        else:
+            import asyncio
+
+            asyncio.run(aclose())
+    except FutureTimeoutError:
+        logger.warning(
+            "Immediate adapter close timed out on %s (>%ss); leaving it registered for batch cleanup",
+            type(adapter).__name__,
+            timeout,
+        )
+        return
+    except Exception as exc:
+        logger.debug(
+            "Immediate adapter close failed on %s; leaving it registered for batch cleanup: %s",
+            type(adapter).__name__,
+            exc,
+        )
+        return
+
+    if unregister:
+        unregister_adapter(adapter)
 
 
 async def cleanup_all_adapters() -> None:

--- a/src/karenina/benchmark/authoring/answers/generator.py
+++ b/src/karenina/benchmark/authoring/answers/generator.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field, field_validator
 from tqdm import tqdm
 
 from karenina.adapters import get_llm
+from karenina.adapters.registry import close_adapter
 from karenina.benchmark.authoring.questions.reader import read_questions_from_file
 from karenina.benchmark.verification.utils.class_discovery import find_answer_class
 from karenina.benchmark.verification.utils.template_validation import (
@@ -168,7 +169,8 @@ def _generate_structured_output(
     user_content = user_template.format(**inputs)
 
     # Get LLM with structured output and retry support
-    llm = get_llm(config).with_structured_output(output_schema, max_retries=max_retries)
+    base_llm = get_llm(config)
+    llm = base_llm.with_structured_output(output_schema, max_retries=max_retries)
 
     # Build messages
     messages = [
@@ -176,19 +178,24 @@ def _generate_structured_output(
         Message.user(user_content),
     ]
 
-    # Invoke and return parsed model from raw
-    response = llm.invoke(messages)
+    try:
+        # Invoke and return parsed model from raw
+        response = llm.invoke(messages)
 
-    # The adapter guarantees response.raw is the Pydantic model instance
-    if isinstance(response.raw, output_schema):
-        return response.raw
+        # The adapter guarantees response.raw is the Pydantic model instance
+        if isinstance(response.raw, output_schema):
+            return response.raw
 
-    # Fail if the adapter did not return the expected type
-    raise TypeError(
-        f"Adapter returned invalid structured output. "
-        f"Expected {output_schema.__name__}, got {type(response.raw).__name__}. "
-        f"The adapter's with_structured_output() must guarantee a Pydantic model in response.raw."
-    )
+        # Fail if the adapter did not return the expected type
+        raise TypeError(
+            f"Adapter returned invalid structured output. "
+            f"Expected {output_schema.__name__}, got {type(response.raw).__name__}. "
+            f"The adapter's with_structured_output() must guarantee a Pydantic model in response.raw."
+        )
+    finally:
+        close_adapter(llm)
+        if base_llm is not llm:
+            close_adapter(base_llm)
 
 
 def _generate_plan(
@@ -225,8 +232,11 @@ def _generate_plan(
         ),
     ]
 
-    response = llm.invoke(messages)
-    return response.content
+    try:
+        response = llm.invoke(messages)
+        return response.content
+    finally:
+        close_adapter(llm)
 
 
 def _smoke_test_generated_code(template_code: str) -> tuple[bool, str | None]:

--- a/src/karenina/benchmark/task_eval/models.py
+++ b/src/karenina/benchmark/task_eval/models.py
@@ -397,7 +397,7 @@ class StepEval(BaseModel):
         Returns:
             dict: Trait names mapped to aggregated values (pass rate or average score)
         """
-        trait_values: dict[str, list[bool | int]] = {}
+        trait_values: dict[str, list[bool | int | float]] = {}
 
         for result in results:
             if result.rubric and result.rubric.callable_trait_scores:

--- a/src/karenina/benchmark/verification/evaluators/rubric/agentic_trait.py
+++ b/src/karenina/benchmark/verification/evaluators/rubric/agentic_trait.py
@@ -14,6 +14,7 @@ from typing import Any, cast
 from pydantic import BaseModel
 
 from karenina.adapters import get_agent, get_llm, get_parser
+from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
 from karenina.ports import AgentConfig, Message, PortCapabilities
 from karenina.schemas.config.models import ModelConfig
@@ -189,12 +190,15 @@ class AgenticTraitEvaluator:
         and no workspace tools are needed.
         """
         llm = get_llm(self._model_config)
-        result = llm.invoke(messages)
-        logger.info(
-            "Agentic rubric investigation for '%s' completed via LLMPort (trace_only, no tools)",
-            trait.name,
-        )
-        return result.content or ""
+        try:
+            result = llm.invoke(messages)
+            logger.info(
+                "Agentic rubric investigation for '%s' completed via LLMPort (trace_only, no tools)",
+                trait.name,
+            )
+            return result.content or ""
+        finally:
+            close_adapter(llm)
 
     def _run_agent_investigation(
         self,
@@ -211,14 +215,17 @@ class AgenticTraitEvaluator:
             workspace_path=Path(workspace_path) if workspace_path else None,
         )
 
-        result = agent.run(messages=messages, config=agent_config)
-        logger.info(
-            "Agentic rubric investigation for '%s' completed in %d turns (limit_reached=%s)",
-            trait.name,
-            result.turns,
-            result.limit_reached,
-        )
-        return result.raw_trace
+        try:
+            result = agent.run(messages=messages, config=agent_config)
+            logger.info(
+                "Agentic rubric investigation for '%s' completed in %d turns (limit_reached=%s)",
+                trait.name,
+                result.turns,
+                result.limit_reached,
+            )
+            return result.raw_trace
+        finally:
+            close_adapter(agent)
 
     def run_extraction(
         self,
@@ -258,23 +265,26 @@ class AgenticTraitEvaluator:
             user_instructions=user_instructions,
         )
 
-        if trait.kind == "boolean":
-            bool_result = parser.parse_to_pydantic(messages, SingleBooleanScore)
-            return bool_result.parsed.result
+        try:
+            if trait.kind == "boolean":
+                bool_result = parser.parse_to_pydantic(messages, SingleBooleanScore)
+                return bool_result.parsed.result
 
-        if trait.kind == "score":
-            score_result = parser.parse_to_pydantic(messages, SingleNumericScore)
-            return score_result.parsed.score
+            if trait.kind == "score":
+                score_result = parser.parse_to_pydantic(messages, SingleNumericScore)
+                return score_result.parsed.score
 
-        if trait.kind == "literal":
-            literal_result = parser.parse_to_pydantic(
-                messages,
-                SingleLiteralClassification,
-            )
-            return self._resolve_literal_index(
-                literal_result.parsed.classification,
-                trait,
-            )
+            if trait.kind == "literal":
+                literal_result = parser.parse_to_pydantic(
+                    messages,
+                    SingleLiteralClassification,
+                )
+                return self._resolve_literal_index(
+                    literal_result.parsed.classification,
+                    trait,
+                )
+        finally:
+            close_adapter(parser)
 
         raise ValueError(f"Unknown trait kind: {trait.kind}")
 
@@ -318,9 +328,12 @@ class AgenticTraitEvaluator:
             user_instructions=user_instructions,
         )
 
-        kind_class = cast(type[BaseModel], trait.kind)
-        parse_result = parser.parse_to_pydantic(messages, kind_class)
-        return parse_result.parsed.model_dump()
+        try:
+            kind_class = cast(type[BaseModel], trait.kind)
+            parse_result = parser.parse_to_pydantic(messages, kind_class)
+            return parse_result.parsed.model_dump()
+        finally:
+            close_adapter(parser)
 
     @staticmethod
     def _build_extraction_texts(

--- a/src/karenina/benchmark/verification/evaluators/rubric/deep_judgment.py
+++ b/src/karenina/benchmark/verification/evaluators/rubric/deep_judgment.py
@@ -28,6 +28,7 @@ import re
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
+from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts.assembler import PromptAssembler
 from karenina.benchmark.verification.prompts.deep_judgment.rubric.deep_judgment import DeepJudgmentPromptBuilder
 from karenina.benchmark.verification.prompts.task_types import PromptTask
@@ -465,6 +466,7 @@ class RubricDeepJudgmentHandler:
             )
 
             # Use LLMPort.with_structured_output() for parsing
+            structured_llm: LLMPort | None = None
             try:
                 structured_llm = self.llm.with_structured_output(TraitExcerptsOutput)
                 response = structured_llm.invoke(messages)
@@ -495,6 +497,9 @@ class RubricDeepJudgmentHandler:
                         "auto_fail": True,
                         "usage_metadata_list": usage_metadata_list,
                     }
+            finally:
+                if structured_llm is not None and structured_llm is not self.llm:
+                    close_adapter(structured_llm)
 
             # Validate excerpts with fuzzy matching
             validated, failed = self._validate_trait_excerpts(raw_excerpts, answer, fuzzy_threshold)
@@ -622,6 +627,7 @@ class RubricDeepJudgmentHandler:
             # Use LLMPort.with_structured_output() for parsing
             from karenina.schemas.outputs import HallucinationRiskOutput
 
+            structured_llm: LLMPort | None = None
             try:
                 structured_llm = self.llm.with_structured_output(HallucinationRiskOutput)
                 response = structured_llm.invoke(messages)
@@ -640,6 +646,9 @@ class RubricDeepJudgmentHandler:
                 logger.warning(f"Failed to parse hallucination assessment: {e}")
                 risk = "medium"
                 justification = "Failed to parse"
+            finally:
+                if structured_llm is not None and structured_llm is not self.llm:
+                    close_adapter(structured_llm)
 
             # Update excerpt with search data
             excerpt["search_results"] = search_results[i] if i < len(search_results) else None
@@ -750,6 +759,7 @@ class RubricDeepJudgmentHandler:
         )
 
         # Use LLMPort.with_structured_output() for parsing
+        structured_llm: LLMPort | None = None
         try:
             structured_llm = self.llm.with_structured_output(schema_class)
             response = structured_llm.invoke(messages)
@@ -773,6 +783,9 @@ class RubricDeepJudgmentHandler:
             score = self._parse_trait_score_response(raw_response, trait)
             usage_metadata = asdict(response.usage) if response.usage else {}
             return {"score": score, "usage_metadata": usage_metadata}
+        finally:
+            if structured_llm is not None and structured_llm is not self.llm:
+                close_adapter(structured_llm)
 
     def _parse_trait_score_response(self, response: str, trait: LLMRubricTrait) -> int | bool:
         """Parse a trait score response."""

--- a/src/karenina/benchmark/verification/evaluators/rubric/evaluator.py
+++ b/src/karenina/benchmark/verification/evaluators/rubric/evaluator.py
@@ -19,6 +19,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from karenina.adapters import get_llm
+from karenina.adapters.registry import close_adapter
 from karenina.ports import LLMPort
 from karenina.schemas.config import ModelConfig
 from karenina.schemas.entities import CallableRubricTrait, MetricRubricTrait, RegexRubricTrait, Rubric
@@ -100,6 +101,10 @@ class RubricEvaluator:
                 self.llm, model_config=self.model_config, prompt_config=self._prompt_config
             )
         return self._metric_trait_evaluator
+
+    def close(self) -> None:
+        """Release adapter resources held by this evaluator."""
+        close_adapter(self.llm)
 
     def evaluate_rubric(
         self,

--- a/src/karenina/benchmark/verification/evaluators/rubric/llm_trait.py
+++ b/src/karenina/benchmark/verification/evaluators/rubric/llm_trait.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import BaseModel
 
+from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
 from karenina.benchmark.verification.prompts.rubric.literal_trait import LiteralTraitPromptBuilder
 from karenina.benchmark.verification.prompts.rubric.llm_trait import LLMTraitPromptBuilder
@@ -166,7 +167,11 @@ class LLMTraitEvaluator:
         # Use LLMPort.with_structured_output() for parsing
         # The adapter guarantees response.raw is a validated BatchRubricScores instance
         structured_llm = self.llm.with_structured_output(BatchRubricScores)
-        response = structured_llm.invoke(messages)
+        try:
+            response = structured_llm.invoke(messages)
+        finally:
+            if structured_llm is not self.llm:
+                close_adapter(structured_llm)
 
         # Extract usage metadata
         usage_metadata = asdict(response.usage) if response.usage else {}
@@ -279,6 +284,7 @@ class LLMTraitEvaluator:
 
         for i, (messages, model_class) in enumerate(tasks):
             trait = traits[i]
+            structured_llm: LLMPort | None = None
             try:
                 # Use LLMPort.with_structured_output() for parsing
                 structured_llm = self.llm.with_structured_output(model_class)
@@ -299,6 +305,9 @@ class LLMTraitEvaluator:
                 logger.warning(f"Failed to evaluate trait '{trait.name}': {e}")
                 results[trait.name] = None  # type: ignore[assignment]
                 usage_metadata_list.append({})
+            finally:
+                if structured_llm is not None and structured_llm is not self.llm:
+                    close_adapter(structured_llm)
 
         return results, usage_metadata_list
 
@@ -464,6 +473,7 @@ class LLMTraitEvaluator:
 
         for i, (messages, model_class) in enumerate(tasks):
             trait = traits[i]
+            structured_llm: LLMPort | None = None
             try:
                 structured_llm = self.llm.with_structured_output(model_class)
                 response = structured_llm.invoke(messages)
@@ -474,6 +484,9 @@ class LLMTraitEvaluator:
                 logger.warning("Failed to evaluate template trait '%s': %s", trait.name, e)
                 self._flatten_template_result(trait.name, None, results)
                 usage_metadata_list.append({})
+            finally:
+                if structured_llm is not None and structured_llm is not self.llm:
+                    close_adapter(structured_llm)
 
         return results, usage_metadata_list
 
@@ -537,7 +550,11 @@ class LLMTraitEvaluator:
 
         # Use LLMPort.with_structured_output() for parsing
         structured_llm = self.llm.with_structured_output(BatchLiteralClassifications)
-        response = structured_llm.invoke(messages)
+        try:
+            response = structured_llm.invoke(messages)
+        finally:
+            if structured_llm is not self.llm:
+                close_adapter(structured_llm)
 
         # Extract usage metadata
         usage_metadata = asdict(response.usage) if response.usage else {}
@@ -660,6 +677,7 @@ class LLMTraitEvaluator:
 
         for i, (messages, model_class) in enumerate(tasks):
             trait = traits[i]
+            structured_llm: LLMPort | None = None
             try:
                 # Use LLMPort.with_structured_output() for parsing
                 structured_llm = self.llm.with_structured_output(model_class)
@@ -679,6 +697,9 @@ class LLMTraitEvaluator:
                 scores[trait.name] = -1
                 labels[trait.name] = f"[EVALUATION_ERROR: {e!s}]"
                 usage_metadata_list.append({})
+            finally:
+                if structured_llm is not None and structured_llm is not self.llm:
+                    close_adapter(structured_llm)
 
         return scores, labels, usage_metadata_list
 

--- a/src/karenina/benchmark/verification/evaluators/rubric/metric_trait.py
+++ b/src/karenina/benchmark/verification/evaluators/rubric/metric_trait.py
@@ -18,6 +18,7 @@ import logging
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
+from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
 from karenina.benchmark.verification.prompts.rubric.metric_trait import MetricTraitPromptBuilder
 from karenina.ports import LLMPort, PortCapabilities
@@ -157,7 +158,11 @@ class MetricTraitEvaluator:
 
         # Use LLMPort.with_structured_output() for parsing
         structured_llm = self.llm.with_structured_output(ConfusionMatrixOutput)
-        response = structured_llm.invoke(messages)
+        try:
+            response = structured_llm.invoke(messages)
+        finally:
+            if structured_llm is not self.llm:
+                close_adapter(structured_llm)
 
         # Extract usage metadata
         usage_metadata = asdict(response.usage) if response.usage else {}

--- a/src/karenina/benchmark/verification/evaluators/template/evaluator.py
+++ b/src/karenina/benchmark/verification/evaluators/template/evaluator.py
@@ -13,6 +13,7 @@ import os
 from typing import TYPE_CHECKING, Any
 
 from karenina.adapters import get_llm, get_parser
+from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
 from karenina.benchmark.verification.prompts.parsing.parsing_instructions import TemplatePromptBuilder
 from karenina.benchmark.verification.utils import prepare_evaluation_input
@@ -115,6 +116,11 @@ class TemplateEvaluator:
 
         # Initialize prompt builder
         self._prompt_builder = TemplatePromptBuilder(answer_class=answer_class)
+
+    def close(self) -> None:
+        """Release adapter resources held by this evaluator."""
+        close_adapter(self._parser)
+        close_adapter(self._llm)
 
     # ========================================================================
     # Public API

--- a/src/karenina/benchmark/verification/evaluators/trace/abstention.py
+++ b/src/karenina/benchmark/verification/evaluators/trace/abstention.py
@@ -7,6 +7,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from karenina.adapters import get_llm
+from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts.assembler import PromptAssembler
 from karenina.benchmark.verification.prompts.task_types import PromptTask
 from karenina.benchmark.verification.prompts.trace.abstention import ABSTENTION_DETECTION_SYS, ABSTENTION_DETECTION_USER
@@ -62,6 +63,8 @@ def detect_abstention(
     """
 
     usage_metadata: dict[str, Any] = {}
+    llm: Any | None = None
+    structured_llm: Any | None = None
 
     try:
         # Create config copy with temperature=0 for consistent detection
@@ -112,3 +115,8 @@ def detect_abstention(
         # Non-recoverable error: log and treat as check failure
         logger.warning("Abstention detection failed: %s", e)
         return False, False, None, usage_metadata
+    finally:
+        if structured_llm is not None:
+            close_adapter(structured_llm)
+        if llm is not None and llm is not structured_llm:
+            close_adapter(llm)

--- a/src/karenina/benchmark/verification/evaluators/trace/sufficiency.py
+++ b/src/karenina/benchmark/verification/evaluators/trace/sufficiency.py
@@ -7,6 +7,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from karenina.adapters import get_llm
+from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts.assembler import PromptAssembler
 from karenina.benchmark.verification.prompts.task_types import PromptTask
 from karenina.benchmark.verification.prompts.trace.sufficiency import (
@@ -70,6 +71,8 @@ def detect_sufficiency(
     """
 
     usage_metadata: dict[str, Any] = {}
+    llm: Any | None = None
+    structured_llm: Any | None = None
 
     try:
         # Create config copy with temperature=0 for consistent detection
@@ -127,3 +130,8 @@ def detect_sufficiency(
         # Non-recoverable error: log and treat as check failure
         logger.warning("Sufficiency detection failed: %s", e)
         return True, False, None, usage_metadata  # Default to sufficient on failure
+    finally:
+        if structured_llm is not None:
+            close_adapter(structured_llm)
+        if llm is not None and llm is not structured_llm:
+            close_adapter(llm)

--- a/src/karenina/benchmark/verification/stages/pipeline/agentic_parse_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/agentic_parse_template.py
@@ -10,6 +10,7 @@ import logging
 from typing import Any
 
 from karenina.adapters import get_agent, get_parser
+from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
 from karenina.benchmark.verification.utils.schema_builder import build_parsing_schema
 from karenina.ports import AgentConfig, PortCapabilities
@@ -206,13 +207,16 @@ class AgenticParseTemplateStage(BaseVerificationStage):
             workspace_path=context.workspace_path,
         )
 
-        result = agent.run(messages=messages, config=agent_config)
-        logger.info(
-            "Investigation completed in %d turns (limit_reached=%s)",
-            result.turns,
-            result.limit_reached,
-        )
-        return result.raw_trace
+        try:
+            result = agent.run(messages=messages, config=agent_config)
+            logger.info(
+                "Investigation completed in %d turns (limit_reached=%s)",
+                result.turns,
+                result.limit_reached,
+            )
+            return result.raw_trace
+        finally:
+            close_adapter(agent)
 
     def _run_extraction(
         self,
@@ -264,5 +268,8 @@ class AgenticParseTemplateStage(BaseVerificationStage):
             },
         )
 
-        parse_result = parser.parse_to_pydantic(messages, answer_class)
-        return parse_result.parsed
+        try:
+            parse_result = parser.parse_to_pydantic(messages, answer_class)
+            return parse_result.parsed
+        finally:
+            close_adapter(parser)

--- a/src/karenina/benchmark/verification/stages/pipeline/agentic_rubric_evaluation.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/agentic_rubric_evaluation.py
@@ -11,7 +11,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from karenina.adapters.registry import AdapterRegistry
+from karenina.adapters.registry import AdapterRegistry, close_adapter
 from karenina.benchmark.verification.evaluators import AgenticTraitEvaluator
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
 from karenina.ports import PortCapabilities
@@ -282,6 +282,7 @@ class AgenticRubricEvaluationStage(BaseVerificationStage):
         shared_timeout = max(t.timeout_seconds for t in valid_traits)
 
         # Run a single shared investigation
+        agent: Any | None = None
         try:
             from karenina.adapters import get_agent
             from karenina.ports import AgentConfig
@@ -343,6 +344,9 @@ class AgenticRubricEvaluationStage(BaseVerificationStage):
                 raw_response,
                 workspace_path,
             )
+        finally:
+            if agent is not None:
+                close_adapter(agent)
 
         # Per-trait extraction from the shared trace
         result_scores: dict[str, int | bool | dict[str, Any] | None] = {}

--- a/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
@@ -306,7 +306,7 @@ class FinalizeResultStage(BaseVerificationStage):
 
             llm_trait_scores: dict[str, Any] | None = None
             regex_trait_scores: dict[str, bool] | None = None
-            callable_trait_scores: dict[str, bool | int] | None = None
+            callable_trait_scores: dict[str, bool | int | float] | None = None
             metric_trait_scores_dict: dict[str, dict[str, float]] | None = None
 
             if verify_rubric and evaluation_rubric and isinstance(verify_rubric, dict):
@@ -320,7 +320,7 @@ class FinalizeResultStage(BaseVerificationStage):
                 # carries Any to accept strings, lists, bools, and numerics.
                 llm_results: dict[str, Any] = {}
                 regex_results: dict[str, bool] = {}
-                callable_results: dict[str, bool | int] = {}
+                callable_results: dict[str, bool | int | float] = {}
 
                 for trait_name, trait_value in verify_rubric.items():
                     # Skip failed trait evaluations (None values)

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -13,6 +13,7 @@ import traceback
 from typing import Any
 
 from karenina.adapters import get_agent, get_llm
+from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.utils.llm_invocation import _construct_few_shot_prompt
 from karenina.benchmark.verification.utils.trace_agent_metrics import extract_agent_metrics_from_messages
 from karenina.benchmark.verification.utils.trace_usage_tracker import UsageTracker
@@ -612,6 +613,11 @@ class GenerateAnswerStage(BaseVerificationStage):
             context.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "")
             context.set_artifact(ArtifactKeys.RECURSION_LIMIT_REACHED, False)
             return
+        finally:
+            if answering_agent is not None:
+                close_adapter(answering_agent)
+            if answering_llm is not None:
+                close_adapter(answering_llm)
 
         # Store results (both artifact and result field)
         self.set_artifact_and_result(context, "raw_llm_response", raw_llm_response)

--- a/src/karenina/benchmark/verification/stages/pipeline/rubric_evaluation.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/rubric_evaluation.py
@@ -11,6 +11,7 @@ from dataclasses import asdict
 from typing import Any
 
 from karenina.adapters import get_llm
+from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.evaluators import RubricEvaluator
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
 from karenina.benchmark.verification.prompts.rubric.presence_check import PresenceCheckPromptBuilder
@@ -173,6 +174,7 @@ class RubricEvaluationStage(BaseVerificationStage):
         llm_trait_labels = None
         metric_confusion_lists = None
         metric_results = None
+        evaluator: RubricEvaluator | None = None
 
         # If rubric is None after dynamic resolution (all traits absent), skip evaluation
         if rubric is None or not any(
@@ -354,6 +356,9 @@ class RubricEvaluationStage(BaseVerificationStage):
             logger.warning("Rubric evaluation failed for question %s: %s", context.question_id, e)
             context.add_warning(f"Rubric evaluation failed: {e}")
             rubric_result = None  # type: ignore[assignment]
+        finally:
+            if evaluator is not None:
+                evaluator.close()
 
         self._store_results(context, rubric_result, llm_trait_labels, metric_confusion_lists, metric_results)
 
@@ -550,9 +555,17 @@ class RubricEvaluationStage(BaseVerificationStage):
 
         # Invoke structured LLM
         detection_config = parsing_model.model_copy(update={"temperature": 0.0})
-        llm = get_llm(detection_config)
-        structured_llm = llm.with_structured_output(ConceptPresenceResult)
-        response: LLMResponse = structured_llm.invoke(messages)
+        llm: Any | None = None
+        structured_llm: Any | None = None
+        try:
+            llm = get_llm(detection_config)
+            structured_llm = llm.with_structured_output(ConceptPresenceResult)
+            response: LLMResponse = structured_llm.invoke(messages)
+        finally:
+            if structured_llm is not None:
+                close_adapter(structured_llm)
+            if llm is not None and llm is not structured_llm:
+                close_adapter(llm)
 
         # Track usage
         usage_tracker = self.get_or_create_usage_tracker(context)

--- a/src/karenina/benchmark/verification/stages/pipeline/verify_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/verify_template.py
@@ -200,3 +200,7 @@ class VerifyTemplateStage(BaseVerificationStage):
             error_msg = f"Verification failed: {e}"
             logger.error(error_msg)
             context.mark_error(error_msg)
+        finally:
+            if evaluator is not None and hasattr(evaluator, "close"):
+                evaluator.close()
+                context.set_artifact(ArtifactKeys.TEMPLATE_EVALUATOR, None)

--- a/src/karenina/benchmark/verification/utils/embedding_check.py
+++ b/src/karenina/benchmark/verification/utils/embedding_check.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from typing import Any
 
 from karenina.adapters.factory import get_llm
+from karenina.adapters.registry import close_adapter
 from karenina.ports.messages import Message
 from karenina.schemas.config import ModelConfig
 from karenina.schemas.verification.config import DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_THRESHOLD
@@ -232,6 +233,8 @@ def check_semantic_equivalence(
     if not ground_truth_data or not llm_response_data:
         return False
 
+    parsing_llm: Any | None = None
+
     try:
         # Get LLM via the port/adapter factory (respects interface routing)
         parsing_llm = get_llm(parsing_model)
@@ -286,6 +289,9 @@ Are these two responses semantically equivalent?"""
 
     except Exception as e:
         raise RuntimeError(f"Failed to perform semantic equivalence check: {e}") from e
+    finally:
+        if parsing_llm is not None:
+            close_adapter(parsing_llm)
 
 
 def perform_embedding_check(

--- a/src/karenina/schemas/dataframes/rubric.py
+++ b/src/karenina/schemas/dataframes/rubric.py
@@ -468,7 +468,7 @@ class RubricDataFrameBuilder:
         self,
         result: VerificationResult,
         trait_name: str,
-        trait_score: bool | int,
+        trait_score: bool | int | float,
     ) -> dict[str, Any]:
         """Create DataFrame row for callable trait."""
         metadata = result.metadata

--- a/src/karenina/schemas/results/rubric.py
+++ b/src/karenina/schemas/results/rubric.py
@@ -222,7 +222,7 @@ class RubricResults(BaseModel):
 
     def get_callable_trait_scores(
         self, question_id: str | None = None, trait_name: str | None = None
-    ) -> dict[str, dict[str, bool | int]]:
+    ) -> dict[str, dict[str, bool | int | float]]:
         """
         Get callable trait scores from all results.
 
@@ -232,7 +232,7 @@ class RubricResults(BaseModel):
 
         Returns:
             Dictionary mapping result identifiers to callable trait scores
-            Format: {result_id: {trait_name: bool | int}}
+            Format: {result_id: {trait_name: bool | int | float}}
         """
         scores = {}
         for result in self.get_results_with_rubric():

--- a/src/karenina/schemas/verification/result_components.py
+++ b/src/karenina/schemas/verification/result_components.py
@@ -232,7 +232,9 @@ class VerificationResultRubric(BaseModel):
     # and the human-readable class names are stored here. For non-literal traits, this field is not used.
     # Error state: score=-1 in llm_trait_scores indicates invalid classification, label contains the invalid value.
     regex_trait_scores: dict[str, bool] | None = None  # Regex-based traits (boolean)
-    callable_trait_scores: dict[str, bool | int] | None = None  # Callable-based traits (boolean or score)
+    callable_trait_scores: dict[str, bool | int | float] | None = (
+        None  # Callable-based traits (boolean or score; score may be float in [min_score, max_score])
+    )
     metric_trait_scores: dict[str, dict[str, float]] | None = None  # Metric traits with nested metrics dict
 
     # Metric trait evaluation metadata (confusion-matrix analysis)

--- a/tests/unit/adapters/langchain/test_mcp_json_string_coercion.py
+++ b/tests/unit/adapters/langchain/test_mcp_json_string_coercion.py
@@ -1,0 +1,88 @@
+"""Tests for schema-gated MCP tool argument coercion."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel
+
+from karenina.adapters.langchain.mcp import (
+    _coerce_json_string_tool_args,
+    _wrap_json_string_args_tool,
+)
+
+
+class SearchArgs(BaseModel):
+    query_strings: list[str]
+    query_string: str
+    variables: dict[str, Any]
+
+
+def test_coerces_json_strings_for_schema_container_fields() -> None:
+    result = _coerce_json_string_tool_args(
+        {
+            "query_strings": '["atopic eczema", "Atopic Dermatitides"]',
+            "query_string": '["this remains a string"]',
+            "variables": '{"efoId": "EFO_0000274"}',
+        },
+        SearchArgs,
+        "search_entities",
+    )
+
+    assert result == {
+        "query_strings": ["atopic eczema", "Atopic Dermatitides"],
+        "query_string": '["this remains a string"]',
+        "variables": {"efoId": "EFO_0000274"},
+    }
+
+
+def test_leaves_correct_and_invalid_values_unchanged() -> None:
+    original = {
+        "query_strings": ["atopic eczema"],
+        "query_string": "atopic eczema",
+        "variables": "{not json}",
+    }
+
+    result = _coerce_json_string_tool_args(original, SearchArgs, "search_entities")
+
+    assert result == original
+    assert result is not original
+
+
+@pytest.mark.asyncio
+async def test_wrapped_tool_coerces_before_pydantic_validation() -> None:
+    async def search_entities(
+        query_strings: list[str],
+        query_string: str,
+        variables: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "query_strings": query_strings,
+            "query_string": query_string,
+            "variables": variables,
+        }
+
+    tool = StructuredTool.from_function(
+        coroutine=search_entities,
+        name="search_entities",
+        description="Search entities.",
+        args_schema=SearchArgs,
+    )
+    wrapped = _wrap_json_string_args_tool(tool)
+
+    assert wrapped.response_format == "content"
+    result = await wrapped.ainvoke(
+        {
+            "query_strings": '["atopic eczema"]',
+            "query_string": '["literal string"]',
+            "variables": '{"efoId": "EFO_0000274"}',
+        }
+    )
+
+    assert result == {
+        "query_strings": ["atopic eczema"],
+        "query_string": '["literal string"]',
+        "variables": {"efoId": "EFO_0000274"},
+    }

--- a/tests/unit/adapters/test_registry_lifecycle.py
+++ b/tests/unit/adapters/test_registry_lifecycle.py
@@ -1,0 +1,40 @@
+"""Tests for immediate adapter lifecycle cleanup helpers."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from karenina.adapters.registry import cleanup_all_adapters, close_adapter, register_adapter
+
+
+class CountingAdapter:
+    def __init__(self) -> None:
+        self.close_count = 0
+
+    async def aclose(self) -> None:
+        self.close_count += 1
+
+
+def test_close_adapter_closes_and_unregisters_transient_adapter() -> None:
+    adapter = CountingAdapter()
+    register_adapter(adapter)
+
+    close_adapter(adapter)
+
+    assert adapter.close_count == 1
+
+    # If close_adapter did not unregister, global cleanup would close it again.
+    asyncio.run(cleanup_all_adapters())
+    assert adapter.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cleanup_all_adapters_still_closes_registered_adapter() -> None:
+    adapter = CountingAdapter()
+    register_adapter(adapter)
+
+    await cleanup_all_adapters()
+
+    assert adapter.close_count == 1


### PR DESCRIPTION
## Summary
Adds adapter lifecycle regression coverage and fixes edge cases found while exercising MCP tools and callable trait scoring.

## Changes
- Handles JSON-stringified MCP tool arguments.
- Closes transient adapters during verification.
- Allows float scores through callable_trait_scores end to end.
- Adds software regression tests for the adapter lifecycle behavior.

## Test plan
- Targeted non-optional pytest suite: 83 passed locally.