### PR TITLE
Represent null-extracted fields with None to avoid whole-record failure

### DIFF
--- a/src/karenina/benchmark/verification/evaluators/template/evaluator.py
+++ b/src/karenina/benchmark/verification/evaluators/template/evaluator.py
@@ -17,7 +17,11 @@ from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
 from karenina.benchmark.verification.prompts.parsing.parsing_instructions import TemplatePromptBuilder
 from karenina.benchmark.verification.utils import prepare_evaluation_input
-from karenina.benchmark.verification.utils.schema_builder import build_parsing_schema
+from karenina.benchmark.verification.utils.schema_builder import (
+    build_extraction_relaxed_class,
+    build_parsing_schema,
+    rebuild_strict_answer_with_null_fields,
+)
 from karenina.ports import LLMPort
 from karenina.schemas.config import ModelConfig
 from karenina.schemas.entities import BaseAnswer
@@ -311,9 +315,16 @@ class TemplateEvaluator:
                 },
             )
 
-            # 3. Parse via adapter (returns ParsePortResult with usage)
-            parse_port_result = self._parser.parse_to_pydantic(messages, self.answer_class)
-            parsed = parse_port_result.parsed
+            # 3. Parse via adapter (returns ParsePortResult with usage).
+            # Use a relaxed extraction class so a null verified field does not
+            # reject the whole record. The strict Answer instance tracks those
+            # fields via _null_fields for tri-valued field_results.
+            extraction_class = build_extraction_relaxed_class(self.answer_class)
+            parse_port_result = self._parser.parse_to_pydantic(messages, extraction_class)
+            parsed = rebuild_strict_answer_with_null_fields(
+                self.answer_class,
+                parse_port_result.parsed,
+            )
 
             if isinstance(parsed, self.answer_class):
                 result.parsed_answer = parsed

--- a/src/karenina/benchmark/verification/stages/pipeline/agentic_parse_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/agentic_parse_template.py
@@ -13,7 +13,11 @@ from karenina.adapters import get_agent, get_parser
 from karenina.adapters.agent_runtime import workspace_path_for_prompt
 from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
-from karenina.benchmark.verification.utils.schema_builder import build_parsing_schema
+from karenina.benchmark.verification.utils.schema_builder import (
+    build_extraction_relaxed_class,
+    build_parsing_schema,
+    rebuild_strict_answer_with_null_fields,
+)
 from karenina.ports import AgentConfig, UsageMetadata
 from karenina.schemas.entities.answer import BaseAnswer
 from karenina.schemas.verification.model_identity import ModelIdentity
@@ -301,8 +305,22 @@ class AgenticParseTemplateStage(BaseVerificationStage):
         )
 
         try:
-            parse_result = parser.parse_to_pydantic(messages, answer_class)
-            return parse_result.parsed, parse_result.usage
+            # Parse against a relaxed sibling class where each VerifiedField is
+            # Optional[T] = None. This lets the LLM return null for individual
+            # sub-questions ("couldn't compute X") without the whole record
+            # failing pydantic validation. After parsing, we reconstruct the
+            # strict template via model_construct (skipping null fields) and
+            # carry the set of null fields as private metadata so downstream
+            # verification reports them as None rather than False, preventing
+            # accidental matches against a False ground truth.
+            extraction_class = build_extraction_relaxed_class(answer_class)
+            parse_result = parser.parse_to_pydantic(messages, extraction_class)
+            strict_instance = rebuild_strict_answer_with_null_fields(
+                answer_class,
+                parse_result.parsed,
+            )
+
+            return strict_instance, parse_result.usage
         finally:
             close_adapter(parser)
 

--- a/src/karenina/benchmark/verification/utils/schema_builder.py
+++ b/src/karenina/benchmark/verification/utils/schema_builder.py
@@ -3,10 +3,19 @@
 Two filtering operations:
 1. Remove trace fields (judge should not parse these)
 2. Strip __verification__ metadata (judge must not see ground truth)
