### PR TITLE
Plumb per-call usage_metadata through Message → trace_messages

### DIFF
--- a/src/karenina/adapters/claude_agent_sdk/messages.py
+++ b/src/karenina/adapters/claude_agent_sdk/messages.py
@@ -169,6 +169,44 @@ class ClaudeSDKMessageConverter:
                 text_parts.append(block.text)
         return Message.user("\n".join(text_parts) if text_parts else "")
 
+    def _extract_assistant_usage(self, msg: AssistantMessage) -> dict[str, int] | None:
+        """Extract per-call usage metadata from an SDK AssistantMessage.
+
+        SDK AssistantMessage exposes an Anthropic-shaped usage dict with
+        input_tokens / output_tokens (always) and optional cache fields
+        (cache_read_input_tokens / cache_creation_input_tokens).
+
+        Mirrors the extraction logic in
+        ``claude_agent_sdk/trace.py::sdk_messages_to_trace_messages`` so the
+        Message-based production trace path carries the same per-turn
+        accounting as the direct-to-dict helper.
+
+        Args:
+            msg: SDK AssistantMessage instance.
+
+        Returns:
+            Dict with input_tokens / output_tokens (and any reported cache
+            fields), or None when no usage is reported (missing attribute
+            or empty/falsy dict).
+        """
+        usage_data = getattr(msg, "usage", None)
+        if not usage_data:
+            return None
+
+        per_call: dict[str, int] = {
+            "input_tokens": int(usage_data.get("input_tokens", 0) or 0),
+            "output_tokens": int(usage_data.get("output_tokens", 0) or 0),
+        }
+        # Only include cache fields when reported, so we can distinguish
+        # "not reported" from a real zero.
+        cache_read = usage_data.get("cache_read_input_tokens")
+        if cache_read is not None:
+            per_call["cache_read_input_tokens"] = int(cache_read)
+        cache_creation = usage_data.get("cache_creation_input_tokens")
+        if cache_creation is not None:
+            per_call["cache_creation_input_tokens"] = int(cache_creation)
+        return per_call
+
     def _convert_assistant_message(
         self,
         msg: AssistantMessage,
@@ -263,9 +301,18 @@ class ClaudeSDKMessageConverter:
             # Add tool calls
             content.extend(tool_calls)
 
+            # Extract per-call usage so it survives end-to-end into
+            # template.trace_messages[*].usage_metadata for both CSDK and
+            # DA interfaces.
+            usage_metadata = self._extract_assistant_usage(msg)
+
             result.insert(
                 0,
-                Message(role=Role.ASSISTANT, content=content),  # type: ignore[arg-type]
+                Message(
+                    role=Role.ASSISTANT,
+                    content=content,  # type: ignore[arg-type]
+                    usage_metadata=usage_metadata,
+                ),
             )
 
         return result

--- a/src/karenina/adapters/claude_agent_sdk/trace.py
+++ b/src/karenina/adapters/claude_agent_sdk/trace.py
@@ -213,6 +213,27 @@ def sdk_messages_to_trace_messages(
                 if hasattr(msg, "model") and msg.model:
                     trace_msg["model"] = msg.model
 
+                # Add per-call usage metadata if present so post-hoc audit of
+                # token usage / cache hits per turn is preserved. SDK
+                # AssistantMessage exposes Anthropic-shaped usage dict with
+                # input_tokens / output_tokens (always) and optional cache
+                # fields (cache_read_input_tokens / cache_creation_input_tokens).
+                if hasattr(msg, "usage") and msg.usage:
+                    usage_data = msg.usage
+                    per_call_usage: dict[str, int] = {
+                        "input_tokens": int(usage_data.get("input_tokens", 0) or 0),
+                        "output_tokens": int(usage_data.get("output_tokens", 0) or 0),
+                    }
+                    # Only include cache fields when reported, so we can
+                    # distinguish "not reported" from a real zero.
+                    cache_read = usage_data.get("cache_read_input_tokens")
+                    if cache_read is not None:
+                        per_call_usage["cache_read_input_tokens"] = int(cache_read)
+                    cache_creation = usage_data.get("cache_creation_input_tokens")
+                    if cache_creation is not None:
+                        per_call_usage["cache_creation_input_tokens"] = int(cache_creation)
+                    trace_msg["usage_metadata"] = per_call_usage
+
                 result.append(trace_msg)
                 block_index += 1
 

--- a/src/karenina/adapters/langchain_deep_agents/__init__.py
+++ b/src/karenina/adapters/langchain_deep_agents/__init__.py
@@ -18,6 +18,7 @@ Utilities:
     - convert_mcp_to_tools: Convert MCPServerConfig to LangChain tools
     - extract_deep_agents_usage: Extract UsageMetadata from agent results
     - deep_agents_messages_to_raw_trace: Format messages as raw trace string
+    - deep_agents_messages_to_trace_messages: Structured trace_messages with per-call usage
 """
 
 from typing import TYPE_CHECKING, Any
@@ -31,6 +32,7 @@ __all__ = [
     "convert_mcp_to_tools",
     "extract_deep_agents_usage",
     "deep_agents_messages_to_raw_trace",
+    "deep_agents_messages_to_trace_messages",
     "wrap_deep_agents_error",
 ]
 
@@ -42,7 +44,10 @@ if TYPE_CHECKING:
     from karenina.adapters.langchain_deep_agents.mcp import convert_mcp_to_tools
     from karenina.adapters.langchain_deep_agents.messages import DeepAgentsMessageConverter
     from karenina.adapters.langchain_deep_agents.parser import DeepAgentsParserAdapter
-    from karenina.adapters.langchain_deep_agents.trace import deep_agents_messages_to_raw_trace
+    from karenina.adapters.langchain_deep_agents.trace import (
+        deep_agents_messages_to_raw_trace,
+        deep_agents_messages_to_trace_messages,
+    )
     from karenina.adapters.langchain_deep_agents.usage import extract_deep_agents_usage
 
 
@@ -57,6 +62,7 @@ def __getattr__(name: str) -> Any:
         "convert_mcp_to_tools": "karenina.adapters.langchain_deep_agents.mcp",
         "extract_deep_agents_usage": "karenina.adapters.langchain_deep_agents.usage",
         "deep_agents_messages_to_raw_trace": "karenina.adapters.langchain_deep_agents.trace",
+        "deep_agents_messages_to_trace_messages": "karenina.adapters.langchain_deep_agents.trace",
         "wrap_deep_agents_error": "karenina.adapters.langchain_deep_agents.errors",
     }
 

--- a/src/karenina/adapters/langchain_deep_agents/messages.py
+++ b/src/karenina/adapters/langchain_deep_agents/messages.py
@@ -102,7 +102,17 @@ class DeepAgentsMessageConverter:
                 result.append(Message.user(msg.content if isinstance(msg.content, str) else str(msg.content)))
 
             elif isinstance(msg, AIMessage):
-                result.append(self._convert_ai_message(msg))
+                converted = self._convert_ai_message(msg)
+                # Attach per-call usage so it propagates into
+                # template.trace_messages[*].usage_metadata via to_dict().
+                # Reuse the extraction helper from trace.py to keep the two
+                # paths consistent.
+                from karenina.adapters.langchain_deep_agents.trace import (
+                    _extract_ai_usage_metadata,
+                )
+
+                converted.usage_metadata = _extract_ai_usage_metadata(msg)
+                result.append(converted)
 
             elif isinstance(msg, ToolMessage):
                 content = msg.content if isinstance(msg.content, str) else str(msg.content)

--- a/src/karenina/adapters/langchain_deep_agents/trace.py
+++ b/src/karenina/adapters/langchain_deep_agents/trace.py
@@ -3,6 +3,10 @@
 Converts LangGraph BaseMessage lists into karenina's raw trace format:
 a delimited string for backward compatibility with existing infrastructure
 (regex highlighting, database storage, trace validation).
+
+Also exposes a structured trace_messages builder that returns the
+list[dict] shape consumed by the frontend TraceMessage component and
+preserves per-call usage_metadata on assistant entries.
 """
 
 from __future__ import annotations
@@ -12,6 +16,56 @@ import logging
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_ai_usage_metadata(msg: Any) -> dict[str, int] | None:
+    """Extract per-call usage metadata from a LangChain AIMessage.
+
+    Prefers AIMessage.usage_metadata (the modern LangChain standard with
+    input_tokens / output_tokens keys). Falls back to
+    response_metadata.token_usage (older LangChain shape with
+    prompt_tokens / completion_tokens) and renames the keys.
+
+    Mirrors the per-message extraction logic in
+    `langchain_deep_agents/usage.py:extract_deep_agents_usage` but
+    returns the per-message dict instead of aggregating.
+
+    Args:
+        msg: A LangGraph AIMessage instance.
+
+    Returns:
+        Dict with input_tokens / output_tokens (and any cache fields
+        propagated from usage_metadata when present), or None when no
+        usage information is reported.
+    """
+    usage_meta = getattr(msg, "usage_metadata", None)
+    if usage_meta and isinstance(usage_meta, dict):
+        per_call: dict[str, int] = {
+            "input_tokens": int(usage_meta.get("input_tokens", 0) or 0),
+            "output_tokens": int(usage_meta.get("output_tokens", 0) or 0),
+        }
+        # If the prompt-cache middleware is in use, LangChain may expose
+        # Anthropic-shaped cache fields here. Forward them when present.
+        cache_read = usage_meta.get("cache_read_input_tokens")
+        if cache_read is not None:
+            per_call["cache_read_input_tokens"] = int(cache_read)
+        cache_creation = usage_meta.get("cache_creation_input_tokens")
+        if cache_creation is not None:
+            per_call["cache_creation_input_tokens"] = int(cache_creation)
+        return per_call
+
+    resp_meta = getattr(msg, "response_metadata", None)
+    if resp_meta and isinstance(resp_meta, dict):
+        token_usage = resp_meta.get("token_usage")
+        if isinstance(token_usage, dict) and (
+            "prompt_tokens" in token_usage or "completion_tokens" in token_usage
+        ):
+            return {
+                "input_tokens": int(token_usage.get("prompt_tokens", 0) or 0),
+                "output_tokens": int(token_usage.get("completion_tokens", 0) or 0),
+            }
+
+    return None
 
 
 def deep_agents_messages_to_raw_trace(
@@ -90,3 +144,99 @@ def _extract_ai_text(msg: Any) -> str:
         return "\n".join(text_parts)
 
     return ""
+
+
+def deep_agents_messages_to_trace_messages(
+    messages: list[Any],
+    include_user_messages: bool = False,
+) -> list[dict[str, Any]]:
+    """Convert LangGraph messages to structured TraceMessage list.
+
+    Produces the structured list[dict] format consumed by the frontend
+    TraceMessage component. Each assistant entry preserves per-call
+    usage_metadata when the underlying AIMessage reports it (so
+    post-hoc audits of token usage / cache hits per turn remain possible).
+
+    Args:
+        messages: List of LangGraph BaseMessage objects.
+        include_user_messages: If True, include HumanMessage entries. Defaults
+            to False to match the existing raw_trace behavior.
+
+    Returns:
+        List of TraceMessage dicts with role, content, block_index, and
+        optional tool_calls, tool_result, and usage_metadata fields.
+    """
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+    if not messages:
+        return []
+
+    result: list[dict[str, Any]] = []
+    block_index = 0
+
+    for msg in messages:
+        if isinstance(msg, SystemMessage):
+            continue
+
+        if isinstance(msg, HumanMessage):
+            if include_user_messages:
+                content = msg.content if isinstance(msg.content, str) else str(msg.content)
+                if content:
+                    result.append(
+                        {
+                            "role": "user",
+                            "content": content,
+                            "block_index": block_index,
+                        }
+                    )
+                    block_index += 1
+            continue
+
+        if isinstance(msg, AIMessage):
+            text = _extract_ai_text(msg)
+            tool_calls: list[dict[str, Any]] = []
+            if hasattr(msg, "tool_calls") and msg.tool_calls:
+                for tc in msg.tool_calls:
+                    tool_calls.append(
+                        {
+                            "id": tc.get("id", ""),
+                            "name": tc.get("name", "unknown"),
+                            "input": tc.get("args", {}) if isinstance(tc.get("args"), dict) else {},
+                        }
+                    )
+
+            if text or tool_calls:
+                trace_msg: dict[str, Any] = {
+                    "role": "assistant",
+                    "content": text,
+                    "block_index": block_index,
+                }
+
+                if tool_calls:
+                    trace_msg["tool_calls"] = tool_calls
+
+                usage_metadata = _extract_ai_usage_metadata(msg)
+                if usage_metadata is not None:
+                    trace_msg["usage_metadata"] = usage_metadata
+
+                result.append(trace_msg)
+                block_index += 1
+            continue
+
+        if isinstance(msg, ToolMessage):
+            content = msg.content if isinstance(msg.content, str) else str(msg.content)
+            tool_use_id = getattr(msg, "tool_call_id", "") or ""
+            result.append(
+                {
+                    "role": "tool",
+                    "content": content,
+                    "block_index": block_index,
+                    "tool_result": {
+                        "tool_use_id": tool_use_id,
+                        "is_error": False,
+                    },
+                }
+            )
+            block_index += 1
+
+    return result

--- a/src/karenina/ports/messages.py
+++ b/src/karenina/ports/messages.py
@@ -129,6 +129,11 @@ class Message:
     Attributes:
         role: The role of the message sender (system, user, assistant, tool).
         content: List of content blocks that make up the message.
+        usage_metadata: Optional per-call usage accounting (input_tokens,
+            output_tokens, and optional cache_read_input_tokens /
+            cache_creation_input_tokens). Populated by adapters from the
+            provider's per-message usage payload so per-turn token / cache
+            accounting survives into ``template.trace_messages``.
 
     Example:
         >>> msg = Message.user("Hello, world!")
@@ -143,6 +148,7 @@ class Message:
 
     role: Role
     content: list[Content]
+    usage_metadata: dict[str, Any] | None = None
 
     @property
     def text(self) -> str:
@@ -282,6 +288,11 @@ class Message:
                     thinking["signature"] = block.signature
                 result["thinking"] = thinking
                 break
+
+        # Add per-call usage metadata when present so per-turn token /
+        # cache accounting is preserved in template.trace_messages[*].
+        if self.usage_metadata is not None:
+            result["usage_metadata"] = self.usage_metadata
 
         return result
 

--- a/src/karenina/ports/messages.py
+++ b/src/karenina/ports/messages.py
@@ -346,4 +346,8 @@ class Message:
                 )
             )
 
-        return cls(role=role, content=content_blocks)
+        return cls(
+            role=role,
+            content=content_blocks,
+            usage_metadata=data.get("usage_metadata"),
+        )

--- a/tests/unit/adapters/claude_sdk/test_message_converter_usage.py
+++ b/tests/unit/adapters/claude_sdk/test_message_converter_usage.py
@@ -1,0 +1,152 @@
+"""Tests that ClaudeSDKMessageConverter.from_provider populates usage_metadata.
+
+Fix E (extension): the production trace path in claude_agent_sdk/agent.py
+builds ``trace_messages`` via ``self._converter.from_provider(...)`` rather
+than the direct-to-dict ``sdk_messages_to_trace_messages`` helper. This test
+asserts that the converter attaches per-call ``usage_metadata`` to the
+returned ``Message`` so that ``Message.to_dict()`` emits it into
+``template.trace_messages[*]``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.adapters.claude_agent_sdk import ClaudeSDKMessageConverter
+from karenina.ports import Role
+
+
+@pytest.mark.unit
+class TestClaudeSDKConverterUsageMetadata:
+    def test_assistant_message_carries_usage_metadata(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        sdk_messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="The answer is 42.")],
+                usage={"input_tokens": 123, "output_tokens": 45},
+            ),
+        ]
+
+        converter = ClaudeSDKMessageConverter()
+        result = converter.from_provider(sdk_messages)
+
+        assert len(result) == 1
+        msg = result[0]
+        assert msg.role == Role.ASSISTANT
+        assert msg.usage_metadata == {"input_tokens": 123, "output_tokens": 45}
+
+    def test_to_dict_emits_usage_metadata_after_conversion(self) -> None:
+        """End-to-end: converter populates field, to_dict emits it."""
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        sdk_messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="hi")],
+                usage={"input_tokens": 7, "output_tokens": 3},
+            ),
+        ]
+
+        converter = ClaudeSDKMessageConverter()
+        [msg] = converter.from_provider(sdk_messages)
+        out = msg.to_dict()
+
+        assert out["role"] == "assistant"
+        assert out["usage_metadata"] == {"input_tokens": 7, "output_tokens": 3}
+
+    def test_cache_fields_propagate_when_reported(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        sdk_messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="cached")],
+                usage={
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_read_input_tokens": 800,
+                    "cache_creation_input_tokens": 50,
+                },
+            ),
+        ]
+
+        converter = ClaudeSDKMessageConverter()
+        [msg] = converter.from_provider(sdk_messages)
+
+        assert msg.usage_metadata == {
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_read_input_tokens": 800,
+            "cache_creation_input_tokens": 50,
+        }
+
+    def test_partial_cache_fields_only_include_reported(self) -> None:
+        """A reported zero must be preserved; missing fields must stay absent."""
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        sdk_messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="partial")],
+                usage={
+                    "input_tokens": 60,
+                    "output_tokens": 10,
+                    "cache_read_input_tokens": 0,
+                },
+            ),
+        ]
+
+        converter = ClaudeSDKMessageConverter()
+        [msg] = converter.from_provider(sdk_messages)
+
+        assert msg.usage_metadata is not None
+        assert msg.usage_metadata["cache_read_input_tokens"] == 0
+        assert "cache_creation_input_tokens" not in msg.usage_metadata
+
+    def test_no_usage_yields_none_usage_metadata(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        sdk_messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="no usage")],
+            ),
+        ]
+
+        converter = ClaudeSDKMessageConverter()
+        [msg] = converter.from_provider(sdk_messages)
+
+        assert msg.usage_metadata is None
+        # to_dict must omit the key entirely
+        assert "usage_metadata" not in msg.to_dict()
+
+    def test_empty_usage_dict_yields_none(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        sdk_messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="empty usage")],
+                usage={},
+            ),
+        ]
+
+        converter = ClaudeSDKMessageConverter()
+        [msg] = converter.from_provider(sdk_messages)
+
+        assert msg.usage_metadata is None
+        assert "usage_metadata" not in msg.to_dict()

--- a/tests/unit/adapters/claude_sdk/test_trace_includes_usage.py
+++ b/tests/unit/adapters/claude_sdk/test_trace_includes_usage.py
@@ -1,0 +1,134 @@
+"""Tests that sdk_messages_to_trace_messages preserves per-call usage_metadata.
+
+Fix E (karenina infrastructure plan): trace converters must propagate the
+per-message ``usage`` payload that the Claude Agent SDK attaches to each
+``AssistantMessage`` so that ``template.trace_messages[*].usage_metadata``
+contains per-turn token / cache accounting (and not just the aggregate).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _to_trace(messages):
+    from karenina.adapters.claude_agent_sdk.trace import sdk_messages_to_trace_messages
+
+    return sdk_messages_to_trace_messages(messages)
+
+
+@pytest.mark.unit
+class TestTraceUsageMetadataCSDK:
+    def test_assistant_message_with_usage_propagates_input_output_tokens(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="The answer is 42.")],
+                usage={"input_tokens": 123, "output_tokens": 45},
+            ),
+        ]
+
+        trace = _to_trace(messages)
+        assert len(trace) == 1
+        assert trace[0]["role"] == "assistant"
+        assert "usage_metadata" in trace[0]
+        assert trace[0]["usage_metadata"] == {
+            "input_tokens": 123,
+            "output_tokens": 45,
+        }
+
+    def test_cache_fields_present_propagate_when_reported(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="cached answer")],
+                usage={
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_read_input_tokens": 800,
+                    "cache_creation_input_tokens": 50,
+                },
+            ),
+        ]
+
+        trace = _to_trace(messages)
+        assert trace[0]["usage_metadata"] == {
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_read_input_tokens": 800,
+            "cache_creation_input_tokens": 50,
+        }
+
+    def test_partial_cache_fields_only_include_reported_ones(self) -> None:
+        """When only one cache field is reported, the other must not be added.
+
+        This distinguishes 'not reported' from a real zero — crucial for
+        provenance during post-hoc audits.
+        """
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="partial cache info")],
+                usage={
+                    "input_tokens": 60,
+                    "output_tokens": 10,
+                    "cache_read_input_tokens": 0,
+                },
+            ),
+        ]
+
+        trace = _to_trace(messages)
+        usage_metadata = trace[0]["usage_metadata"]
+        assert usage_metadata["input_tokens"] == 60
+        assert usage_metadata["output_tokens"] == 10
+        # cache_read_input_tokens was explicitly reported as 0 → keep it.
+        assert usage_metadata["cache_read_input_tokens"] == 0
+        # cache_creation_input_tokens was NOT reported → must be absent.
+        assert "cache_creation_input_tokens" not in usage_metadata
+
+    def test_assistant_message_without_usage_omits_usage_metadata(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        # usage defaults to None on AssistantMessage construction
+        messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="no usage payload")],
+            ),
+        ]
+
+        trace = _to_trace(messages)
+        assert len(trace) == 1
+        assert trace[0]["role"] == "assistant"
+        assert "usage_metadata" not in trace[0]
+
+    def test_assistant_message_with_empty_usage_dict_omits_usage_metadata(self) -> None:
+        """An empty usage dict is falsy -> treated as 'not reported'."""
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="empty usage")],
+                usage={},
+            ),
+        ]
+
+        trace = _to_trace(messages)
+        assert "usage_metadata" not in trace[0]