+
+Also exposes ``build_extraction_relaxed_class`` which produces a sibling
+Pydantic model with every VerifiedField coerced to ``Optional[T] = None``.
+This relaxed class is used at agentic-extraction time so that a single
+null field from the LLM does not reject the entire record. The caller
+recombines null-valued fields into the strict template afterwards via
+``BaseAnswer.model_construct`` plus a private ``_null_fields`` set.
 """
 
 import logging
 from typing import Any
+
+from pydantic import create_model
 
 from karenina.schemas.entities.answer import BaseAnswer
 
@@ -59,3 +68,67 @@ def build_parsing_schema(answer_class: type[BaseAnswer]) -> dict[str, Any]:
                 _strip_properties(def_schema["properties"])
 
     return schema
+
+
+def build_extraction_relaxed_class(answer_class: type[BaseAnswer]) -> type[BaseAnswer]:
+    """Build a sibling Pydantic class with VerifiedFields relaxed to Optional.
+
+    Each VerifiedField on ``answer_class`` is rewritten as ``Optional[T] = None``
+    so that the agentic parser accepts ``null`` for any single field without
+    failing the whole record. The relaxed class is used only at extraction
+    time; downstream verification then reconstructs the strict template and
+    tracks which fields came back null via a private ``_null_fields`` set.
+
+    Non-VerifiedField fields (e.g. ``id``) and unverified plain fields are
+    preserved as-is; only fields that carry ``__verification__`` metadata are
+    loosened, because only those participate in scoring.
+
+    Args:
+        answer_class: The strict template class to derive from.
+
+    Returns:
+        A new Pydantic ``BaseAnswer`` subclass with relaxed field types.
+    """
+    relaxed_fields: dict[str, Any] = {}
+    for name, field_info in answer_class.model_fields.items():
+        extra = field_info.json_schema_extra
+        is_verified = isinstance(extra, dict) and "__verification__" in extra
+
+        if not is_verified:
+            # Preserve non-verified fields verbatim
+            relaxed_fields[name] = (field_info.annotation, field_info)
+            continue
+
+        # Coerce the annotation to Optional[T] with default None.
+        annotation = field_info.annotation or Any
+        relaxed_annotation = annotation | None
+        relaxed_fields[name] = (relaxed_annotation, None)
+
+    relaxed_cls = create_model(
+        f"{answer_class.__name__}__Relaxed",
+        __base__=BaseAnswer,
+        **relaxed_fields,
+    )
+    return relaxed_cls
+
+
+def rebuild_strict_answer_with_null_fields(
+    answer_class: type[BaseAnswer],
+    relaxed_instance: Any,
+) -> BaseAnswer:
+    """Rebuild a strict Answer while preserving null verified fields.
+
+    Parser adapters receive the relaxed class from
+    ``build_extraction_relaxed_class``. This helper converts the parsed relaxed
+    instance back to the original strict answer class, omitting null field
+    values and storing the names of verified null fields on ``_null_fields``.
+    ``BaseAnswer._compute_field_results`` consumes that marker and reports
+    those fields as ``None`` instead of conflating them with ``False``.
+    """
+    extracted_dict = relaxed_instance.model_dump()
+    verified_names = set(answer_class._get_verified_fields().keys())
+    null_fields = {name for name, value in extracted_dict.items() if value is None and name in verified_names}
+    strict_payload = {name: value for name, value in extracted_dict.items() if value is not None}
+    strict_instance = answer_class.model_construct(**strict_payload)
+    strict_instance.__dict__["_null_fields"] = null_fields
+    return strict_instance

--- a/src/karenina/schemas/entities/answer.py
+++ b/src/karenina/schemas/entities/answer.py
@@ -249,7 +249,7 @@ class BaseAnswer(BaseModel):
         self.__dict__.pop("_field_results", None)
         self.__dict__.pop("_resolved_ground_truths", None)
 
-    def _compute_field_results(self) -> dict[str, bool]:
+    def _compute_field_results(self) -> dict[str, bool | None]:
         """Evaluate all VerifiedField checks and cache in _field_results.
 
         Results are cached in self.__dict__["_field_results"] after the first
@@ -265,22 +265,31 @@ class BaseAnswer(BaseModel):
         check_trace() result against bool(meta.ground_truth). For parsed
         fields, calls primitive.check(extracted, ground_truth).
 
+        Tri-valued results:
+            - True: field extracted and matches ground truth.
+            - False: field extracted and does NOT match ground truth.
+            - None: field returned null by the extractor (i.e., the field
+              name is present in ``self._null_fields``). This is kept
+              distinct from False so a null extraction cannot silently match
+              a False ground truth. Populated by the agentic-parse stage.
+
         Returns:
-            Mapping of field name to pass/fail boolean.
+            Mapping of field name to True / False / None.
 
         Raises:
             ValueError: If a trace field is used but _raw_trace is not set.
         """
         cached = self.__dict__.get("_field_results")
         if cached is not None:
-            return cast(dict[str, bool], cached)
+            return cast(dict[str, bool | None], cached)
 
         from karenina.schemas.entities.conditional import _resolve_conditional
         from karenina.schemas.primitives import TracePrimitive
         from karenina.schemas.primitives.registry import _reconstruct_primitive
 
         verified = self.__class__._get_verified_fields()
-        results: dict[str, bool] = {}
+        null_fields: set[str] = self.__dict__.get("_null_fields") or set()
+        results: dict[str, bool | None] = {}
         resolved_gts: dict[str, Any] = {}
 
         for name, meta in verified.items():
@@ -297,6 +306,12 @@ class BaseAnswer(BaseModel):
 
             resolved_gts[name] = ground_truth
 
+            # If the extractor returned null for this field, surface None so
+            # downstream scoring can distinguish "not answered" from "False".
+            if name in null_fields:
+                results[name] = None
+                continue
+
             if isinstance(primitive, TracePrimitive):
                 raw_trace = getattr(self, "_raw_trace", None)
                 if raw_trace is None:
@@ -304,7 +319,7 @@ class BaseAnswer(BaseModel):
                 trace_result = primitive.check_trace(raw_trace)
                 results[name] = trace_result == bool(ground_truth)
             else:
-                extracted = getattr(self, name)
+                extracted = getattr(self, name, None)
                 results[name] = primitive.check(extracted, ground_truth)
 
         self.__dict__["_field_results"] = results
@@ -356,7 +371,10 @@ class BaseAnswer(BaseModel):
             if strategy is not None:
                 return evaluate_strategy(strategy, field_results)
 
-        return all(field_results.values())
+        # Tri-valued results: only True counts as pass. None (null extraction)
+        # is treated as not-satisfied here, but remains distinguishable from
+        # False in the cached field_results dict.
+        return all(v is True for v in field_results.values())
 
     def _auto_verify_granular(self) -> float:
         """Auto-generated verify_granular() for VerifiedField templates.
@@ -389,12 +407,16 @@ class BaseAnswer(BaseModel):
         if strategy is not None:
             return self._composition_aware_granular(strategy, field_results, verified)
 
-        # Default AllOf behavior: flat weighted average
+        # Default AllOf behavior: flat weighted average.
+        # None (null extraction) is treated as not-satisfied here: it does NOT
+        # contribute to weighted_sum but still counts toward total_weight, so
+        # the score is n_true / n_total, distinguishing nulls from False only
+        # in field_results, not in the granular score.
         total_weight = 0.0
         weighted_sum = 0.0
         for name, meta in verified.items():
             total_weight += meta.weight
-            if field_results.get(name, False):
+            if field_results.get(name) is True:
                 weighted_sum += meta.weight
 
         if total_weight == 0.0:
@@ -404,14 +426,16 @@ class BaseAnswer(BaseModel):
     @staticmethod
     def _composition_aware_granular(
         strategy: Any,
-        field_results: dict[str, bool],
+        field_results: dict[str, bool | None],
         verified: dict[str, Any],
     ) -> float:
         """Compute granular score honoring composition strategy.
 
         Args:
             strategy: Composition strategy node (AllOf, AnyOf, AtLeastN).
-            field_results: Per-field pass/fail booleans.
+            field_results: Per-field tri-valued result (True / False / None).
+                None denotes a null extraction; treated as not-satisfied
+                here but distinguishable from False in field_results.
             verified: Per-field VerificationMeta (for weights).
 
         Returns:
@@ -424,7 +448,7 @@ class BaseAnswer(BaseModel):
             return 0.0
 
         passing_weights: list[float] = sorted(
-            [verified[name].weight for name, passed in field_results.items() if passed],
+            [verified[name].weight for name, passed in field_results.items() if passed is True],
             reverse=True,
         )
 

--- a/src/karenina/schemas/entities/composition.py
+++ b/src/karenina/schemas/entities/composition.py
@@ -77,15 +77,24 @@ AnyOf.model_rebuild()
 AtLeastN.model_rebuild()
 
 
-def evaluate_strategy(node: StrategyNode, field_results: dict[str, bool]) -> bool:
+def evaluate_strategy(node: StrategyNode, field_results: dict[str, bool | None]) -> bool:
     """Evaluate a composition strategy tree against field results.
 
     Thin wrapper around ``evaluate_composition()`` that supplies the
     FieldCheck leaf evaluator for the template domain.
 
+    The leaf evaluator returns True only when ``field_results[leaf.field]``
+    is exactly ``True``. ``None`` (null extraction) is treated as
+    not-satisfied at composition time, equivalent to soft-False, so
+    AllOf / AnyOf / AtLeastN behave conservatively when a sub-field is
+    unanswered. Distinguishing None from False is preserved in
+    ``field_results`` for downstream consumers (granular scoring,
+    serialized result rows).
+
     Args:
         node: The root node of the strategy tree.
-        field_results: Mapping of field names to their pass/fail results.
+        field_results: Mapping of field names to their tri-valued result
+            (True / False / None).
 
     Returns:
         True if the strategy passes.