--- a/tests/unit/adapters/langchain_deep_agents/test_message_converter_usage.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_message_converter_usage.py
@@ -1,0 +1,127 @@
+"""Tests that DeepAgentsMessageConverter.from_provider populates usage_metadata.
+
+Fix E (extension): the production trace path in
+langchain_deep_agents/agent.py builds ``trace_messages`` via
+``self._converter.from_provider(lc_messages)`` rather than the direct
+``deep_agents_messages_to_trace_messages`` helper. The converter must
+attach per-call usage to each assistant ``Message`` so that
+``Message.to_dict()`` emits it into ``template.trace_messages[*]``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.adapters.langchain_deep_agents.messages import DeepAgentsMessageConverter
+from karenina.ports import Role
+
+
+@pytest.mark.unit
+class TestDeepAgentsConverterUsageMetadata:
+    def test_modern_usage_metadata_propagates(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="Hello world",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            },
+        )
+
+        converter = DeepAgentsMessageConverter()
+        [out] = converter.from_provider([msg])
+
+        assert out.role == Role.ASSISTANT
+        assert out.usage_metadata == {"input_tokens": 100, "output_tokens": 50}
+
+    def test_to_dict_emits_usage_metadata_after_conversion(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="Hello",
+            usage_metadata={"input_tokens": 7, "output_tokens": 3, "total_tokens": 10},
+        )
+
+        converter = DeepAgentsMessageConverter()
+        [out] = converter.from_provider([msg])
+
+        assert out.to_dict()["usage_metadata"] == {
+            "input_tokens": 7,
+            "output_tokens": 3,
+        }
+
+    def test_cache_fields_propagate_when_reported(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="cached",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+                "cache_read_input_tokens": 800,
+                "cache_creation_input_tokens": 50,
+            },
+        )
+
+        converter = DeepAgentsMessageConverter()
+        [out] = converter.from_provider([msg])
+
+        assert out.usage_metadata == {
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_read_input_tokens": 800,
+            "cache_creation_input_tokens": 50,
+        }
+
+    def test_response_metadata_token_usage_fallback(self) -> None:
+        """Older LangChain adapters use response_metadata.token_usage with
+        prompt_tokens / completion_tokens — converter must rename keys.
+        """
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="Legacy adapter response",
+            response_metadata={
+                "token_usage": {
+                    "prompt_tokens": 200,
+                    "completion_tokens": 75,
+                    "total_tokens": 275,
+                }
+            },
+        )
+
+        converter = DeepAgentsMessageConverter()
+        [out] = converter.from_provider([msg])
+
+        assert out.usage_metadata == {"input_tokens": 200, "output_tokens": 75}
+
+    def test_no_usage_yields_none(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(content="no usage")
+
+        converter = DeepAgentsMessageConverter()
+        [out] = converter.from_provider([msg])
+
+        assert out.usage_metadata is None
+        assert "usage_metadata" not in out.to_dict()
+
+    def test_modern_usage_metadata_wins_over_response_metadata(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="both",
+            usage_metadata={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+            response_metadata={
+                "token_usage": {"prompt_tokens": 999, "completion_tokens": 888}
+            },
+        )
+
+        converter = DeepAgentsMessageConverter()
+        [out] = converter.from_provider([msg])
+
+        # The modern usage_metadata path is preferred per _extract_ai_usage_metadata.
+        assert out.usage_metadata == {"input_tokens": 10, "output_tokens": 5}

--- a/tests/unit/adapters/langchain_deep_agents/test_trace_includes_usage.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_trace_includes_usage.py
@@ -1,0 +1,170 @@
+"""Tests that deep_agents_messages_to_trace_messages preserves per-call usage.
+
+Fix E (karenina infrastructure plan): the DA structured trace converter must
+propagate the per-message ``usage_metadata`` that LangChain AIMessages carry
+(or fall back to ``response_metadata.token_usage`` for adapters that haven't
+adopted the modern usage_metadata standard) so that per-turn token /
+cache accounting survives into ``template.trace_messages``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _to_trace(messages):
+    from karenina.adapters.langchain_deep_agents.trace import (
+        deep_agents_messages_to_trace_messages,
+    )
+
+    return deep_agents_messages_to_trace_messages(messages)
+
+
+@pytest.mark.unit
+class TestTraceUsageMetadataDA:
+    def test_ai_message_with_modern_usage_metadata_propagates(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="Hello world",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            },
+        )
+
+        trace = _to_trace([msg])
+        assert len(trace) == 1
+        assert trace[0]["role"] == "assistant"
+        assert trace[0]["content"] == "Hello world"
+        assert trace[0]["usage_metadata"] == {
+            "input_tokens": 100,
+            "output_tokens": 50,
+        }
+
+    def test_ai_message_with_response_metadata_token_usage_is_renamed(self) -> None:
+        """Older LangChain adapters expose token counts via
+        ``response_metadata.token_usage`` using OpenAI-style keys
+        (prompt_tokens / completion_tokens). The converter must rename
+        those keys to input_tokens / output_tokens so downstream consumers
+        see a uniform shape.
+        """
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="From an older provider",
+            response_metadata={
+                "token_usage": {
+                    "prompt_tokens": 80,
+                    "completion_tokens": 20,
+                }
+            },
+        )
+
+        trace = _to_trace([msg])
+        assert trace[0]["usage_metadata"] == {
+            "input_tokens": 80,
+            "output_tokens": 20,
+        }
+
+    def test_ai_message_usage_metadata_preferred_over_response_metadata(self) -> None:
+        """When both are present, usage_metadata wins (it's the modern source)."""
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="x",
+            usage_metadata={
+                "input_tokens": 5,
+                "output_tokens": 7,
+                "total_tokens": 12,
+            },
+            response_metadata={
+                "token_usage": {"prompt_tokens": 999, "completion_tokens": 999}
+            },
+        )
+
+        trace = _to_trace([msg])
+        assert trace[0]["usage_metadata"] == {
+            "input_tokens": 5,
+            "output_tokens": 7,
+        }
+
+    def test_ai_message_without_any_usage_omits_usage_metadata(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(content="no usage info")
+        trace = _to_trace([msg])
+
+        assert len(trace) == 1
+        assert "usage_metadata" not in trace[0]
+
+    def test_cache_fields_in_usage_metadata_propagate(self) -> None:
+        """If the prompt-cache middleware exposes Anthropic-shaped cache
+        fields via AIMessage.usage_metadata, they survive into the trace.
+        """
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="cached",
+            usage_metadata={
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "total_tokens": 15,
+                "cache_read_input_tokens": 200,
+                "cache_creation_input_tokens": 25,
+            },
+        )
+
+        trace = _to_trace([msg])
+        assert trace[0]["usage_metadata"] == {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cache_read_input_tokens": 200,
+            "cache_creation_input_tokens": 25,
+        }
+
+    def test_tool_call_message_emits_assistant_with_tool_calls_and_usage(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="Searching",
+            tool_calls=[{"id": "call_1", "name": "search", "args": {"q": "BCL2"}}],
+            usage_metadata={
+                "input_tokens": 30,
+                "output_tokens": 6,
+                "total_tokens": 36,
+            },
+        )
+
+        trace = _to_trace([msg])
+        assert trace[0]["role"] == "assistant"
+        assert trace[0]["tool_calls"] == [
+            {"id": "call_1", "name": "search", "input": {"q": "BCL2"}}
+        ]
+        assert trace[0]["usage_metadata"] == {"input_tokens": 30, "output_tokens": 6}
+
+    def test_tool_message_does_not_get_usage_metadata(self) -> None:
+        from langchain_core.messages import AIMessage, ToolMessage
+
+        messages = [
+            AIMessage(
+                content="step",
+                tool_calls=[{"id": "c1", "name": "s", "args": {}}],
+                usage_metadata={
+                    "input_tokens": 1,
+                    "output_tokens": 1,
+                    "total_tokens": 2,
+                },
+            ),
+            ToolMessage(content="result", tool_call_id="c1"),
+        ]
+
+        trace = _to_trace(messages)
+        # Find tool entry
+        tool_entries = [t for t in trace if t["role"] == "tool"]
+        assert len(tool_entries) == 1
+        assert "usage_metadata" not in tool_entries[0]
+
+    def test_empty_messages_returns_empty_list(self) -> None:
+        assert _to_trace([]) == []