@@ -95,6 +104,6 @@ def evaluate_strategy(node: StrategyNode, field_results: dict[str, bool]) -> boo
     """
 
     def _field_check_evaluator(leaf: FieldCheck) -> bool:
-        return field_results[leaf.field]
+        return field_results[leaf.field] is True
 
     return evaluate_composition(node, _field_check_evaluator)

--- a/src/karenina/schemas/verification/result_components.py
+++ b/src/karenina/schemas/verification/result_components.py
@@ -144,7 +144,11 @@ class VerificationResultTemplate(BaseModel):
     )  # Template verification result (None if template verification skipped)
     verify_granular_result: Any | None = None
     field_verification_error: str | None = None  # Error from verify() exception (issue 146)
-    field_results: dict[str, bool] | None = None  # Per-field primitive verification results (issue 150)
+    # Per-field primitive verification results (issue 150). Values are
+    # tri-valued: True (pass), False (fail), or None (extractor returned
+    # null for that field, kept distinct from False so a null cannot
+    # silently match a False ground truth).
+    field_results: dict[str, bool | None] | None = None
     composition_strategy: str | None = (
         None  # Composition strategy used: "all_of", "any_of", "at_least_n(N)" (issue 151)
     )

--- a/tests/unit/benchmark/verification/stages/test_agentic_parse_template.py
+++ b/tests/unit/benchmark/verification/stages/test_agentic_parse_template.py
@@ -138,8 +138,12 @@ class TestAgenticParseTemplateStage:
         # Parser was called
         mock_parser.parse_to_pydantic.assert_called_once()
 
-        # Results stored
-        assert ctx.get_artifact(ArtifactKeys.PARSED_ANSWER) is parsed_answer
+        # Results stored. After Fix C the stage rebuilds the strict answer
+        # via model_construct, so identity is no longer preserved; match
+        # by class + field values instead.
+        stored = ctx.get_artifact(ArtifactKeys.PARSED_ANSWER)
+        assert isinstance(stored, MockAnswer)
+        assert stored.test_field is True
         assert ctx.get_artifact(ArtifactKeys.AGENTIC_PARSING_PERFORMED) is True
         assert ctx.get_artifact(ArtifactKeys.INVESTIGATION_TRACE) == "investigation trace"
 

--- a/tests/unit/benchmark/verification/stages/test_agentic_parse_template_optional_fields.py
+++ b/tests/unit/benchmark/verification/stages/test_agentic_parse_template_optional_fields.py
@@ -1,0 +1,200 @@
+"""Fix C: agentic-parse-template tolerates null sub-question extractions.
+
+The agentic parser passes a relaxed sibling schema (every VerifiedField
+becomes Optional[T] = None) to the LLM-side parser. Fields the LLM
+returns as ``null`` are stored on the strict template via
+``_null_fields``, so ``_compute_field_results`` reports them as ``None``
+rather than False, preserving partial credit on the other fields.
+
+Two regressions guarded here:
+
+1. With a 3-field template and ``q2`` returned as null, q1 and q3 are
+   scored normally and field_results["q2"] is exactly ``None``.
+
+2. **Critical**: when ground truth for a boolean is ``False`` and the
+   model returned ``None``, field_results["q2"] MUST stay ``None``
+   (not become ``False``). Scoring it as False would silently look
+   correct against the False ground truth. The bug Fix C exists to
+   prevent.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import (
+    ArtifactKeys,
+    VerificationContext,
+)
+from karenina.schemas.config.models import ModelConfig
+from karenina.schemas.entities.answer import BaseAnswer
+from karenina.schemas.entities.verified_field import VerifiedField
+from karenina.schemas.primitives import BooleanMatch, NumericTolerance
+
+
+class ThreeFieldAnswer(BaseAnswer):
+    """Three-field template; one bool, two floats. Mirrors BixBench shape."""
+
+    q1: float = VerifiedField(
+        description="First sub-answer.",
+        ground_truth=1.5,
+        verify_with=NumericTolerance(tolerance=0.1),
+    )
+    q2: bool = VerifiedField(
+        description="Second sub-answer.",
+        ground_truth=True,
+        verify_with=BooleanMatch(),
+    )
+    q3: float = VerifiedField(
+        description="Third sub-answer.",
+        ground_truth=2.0,
+        verify_with=NumericTolerance(tolerance=0.1),
+    )
+
+
+class FalseGTAnswer(BaseAnswer):
+    """Boolean with ground truth = False. Used for the critical regression."""
+
+    q2: bool = VerifiedField(
+        description="Did X happen?",
+        ground_truth=False,
+        verify_with=BooleanMatch(),
+    )
+
+
+def _make_context(answer_cls: type[BaseAnswer]) -> VerificationContext:
+    """Minimal VerificationContext for agentic-parse stage tests."""
+    ctx = VerificationContext(
+        question_id="q1",
+        template_id="t1",
+        question_text="Compute stuff.",
+        template_code=f"class {answer_cls.__name__}(BaseAnswer): ...",
+        answering_model=ModelConfig(id="test", model_name="test-model", interface="claude_agent_sdk"),
+        parsing_model=ModelConfig(id="test", model_name="test-model", interface="claude_agent_sdk"),
+        agentic_parsing=True,
+        agentic_judge_context="workspace_only",
+        workspace_path=Path("/tmp/test_workspace"),
+    )
+    ctx.set_artifact(ArtifactKeys.RAW_ANSWER, answer_cls)
+    ctx.set_artifact(ArtifactKeys.ANSWER, answer_cls)
+    ctx.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "raw trace")
+    return ctx
+
+
+@pytest.mark.unit
+class TestAgenticParseOptionalFields:
+    """Null extractions surface as None in field_results, not False."""
+
+    @patch("karenina.benchmark.verification.stages.pipeline.agentic_parse_template.get_agent")
+    @patch("karenina.benchmark.verification.stages.pipeline.agentic_parse_template.get_parser")
+    def test_null_field_does_not_fail_whole_record(self, mock_get_parser, mock_get_agent):
+        """q1 + q3 score normally; q2 (null in extraction) is None."""
+        from karenina.benchmark.verification.stages.pipeline.agentic_parse_template import (
+            AgenticParseTemplateStage,
+        )
+        from karenina.benchmark.verification.utils.schema_builder import (
+            build_extraction_relaxed_class,
+        )
+        from karenina.ports import AgentResult, ParsePortResult, UsageMetadata
+
+        mock_agent = MagicMock()
+        mock_agent.run.return_value = AgentResult(
+            final_response="ok",
+            raw_trace="investigation trace",
+            trace_messages=[],
+            usage=UsageMetadata(),
+            turns=2,
+            limit_reached=False,
+        )
+        mock_get_agent.return_value = mock_agent
+
+        # Parser returns a *relaxed* instance with q2=None; the production
+        # code path calls build_extraction_relaxed_class(answer_class) and
+        # passes that to parse_to_pydantic, so we build the same class here.
+        relaxed_cls = build_extraction_relaxed_class(ThreeFieldAnswer)
+        relaxed_instance = relaxed_cls(q1=1.5, q2=None, q3=2.0)
+
+        mock_parser = MagicMock()
+        mock_parser.parse_to_pydantic.return_value = ParsePortResult(
+            parsed=relaxed_instance,
+            usage=UsageMetadata(),
+        )
+        mock_get_parser.return_value = mock_parser
+
+        ctx = _make_context(ThreeFieldAnswer)
+        AgenticParseTemplateStage().execute(ctx)
+
+        assert ctx.error is None, ctx.error
+        stored = ctx.get_artifact(ArtifactKeys.PARSED_ANSWER)
+        assert isinstance(stored, ThreeFieldAnswer)
+        # q2 was nulled, so it is present in _null_fields.
+        assert stored.__dict__.get("_null_fields") == {"q2"}
+
+        # Tri-valued field_results: q1 True, q2 None, q3 True
+        field_results = stored._compute_field_results()
+        assert field_results["q1"] is True
+        assert field_results["q2"] is None
+        assert field_results["q3"] is True
+
+        # AllOf default: any non-True (including None) makes verify() False.
+        assert stored.verify() is False
+        # Granular: n_true / n_total = 2 / 3
+        assert stored.verify_granular() == pytest.approx(2 / 3)
+
+    @patch("karenina.benchmark.verification.stages.pipeline.agentic_parse_template.get_agent")
+    @patch("karenina.benchmark.verification.stages.pipeline.agentic_parse_template.get_parser")
+    def test_null_extraction_with_false_ground_truth_stays_none(self, mock_get_parser, mock_get_agent):
+        """CRITICAL: GT=False + extracted=None MUST yield None, not False.
+
+        Without Fix C, a null extraction could be silently scored as False
+        and "accidentally match" a False ground truth. The user called this
+        out explicitly. It is the load-bearing regression test for the
+        whole tri-valued design.
+        """
+        from karenina.benchmark.verification.stages.pipeline.agentic_parse_template import (
+            AgenticParseTemplateStage,
+        )
+        from karenina.benchmark.verification.utils.schema_builder import (
+            build_extraction_relaxed_class,
+        )
+        from karenina.ports import AgentResult, ParsePortResult, UsageMetadata
+
+        mock_agent = MagicMock()
+        mock_agent.run.return_value = AgentResult(
+            final_response="ok",
+            raw_trace="investigation trace",
+            trace_messages=[],
+            usage=UsageMetadata(),
+            turns=2,
+            limit_reached=False,
+        )
+        mock_get_agent.return_value = mock_agent
+
+        relaxed_cls = build_extraction_relaxed_class(FalseGTAnswer)
+        relaxed_instance = relaxed_cls(q2=None)
+
+        mock_parser = MagicMock()
+        mock_parser.parse_to_pydantic.return_value = ParsePortResult(
+            parsed=relaxed_instance,
+            usage=UsageMetadata(),
+        )
+        mock_get_parser.return_value = mock_parser
+
+        ctx = _make_context(FalseGTAnswer)
+        AgenticParseTemplateStage().execute(ctx)
+
+        assert ctx.error is None, ctx.error
+        stored = ctx.get_artifact(ArtifactKeys.PARSED_ANSWER)
+        field_results = stored._compute_field_results()
+
+        # The bug Fix C prevents: BooleanMatch(None, False) might return True
+        # (silently treating a null extraction as a False match). The
+        # tri-valued contract says field_results[q2] is None, not False/True.
+        assert field_results["q2"] is None, f"q2 with null extraction must be None, got {field_results['q2']!r}"
+        # Strict identity to rule out tricky truthiness bugs
+        assert field_results["q2"] is not False
+        assert field_results["q2"] is not True
+
+        # verify() rejects None at the leaf (soft-False)
+        assert stored.verify() is False