--- a/tests/unit/ports/test_message_to_dict_usage.py
+++ b/tests/unit/ports/test_message_to_dict_usage.py
@@ -1,0 +1,73 @@
+"""Tests that Message.to_dict() emits the usage_metadata field when set.
+
+Fix E (extension): the unified ``Message`` carries an optional
+``usage_metadata`` dict so that per-call token / cache accounting is
+preserved end-to-end into ``template.trace_messages[*]``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.ports import Message, Role, TextContent
+
+
+@pytest.mark.unit
+class TestMessageToDictUsageMetadata:
+    def test_to_dict_emits_usage_metadata_when_set(self) -> None:
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[TextContent(text="42")],
+            usage_metadata={"input_tokens": 100, "output_tokens": 20},
+        )
+
+        out = msg.to_dict()
+
+        assert out["role"] == "assistant"
+        assert out["content"] == "42"
+        assert out["usage_metadata"] == {"input_tokens": 100, "output_tokens": 20}
+
+    def test_to_dict_omits_usage_metadata_when_none(self) -> None:
+        msg = Message(role=Role.ASSISTANT, content=[TextContent(text="hi")])
+
+        out = msg.to_dict()
+
+        assert "usage_metadata" not in out
+
+    def test_to_dict_emits_usage_metadata_with_cache_fields(self) -> None:
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[TextContent(text="cached")],
+            usage_metadata={
+                "input_tokens": 50,
+                "output_tokens": 10,
+                "cache_read_input_tokens": 800,
+                "cache_creation_input_tokens": 0,
+            },
+        )
+
+        out = msg.to_dict()
+
+        assert out["usage_metadata"] == {
+            "input_tokens": 50,
+            "output_tokens": 10,
+            "cache_read_input_tokens": 800,
+            "cache_creation_input_tokens": 0,
+        }
+
+    def test_to_dict_emits_empty_usage_metadata_dict(self) -> None:
+        """An explicit empty dict is distinct from None and should be emitted."""
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[TextContent(text="weird")],
+            usage_metadata={},
+        )
+
+        out = msg.to_dict()
+
+        # Explicit empty dict is still 'set' (not None) → emit it.
+        assert out["usage_metadata"] == {}
+
+    def test_default_usage_metadata_is_none(self) -> None:
+        msg = Message.assistant("hi")
+        assert msg.usage_metadata is None

--- a/tests/unit/ports/test_message_to_dict_usage.py
+++ b/tests/unit/ports/test_message_to_dict_usage.py
@@ -71,3 +71,24 @@ class TestMessageToDictUsageMetadata:
     def test_default_usage_metadata_is_none(self) -> None:
         msg = Message.assistant("hi")
         assert msg.usage_metadata is None
+
+    def test_from_dict_preserves_usage_metadata(self) -> None:
+        data = {
+            "role": "assistant",
+            "content": "cached answer",
+            "block_index": 0,
+            "usage_metadata": {
+                "input_tokens": 50,
+                "output_tokens": 10,
+                "cache_read_input_tokens": 800,
+            },
+        }
+
+        msg = Message.from_dict(data)
+
+        assert msg.usage_metadata == {
+            "input_tokens": 50,
+            "output_tokens": 10,
+            "cache_read_input_tokens": 800,
+        }
+        assert msg.to_dict()["usage_metadata"] == data["usage_metadata"]


### PR DESCRIPTION
## Problem

Only aggregate token usage is preserved in result JSONs (`template.usage_metadata.answer_generation.*`). Individual entries in `template.trace_messages[*]` carry no `usage_metadata`. Post-hoc audit of per-turn token usage, cache hits, or per-call cost is impossible from saved results.

The SDK / LangChain do surface per-call usage on each assistant message (`AssistantMessage.usage` for Claude SDK; `AIMessage.usage_metadata` or `response_metadata.token_usage` for LangChain), but the converters strip it during conversion to the unified `Message` type.

## Change

Four commits, structured incrementally:

1. **Helpers in trace converters** (`adapters/claude_agent_sdk/trace.py`, new `adapters/langchain_deep_agents/trace.py`) — direct-to-dict `*_to_trace_messages` functions now attach `usage_metadata` when present. Useful for callers that bypass `Message`.

2. **`Message.usage_metadata` field** (`ports/messages.py`) — adds an optional `dict[str, Any] | None = None` field. `Message.to_dict()` emits the key only when not None.

3. **CSDK `from_provider` populates it** (`adapters/claude_agent_sdk/messages.py`) — `_extract_assistant_usage` helper builds the per-call dict from `AssistantMessage.usage`; constructs `Message(..., usage_metadata=...)`.

4. **DA `from_provider` populates it** (`adapters/langchain_deep_agents/messages.py`) — reuses `_extract_ai_usage_metadata` from `trace.py` (prefers `AIMessage.usage_metadata`, falls back to `response_metadata.token_usage` with key rename `prompt_tokens` → `input_tokens` etc.); assigns onto the converted `Message`.

The schema of the emitted dict is `{input_tokens, output_tokens, [cache_read_input_tokens, cache_creation_input_tokens]}` — cache fields are present only when the source data carries them (distinguishes "not reported" from "zero").

The production path is `agent.arun() → converter.from_provider() → list[Message] → Message.to_dict() → JSON`, so populating the `Message` field is what actually surfaces the data in the result file.

## Tests

- `tests/unit/adapters/claude_sdk/test_trace_includes_usage.py` (5 tests) — direct-to-dict helper
- `tests/unit/adapters/langchain_deep_agents/test_trace_includes_usage.py` (8 tests) — direct-to-dict helper, both modern + legacy LangChain shapes
- `tests/unit/ports/test_message_to_dict_usage.py` (5 tests) — Message field and to_dict emission
- `tests/unit/adapters/claude_sdk/test_message_converter_usage.py` (6 tests) — end-to-end CSDK converter
- `tests/unit/adapters/langchain_deep_agents/test_message_converter_usage.py` (6 tests) — end-to-end DA converter, including the `response_metadata.token_usage` fallback path

30 / 30 pass in the targeted suite. Full suite (`tests/`) shows 9 pre-existing failures unrelated to this change (verified on the branch base).

## Test plan

- [ ] `uv run pytest tests/unit/adapters tests/unit/ports -v`
- [ ] Run a real BixBench replicate and verify each assistant entry in `template.trace_messages` carries `usage_metadata` with sane per-turn counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)