--- a/tests/unit/benchmark/verification/stages/test_parse_template_optional_fields.py
+++ b/tests/unit/benchmark/verification/stages/test_parse_template_optional_fields.py
@@ -1,0 +1,146 @@
+"""Classical template parsing tolerates null sub-question extractions."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import (
+    ArtifactKeys,
+    VerificationContext,
+)
+from karenina.benchmark.verification.stages.pipeline.parse_template import (
+    ParseTemplateStage,
+)
+from karenina.ports import ParsePortResult, UsageMetadata
+from karenina.ports.capabilities import PortCapabilities
+from karenina.schemas.config.models import ModelConfig
+from karenina.schemas.entities.answer import BaseAnswer
+from karenina.schemas.entities.verified_field import VerifiedField
+from karenina.schemas.primitives import BooleanMatch, NumericTolerance
+
+
+class ThreeFieldClassicalAnswer(BaseAnswer):
+    """Three-field template mirroring grouped QA sub-question scoring."""
+
+    q1: float = VerifiedField(
+        description="First sub-answer.",
+        ground_truth=1.5,
+        verify_with=NumericTolerance(tolerance=0.1),
+    )
+    q2: bool = VerifiedField(
+        description="Second sub-answer.",
+        ground_truth=True,
+        verify_with=BooleanMatch(),
+    )
+    q3: float = VerifiedField(
+        description="Third sub-answer.",
+        ground_truth=2.0,
+        verify_with=NumericTolerance(tolerance=0.1),
+    )
+
+
+class FalseGTClassicalAnswer(BaseAnswer):
+    """Boolean with ground truth False for null-vs-False regression coverage."""
+
+    q2: bool = VerifiedField(
+        description="Did X happen?",
+        ground_truth=False,
+        verify_with=BooleanMatch(),
+    )
+
+
+def _make_context(answer_cls: type[BaseAnswer]) -> VerificationContext:
+    ctx = VerificationContext(
+        question_id="q1",
+        template_id="t1",
+        question_text="Compute stuff.",
+        template_code=f"class {answer_cls.__name__}(BaseAnswer): ...",
+        answering_model=ModelConfig(
+            id="test",
+            model_provider="openai",
+            model_name="test-model",
+            interface="langchain",
+        ),
+        parsing_model=ModelConfig(
+            id="test",
+            model_provider="openai",
+            model_name="test-model",
+            interface="langchain",
+        ),
+        use_full_trace_for_template=True,
+    )
+    ctx.set_artifact(ArtifactKeys.RAW_ANSWER, answer_cls)
+    ctx.set_artifact(ArtifactKeys.ANSWER, answer_cls)
+    ctx.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "Final answer text.")
+    return ctx
+
+
+@pytest.mark.unit
+class TestClassicalParseOptionalFields:
+    """Null extractions in classical parsing surface as None in field_results."""
+
+    @patch("karenina.benchmark.verification.evaluators.template.evaluator.get_llm")
+    @patch("karenina.benchmark.verification.evaluators.template.evaluator.get_parser")
+    def test_null_field_does_not_fail_whole_record(self, mock_get_parser, mock_get_llm):
+        mock_get_llm.return_value = MagicMock()
+
+        mock_parser = MagicMock()
+        mock_parser.capabilities = PortCapabilities(supports_structured_output=True)
+
+        def parse_to_pydantic(_messages, schema):
+            return ParsePortResult(
+                parsed=schema(q1=1.5, q2=None, q3=2.0),
+                usage=UsageMetadata(),
+            )
+
+        mock_parser.parse_to_pydantic.side_effect = parse_to_pydantic
+        mock_get_parser.return_value = mock_parser
+
+        ctx = _make_context(ThreeFieldClassicalAnswer)
+        ParseTemplateStage().execute(ctx)
+
+        assert ctx.error is None, ctx.error
+        parsed = ctx.get_artifact(ArtifactKeys.PARSED_ANSWER)
+        assert isinstance(parsed, ThreeFieldClassicalAnswer)
+        assert parsed.__dict__.get("_null_fields") == {"q2"}
+
+        field_results = parsed._compute_field_results()
+        assert field_results == {"q1": True, "q2": None, "q3": True}
+        assert parsed.verify() is False
+        assert parsed.verify_granular() == pytest.approx(2 / 3)
+
+        schema_used = mock_parser.parse_to_pydantic.call_args.args[1]
+        assert schema_used.__name__ == "ThreeFieldClassicalAnswer__Relaxed"
+
+    @patch("karenina.benchmark.verification.evaluators.template.evaluator.get_llm")
+    @patch("karenina.benchmark.verification.evaluators.template.evaluator.get_parser")
+    def test_null_extraction_with_false_ground_truth_stays_none(
+        self,
+        mock_get_parser,
+        mock_get_llm,
+    ):
+        mock_get_llm.return_value = MagicMock()
+
+        mock_parser = MagicMock()
+        mock_parser.capabilities = PortCapabilities(supports_structured_output=True)
+
+        def parse_to_pydantic(_messages, schema):
+            return ParsePortResult(
+                parsed=schema(q2=None),
+                usage=UsageMetadata(),
+            )
+
+        mock_parser.parse_to_pydantic.side_effect = parse_to_pydantic
+        mock_get_parser.return_value = mock_parser
+
+        ctx = _make_context(FalseGTClassicalAnswer)
+        ParseTemplateStage().execute(ctx)
+
+        assert ctx.error is None, ctx.error
+        parsed = ctx.get_artifact(ArtifactKeys.PARSED_ANSWER)
+        field_results = parsed._compute_field_results()
+
+        assert field_results["q2"] is None
+        assert field_results["q2"] is not False
+        assert field_results["q2"] is not True
+        assert parsed.verify() is False

--- a/tests/unit/schemas/test_composition_with_none_fields.py
+++ b/tests/unit/schemas/test_composition_with_none_fields.py
@@ -1,0 +1,188 @@
+"""Tests for composition strategy evaluation with tri-valued field results.
+
+After Fix C, ``field_results`` may contain ``None`` for fields the agentic
+parser returned as null. At composition time None behaves like a soft False
+(not-satisfied), but it must never be conflated with a real False. The
+distinction is preserved in the cached field_results dict for downstream
+consumers (granular scoring, serialized result rows, dataframe export).
+"""
+
+import pytest
+
+from karenina.schemas.entities.composition import (
+    AllOf,
+    AnyOf,
+    AtLeastN,
+    FieldCheck,
+    evaluate_strategy,
+)
+
+
+@pytest.mark.unit
+class TestFieldCheckWithNone:
+    """A leaf FieldCheck must return False when the field is None."""
+
+    def test_none_is_not_passing(self):
+        results = {"target": None}
+        assert evaluate_strategy(FieldCheck(field="target"), results) is False
+
+    def test_true_still_passes(self):
+        results = {"target": True}
+        assert evaluate_strategy(FieldCheck(field="target"), results) is True
+
+    def test_false_still_fails(self):
+        results = {"target": False}
+        assert evaluate_strategy(FieldCheck(field="target"), results) is False
+
+
+@pytest.mark.unit
+class TestAllOfWithNone:
+    """AllOf must reject when any leaf is None (soft-False)."""
+
+    def test_all_true_passes(self):
+        results = {"a": True, "b": True, "c": True}
+        strategy = AllOf(
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is True
+
+    def test_one_none_fails(self):
+        results = {"a": True, "b": None, "c": True}
+        strategy = AllOf(
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is False
+
+    def test_mix_true_false_none(self):
+        results = {"a": True, "b": False, "c": None}
+        strategy = AllOf(
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is False
+
+
+@pytest.mark.unit
+class TestAnyOfWithNone:
+    """AnyOf passes only when at least one leaf is exactly True."""
+
+    def test_one_true_among_nones_passes(self):
+        results = {"a": None, "b": True, "c": None}
+        strategy = AnyOf(
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is True
+
+    def test_all_none_fails(self):
+        results = {"a": None, "b": None, "c": None}
+        strategy = AnyOf(
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is False
+
+    def test_none_and_false_no_true_fails(self):
+        results = {"a": None, "b": False, "c": None}
+        strategy = AnyOf(
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is False
+
+
+@pytest.mark.unit
+class TestAtLeastNWithNone:
+    """AtLeastN counts only exactly-True leaves toward N."""
+
+    def test_two_trues_one_none_meets_n2(self):
+        results = {"a": True, "b": True, "c": None}
+        strategy = AtLeastN(
+            n=2,
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is True
+
+    def test_one_true_two_nones_fails_n2(self):
+        results = {"a": True, "b": None, "c": None}
+        strategy = AtLeastN(
+            n=2,
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is False
+
+    def test_n0_passes_even_with_all_none(self):
+        results = {"a": None, "b": None}
+        strategy = AtLeastN(
+            n=0,
+            conditions=[FieldCheck(field="a"), FieldCheck(field="b")],
+        )
+        assert evaluate_strategy(strategy, results) is True
+
+    def test_n_equals_passing_trues(self):
+        # 3 of 5 leaves True, the rest None and False: n=3 succeeds, n=4 fails.
+        results = {"a": True, "b": True, "c": True, "d": None, "e": False}
+        conditions = [
+            FieldCheck(field="a"),
+            FieldCheck(field="b"),
+            FieldCheck(field="c"),
+            FieldCheck(field="d"),
+            FieldCheck(field="e"),
+        ]
+        assert evaluate_strategy(AtLeastN(n=3, conditions=conditions), results) is True
+        assert evaluate_strategy(AtLeastN(n=4, conditions=conditions), results) is False
+
+
+@pytest.mark.unit
+class TestNestedCompositionWithNone:
+    """Nested compositions handle None at every level."""
+
+    def test_allof_of_anyof_with_none(self):
+        # AllOf( AnyOf(a,b), AnyOf(c,d) ) with a=True, b=None, c=None, d=True.
+        results = {"a": True, "b": None, "c": None, "d": True}
+        strategy = AllOf(
+            conditions=[
+                AnyOf(conditions=[FieldCheck(field="a"), FieldCheck(field="b")]),
+                AnyOf(conditions=[FieldCheck(field="c"), FieldCheck(field="d")]),
+            ]
+        )
+        assert evaluate_strategy(strategy, results) is True
+
+    def test_allof_of_anyof_all_none_in_branch_fails(self):
+        # AllOf( AnyOf(a,b), AnyOf(c,d) ) with first branch all None.
+        results = {"a": None, "b": None, "c": True, "d": False}
+        strategy = AllOf(
+            conditions=[
+                AnyOf(conditions=[FieldCheck(field="a"), FieldCheck(field="b")]),
+                AnyOf(conditions=[FieldCheck(field="c"), FieldCheck(field="d")]),
+            ]
+        )
+        assert evaluate_strategy(strategy, results) is False


### PR DESCRIPTION
## Problem

When the agentic parser (`AgenticParseTemplate` stage) returns JSON with `null` for one of a template's required typed fields — e.g. a float field the model couldn't compute — pydantic rejects the entire record. The question fails with `failure.stage=AgenticParseTemplate`, `field_results` empty, and **all** sub-questions get zero credit, even ones the model answered correctly.

Observed on BixBench: questions like `bix-10` (7 sub-questions) lost full credit because the model honestly returned \`null\` for one field while answering the others. The whole-record-rejection behavior penalizes the model for admitting it couldn't compute one part.

## Design

`field_results` becomes `dict[str, bool | None]`. \`None\` denotes "the model returned null / didn't answer this sub-question." This cannot collide with a legitimate \`False\` — important because, with the previous implicit \"None → False\" mapping, a ground-truth \`False\` would silently look correct against a null extraction.

- **Composition** (\`AllOf\` / \`AnyOf\` / \`AtLeastN\`): None counts as not-satisfied (soft False at composition time). Existing overall verify semantics preserved.
- **Granular score**: \`n_true / n_total_fields\` unchanged. A null costs the same as a False numerically but stays distinguishable in \`field_results\` for downstream auditing.
- **Always-on**, no opt-in flag.

## Change

Three commits:

1. \`bc7e9e02\` — \`build_extraction_relaxed_class(answer_class)\` in \`schema_builder.py\`. Walks \`_get_verified_fields()\` and builds a sibling pydantic class via \`create_model\` where each VerifiedField becomes \`Optional[T] = None\`. Non-verified fields kept verbatim.

2. \`8ba9dea5\` — wiring:
   - \`agentic_parse_template._run_extraction\`: parse against the relaxed class, capture \`null_fields = {k for k,v in extracted.items() if v is None}\` restricted to verified field names, rebuild the strict instance via \`answer_class.model_construct(**non_null_payload)\` (bypassing validation for the rebuild), attach \`_null_fields\` to it for downstream consumers.
   - \`answer.py:_compute_field_results\` returns \`dict[str, bool | None]\` and short-circuits to \`None\` for fields in \`_null_fields\`.
   - \`answer.py:_auto_verify\` switches to \`all(v is True for v in field_results.values())\`.
   - \`answer.py:_auto_verify_granular\` and \`_composition_aware_granular\` use \`is True\` checks; the total-weight denominator is unchanged.
   - \`composition.py:_field_check_evaluator\` returns \`field_results[leaf.field] is True\`.
   - \`result_components.py\` widens the type annotation to \`dict[str, bool | None] | None\`. JSON serialization handles \`None\` natively.

3. \`bd06f139\` — final commit with the proper subject and co-author trailer.

## Tests

- \`tests/unit/schemas/test_composition_with_none_fields.py\` (15 cases) — \`FieldCheck\`, \`AllOf\`, \`AnyOf\`, \`AtLeastN\` over mixed True / False / None field_results, including nested compositions.
- \`tests/unit/benchmark/verification/stages/test_agentic_parse_template_optional_fields.py\` (2 cases):
  - 3-field template with \`q2=None\`: q1/q3 still scored normally, granular = 2/3.
  - **Regression**: GT \`{q2: False}\` and extracted \`{q2: None}\` → \`field_results[\"q2\"] is None\`, not False. (This is the failure mode the design explicitly guards against.)
- Updated one existing assertion in \`test_agentic_parse_template.py\` from identity (\`is parsed_answer\`) to class+value match, because \`model_construct\` returns a new instance.

\`tests/unit/schemas\`: 1101 pass / 0 fail (+15 new). \`tests/unit/benchmark/verification/stages\`: 215 pass / 3 fail (all 3 verified pre-existing on the bixbench base). Full \`tests/\`: 9 pre-existing failures (none touching files this PR modifies).

## Subtle points

- \`_null_fields\` is filtered to verified field names only. \`BaseAnswer.id\` defaults to None but is not a VerifiedField, so it's not classified as a null extraction.
- \`model_construct\` bypasses strict validation on the rebuild path. Fields the parser returned \`null\` for are simply omitted from the payload and retain their pydantic-declared default. The strict instance is still a real \`answer_class\` — \`isinstance\` checks and \`__class__\`-based dispatch (\`VerificationStrategy\` inner class, \`_get_verified_fields\`) all keep working.
- The dataframe exporter at \`schemas/dataframes/template.py:168\` already renders \`None\` distinctly from \`False\`, so the audit trail flows through.

## Test plan

- [ ] \`uv run pytest tests/unit/schemas tests/unit/benchmark/verification/stages -v\`
- [ ] Re-run a BixBench replicate where the model previously got \`AgenticParseTemplate\` rejections (e.g. \`bix-10\` on DA) and confirm partial credit is now awarded on the fields the model did answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)