### PR TITLE
feat(adapters): sandboxed agent runtime, workspace capture, and per-call usage metadata

### DIFF
--- a/src/karenina/adapters/agent_runtime.py
+++ b/src/karenina/adapters/agent_runtime.py
@@ -375,6 +375,13 @@ def _env_flags_for_docker(env: dict[str, str | None]) -> list[str]:
 def _env_flags_for_singularity(env: dict[str, str | None]) -> list[str]:
     flags: list[str] = []
     for name, value in env.items():
+        # Singularity manages HOME via --home / --no-home and refuses to
+        # override it through --env, emitting "Overriding HOME environment
+        # variable with SINGULARITYENV_HOME is not permitted" and silently
+        # dropping the value. The singularity branch in build_container_command
+        # honours HOME via --home instead.
+        if name == "HOME":
+            continue
         env_value = os.environ.get(name, "") if value is None else value
         flags.extend(["--env", f"{name}={env_value}"])
     return flags
@@ -431,14 +438,24 @@ def build_container_command(
     #                          explicit --bind below remains, so the model
     #                          cannot reach $HOME/.local/.../site-packages
     #                          either implicitly or via sys.path.insert.
+    #   --home <path>          sets HOME inside the container without binding
+    #                          anything (singularity blocks --env HOME=... with
+    #                          a warning, so this is the only clean override).
+    #                          Defaults to /tmp so tools that touch $HOME hit a
+    #                          writable tmpfs instead of the host path that
+    #                          --no-home + --no-mount bind-paths leaves
+    #                          unmounted. Caller-supplied env["HOME"] wins.
     #   PYTHONNOUSERSITE=1     belt-and-braces: ignore user-site even if a
     #                          future caller adds a bind that exposes one.
+    home_target = env.get("HOME") or "/tmp"
     command = [
         config.runtime,
         "exec",
         "--no-home",
         "--no-mount",
         "bind-paths",
+        "--home",
+        home_target,
         "--bind",
         f"{host_workspace}:{SANDBOX_WORKSPACE_PATH}:rw",
         "--pwd",

--- a/src/karenina/adapters/agent_runtime.py
+++ b/src/karenina/adapters/agent_runtime.py
@@ -1,0 +1,225 @@
+"""Shared runtime helpers for agent adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from karenina.ports.capabilities import PortCapabilities
+
+if TYPE_CHECKING:
+    from karenina.schemas.config import ModelConfig
+
+
+SANDBOX_WORKSPACE_PATH = "/workspace"
+AGENT_RUNTIME_EXTRA_KEY = "agent_runtime"
+
+
+@dataclass(frozen=True)
+class AgentRuntimeProfile:
+    """Adapter-specific runtime behavior used by shared pipeline prompts."""
+
+    capabilities: Callable[[ModelConfig], PortCapabilities]
+    workspace_path_for_prompt: Callable[[ModelConfig, Path | None], str | None] | None = None
+    map_path_for_prompt: Callable[[ModelConfig, Path | None, Path | None], str | None] | None = None
+
+
+_runtime_profiles: dict[str, AgentRuntimeProfile] = {}
+
+
+def register_agent_runtime_profile(
+    interface: str,
+    profile: AgentRuntimeProfile,
+    *,
+    force: bool = False,
+) -> AgentRuntimeProfile:
+    """Register runtime behavior for an adapter interface.
+
+    External adapters can call this during their own registration to customize
+    prompt-visible paths and capability reporting without editing built-in code.
+    """
+
+    if interface in _runtime_profiles and not force:
+        raise ValueError(
+            f"Runtime profile for interface '{interface}' is already registered. "
+            "Use force=True to intentionally overwrite it."
+        )
+    _runtime_profiles[interface] = profile
+    return profile
+
+
+def get_deepagents_backend(model_config: ModelConfig) -> str:
+    """Return the configured DeepAgents backend name."""
+
+    return str(
+        get_agent_runtime_option(
+            model_config,
+            "backend",
+            "filesystem",
+            legacy_attr="deepagents_backend",
+        )
+    )
+
+
+def claude_sdk_sandbox_enabled(model_config: ModelConfig) -> bool:
+    """Return whether Claude Agent SDK native sandboxing is enabled."""
+
+    return bool(
+        get_agent_runtime_option(
+            model_config,
+            "sandbox_enabled",
+            True,
+            legacy_attr="claude_sdk_sandbox_enabled",
+        )
+    )
+
+
+def get_agent_runtime_options(model_config: ModelConfig) -> dict[str, object]:
+    """Return adapter runtime options from ModelConfig.extra_kwargs.
+
+    Adapter-specific runtime settings live under ``extra_kwargs["agent_runtime"]``
+    so the shared ModelConfig schema does not grow a field for every adapter.
+    """
+
+    extra_kwargs = getattr(model_config, "extra_kwargs", None) or {}
+    raw_options = extra_kwargs.get(AGENT_RUNTIME_EXTRA_KEY)
+    if isinstance(raw_options, dict):
+        return raw_options
+    return {}
+
+
+def get_agent_runtime_option(
+    model_config: ModelConfig,
+    key: str,
+    default: object = None,
+    *,
+    legacy_attr: str | None = None,
+) -> object:
+    """Read one adapter runtime option with a temporary legacy fallback."""
+
+    options = get_agent_runtime_options(model_config)
+    if key in options:
+        return options[key]
+    if legacy_attr and hasattr(model_config, legacy_attr):
+        return getattr(model_config, legacy_attr)
+    return default
+
+
+def _deepagents_capabilities(model_config: ModelConfig) -> PortCapabilities:
+    backend = get_deepagents_backend(model_config)
+    return PortCapabilities(
+        supports_system_prompt=True,
+        supports_file_tools=True,
+        supports_code_execution=backend in {"docker", "local_shell"},
+        uses_sandboxed_execution=backend == "docker",
+    )
+
+
+def _claude_sdk_capabilities(model_config: ModelConfig) -> PortCapabilities:
+    return PortCapabilities(
+        supports_system_prompt=True,
+        supports_file_tools=True,
+        supports_code_execution=True,
+        uses_sandboxed_execution=claude_sdk_sandbox_enabled(model_config),
+    )
+
+
+def _default_workspace_path_for_prompt(_model_config: ModelConfig, workspace_path: Path | None) -> str | None:
+    if workspace_path is None:
+        return None
+    return str(workspace_path)
+
+
+def _default_map_path_for_prompt(
+    _model_config: ModelConfig,
+    path: Path | None,
+    _workspace_path: Path | None,
+) -> str | None:
+    if path is None:
+        return None
+    return str(path)
+
+
+def _deepagents_workspace_path_for_prompt(model_config: ModelConfig, workspace_path: Path | None) -> str | None:
+    if workspace_path is None:
+        return None
+    if get_deepagents_backend(model_config) == "docker":
+        return SANDBOX_WORKSPACE_PATH
+    return str(workspace_path)
+
+
+def _deepagents_map_path_for_prompt(
+    model_config: ModelConfig,
+    path: Path | None,
+    workspace_path: Path | None,
+) -> str | None:
+    if path is None:
+        return None
+    if get_deepagents_backend(model_config) != "docker" or workspace_path is None:
+        return str(path)
+
+    try:
+        rel = path.resolve().relative_to(workspace_path.resolve())
+    except ValueError:
+        return str(path)
+
+    if rel.as_posix() == ".":
+        return SANDBOX_WORKSPACE_PATH
+    return f"{SANDBOX_WORKSPACE_PATH}/{rel.as_posix()}"
+
+
+def get_agent_runtime_profile(interface: str) -> AgentRuntimeProfile | None:
+    """Return the registered runtime profile for an interface, if any."""
+
+    return _runtime_profiles.get(interface)
+
+
+def get_agent_runtime_capabilities(model_config: ModelConfig) -> PortCapabilities:
+    """Return agent capabilities implied by the registered runtime profile."""
+
+    profile = get_agent_runtime_profile(model_config.interface)
+    if profile is None:
+        return PortCapabilities(supports_system_prompt=True)
+    return profile.capabilities(model_config)
+
+
+def workspace_path_for_prompt(model_config: ModelConfig, workspace_path: Path | None) -> str | None:
+    """Return the workspace path that should be shown to the model."""
+
+    profile = get_agent_runtime_profile(model_config.interface)
+    if profile and profile.workspace_path_for_prompt:
+        return profile.workspace_path_for_prompt(model_config, workspace_path)
+    return _default_workspace_path_for_prompt(model_config, workspace_path)
+
+
+def map_path_for_prompt(
+    model_config: ModelConfig,
+    path: Path | None,
+    workspace_path: Path | None,
+) -> str | None:
+    """Map a host path to the sandbox-visible path when needed."""
+
+    profile = get_agent_runtime_profile(model_config.interface)
+    if profile and profile.map_path_for_prompt:
+        return profile.map_path_for_prompt(model_config, path, workspace_path)
+    return _default_map_path_for_prompt(model_config, path, workspace_path)
+
+
+register_agent_runtime_profile(
+    "langchain_deep_agents",
+    AgentRuntimeProfile(
+        capabilities=_deepagents_capabilities,
+        workspace_path_for_prompt=_deepagents_workspace_path_for_prompt,
+        map_path_for_prompt=_deepagents_map_path_for_prompt,
+    ),
+)
+register_agent_runtime_profile(
+    "claude_agent_sdk",
+    AgentRuntimeProfile(
+        capabilities=_claude_sdk_capabilities,
+        workspace_path_for_prompt=_default_workspace_path_for_prompt,
+        map_path_for_prompt=_default_map_path_for_prompt,
+    ),
+)

--- a/src/karenina/adapters/agent_runtime.py
+++ b/src/karenina/adapters/agent_runtime.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
 
 SANDBOX_WORKSPACE_PATH = "/workspace"
 AGENT_RUNTIME_EXTRA_KEY = "agent_runtime"
+AGENT_RUNTIME_ACCESS_MODES = {"read_write", "read_only"}
+CLAUDE_SDK_BACKENDS = {"native", "docker"}
 
 
 @dataclass(frozen=True)
@@ -63,9 +65,31 @@ def get_deepagents_backend(model_config: ModelConfig) -> str:
     )
 
 
+def get_claude_sdk_backend(model_config: ModelConfig) -> str:
+    """Return the configured Claude SDK runtime backend."""
+
+    backend = str(get_agent_runtime_option(model_config, "backend", "native"))
+    if backend not in CLAUDE_SDK_BACKENDS:
+        allowed = ", ".join(sorted(CLAUDE_SDK_BACKENDS))
+        raise ValueError(f"agent_runtime backend for claude_agent_sdk must be one of: {allowed}")
+    return backend
+
+
+def get_agent_runtime_access_mode(model_config: ModelConfig) -> str:
+    """Return the configured runtime access mode."""
+
+    access_mode = str(get_agent_runtime_option(model_config, "access_mode", "read_write"))
+    if access_mode not in AGENT_RUNTIME_ACCESS_MODES:
+        allowed = ", ".join(sorted(AGENT_RUNTIME_ACCESS_MODES))
+        raise ValueError(f"agent_runtime access_mode must be one of: {allowed}")
+    return access_mode
+
+
 def claude_sdk_sandbox_enabled(model_config: ModelConfig) -> bool:
     """Return whether Claude Agent SDK native sandboxing is enabled."""
 
+    if get_claude_sdk_backend(model_config) == "docker":
+        return False
     return bool(
         get_agent_runtime_option(
             model_config,
@@ -109,20 +133,23 @@ def get_agent_runtime_option(
 
 def _deepagents_capabilities(model_config: ModelConfig) -> PortCapabilities:
     backend = get_deepagents_backend(model_config)
+    access_mode = get_agent_runtime_access_mode(model_config)
     return PortCapabilities(
         supports_system_prompt=True,
         supports_file_tools=True,
-        supports_code_execution=backend in {"docker", "local_shell"},
+        supports_code_execution=access_mode != "read_only" and backend in {"docker", "local_shell"},
         uses_sandboxed_execution=backend == "docker",
     )
 
 
 def _claude_sdk_capabilities(model_config: ModelConfig) -> PortCapabilities:
+    access_mode = get_agent_runtime_access_mode(model_config)
+    backend = get_claude_sdk_backend(model_config)
     return PortCapabilities(
         supports_system_prompt=True,
         supports_file_tools=True,
-        supports_code_execution=True,
-        uses_sandboxed_execution=claude_sdk_sandbox_enabled(model_config),
+        supports_code_execution=access_mode != "read_only",
+        uses_sandboxed_execution=backend == "docker" or claude_sdk_sandbox_enabled(model_config),
     )
 
 
@@ -158,6 +185,34 @@ def _deepagents_map_path_for_prompt(
     if path is None:
         return None
     if get_deepagents_backend(model_config) != "docker" or workspace_path is None:
+        return str(path)
+
+    try:
+        rel = path.resolve().relative_to(workspace_path.resolve())
+    except ValueError:
+        return str(path)
+
+    if rel.as_posix() == ".":
+        return SANDBOX_WORKSPACE_PATH
+    return f"{SANDBOX_WORKSPACE_PATH}/{rel.as_posix()}"
+
+
+def _claude_sdk_workspace_path_for_prompt(model_config: ModelConfig, workspace_path: Path | None) -> str | None:
+    if workspace_path is None:
+        return None
+    if get_claude_sdk_backend(model_config) == "docker":
+        return SANDBOX_WORKSPACE_PATH
+    return str(workspace_path)
+
+
+def _claude_sdk_map_path_for_prompt(
+    model_config: ModelConfig,
+    path: Path | None,
+    workspace_path: Path | None,
+) -> str | None:
+    if path is None:
+        return None
+    if get_claude_sdk_backend(model_config) != "docker" or workspace_path is None:
         return str(path)
 
     try:
@@ -219,7 +274,7 @@ register_agent_runtime_profile(
     "claude_agent_sdk",
     AgentRuntimeProfile(
         capabilities=_claude_sdk_capabilities,
-        workspace_path_for_prompt=_default_workspace_path_for_prompt,
-        map_path_for_prompt=_default_map_path_for_prompt,
+        workspace_path_for_prompt=_claude_sdk_workspace_path_for_prompt,
+        map_path_for_prompt=_claude_sdk_map_path_for_prompt,
     ),
 )

--- a/src/karenina/adapters/agent_runtime.py
+++ b/src/karenina/adapters/agent_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from collections.abc import Callable
@@ -18,7 +19,12 @@ if TYPE_CHECKING:
 SANDBOX_WORKSPACE_PATH = "/workspace"
 AGENT_RUNTIME_EXTRA_KEY = "agent_runtime"
 AGENT_RUNTIME_ACCESS_MODES = {"read_write", "read_only"}
-CLAUDE_SDK_BACKENDS = {"native", "docker"}
+CONTAINER_BACKEND = "container"
+LEGACY_DOCKER_BACKEND = "docker"
+CONTAINER_BACKEND_ALIASES = {CONTAINER_BACKEND, LEGACY_DOCKER_BACKEND}
+CONTAINER_RUNTIMES = {"docker", "singularity", "apptainer"}
+CLAUDE_SDK_BACKENDS = {"native", CONTAINER_BACKEND, LEGACY_DOCKER_BACKEND}
+DEEPAGENTS_BACKENDS = {"filesystem", CONTAINER_BACKEND, LEGACY_DOCKER_BACKEND, "local_shell"}
 DOCKER_PREFLIGHT_TIMEOUT_SECONDS = 10
 
 
@@ -29,6 +35,16 @@ class AgentRuntimeProfile:
     capabilities: Callable[[ModelConfig], PortCapabilities]
     workspace_path_for_prompt: Callable[[ModelConfig, Path | None], str | None] | None = None
     map_path_for_prompt: Callable[[ModelConfig, Path | None, Path | None], str | None] | None = None
+
+
+@dataclass(frozen=True)
+class ContainerRuntimeConfig:
+    """Resolved configuration for one-shot container command execution."""
+
+    runtime: str
+    image: str | None
+    network: str = "bridge"
+    add_hosts: tuple[str, ...] = ()
 
 
 _runtime_profiles: dict[str, AgentRuntimeProfile] = {}
@@ -58,7 +74,7 @@ def register_agent_runtime_profile(
 def get_deepagents_backend(model_config: ModelConfig) -> str:
     """Return the configured DeepAgents backend name."""
 
-    return str(
+    backend = str(
         get_agent_runtime_option(
             model_config,
             "backend",
@@ -66,6 +82,12 @@ def get_deepagents_backend(model_config: ModelConfig) -> str:
             legacy_attr="deepagents_backend",
         )
     )
+    if backend not in DEEPAGENTS_BACKENDS:
+        allowed = ", ".join(sorted(DEEPAGENTS_BACKENDS))
+        raise ValueError(f"agent_runtime backend for langchain_deep_agents must be one of: {allowed}")
+    if backend == LEGACY_DOCKER_BACKEND:
+        return CONTAINER_BACKEND
+    return backend
 
 
 def get_claude_sdk_backend(model_config: ModelConfig) -> str:
@@ -75,7 +97,16 @@ def get_claude_sdk_backend(model_config: ModelConfig) -> str:
     if backend not in CLAUDE_SDK_BACKENDS:
         allowed = ", ".join(sorted(CLAUDE_SDK_BACKENDS))
         raise ValueError(f"agent_runtime backend for claude_agent_sdk must be one of: {allowed}")
+    if backend == LEGACY_DOCKER_BACKEND:
+        return CONTAINER_BACKEND
     return backend
+
+
+def is_container_backend(model_config: ModelConfig) -> bool:
+    """Return whether this model is configured for containerized execution."""
+
+    backend = str(get_agent_runtime_option(model_config, "backend", "native"))
+    return backend in CONTAINER_BACKEND_ALIASES
 
 
 def get_agent_runtime_access_mode(model_config: ModelConfig) -> str:
@@ -91,7 +122,7 @@ def get_agent_runtime_access_mode(model_config: ModelConfig) -> str:
 def claude_sdk_sandbox_enabled(model_config: ModelConfig) -> bool:
     """Return whether Claude Agent SDK native sandboxing is enabled."""
 
-    if get_claude_sdk_backend(model_config) == "docker":
+    if get_claude_sdk_backend(model_config) == CONTAINER_BACKEND:
         return False
     return bool(
         get_agent_runtime_option(
@@ -132,6 +163,73 @@ def get_agent_runtime_option(
     if legacy_attr and hasattr(model_config, legacy_attr):
         return getattr(model_config, legacy_attr)
     return default
+
+
+def _runtime_option_alias(
+    model_config: ModelConfig,
+    preferred_key: str,
+    legacy_key: str,
+    default: object = None,
+) -> object:
+    options = get_agent_runtime_options(model_config)
+    if preferred_key in options:
+        return options[preferred_key]
+    if legacy_key in options:
+        return options[legacy_key]
+    return default
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, list | tuple):
+        return tuple(str(item) for item in value)
+    return (str(value),)
+
+
+def get_container_runtime_config(model_config: ModelConfig) -> ContainerRuntimeConfig:
+    """Resolve neutral container runtime options with Docker compatibility aliases."""
+
+    runtime = str(get_agent_runtime_option(model_config, "container_runtime", "docker"))
+    if runtime not in CONTAINER_RUNTIMES:
+        allowed = ", ".join(sorted(CONTAINER_RUNTIMES))
+        raise ValueError(f"agent_runtime container_runtime must be one of: {allowed}")
+
+    image = _runtime_option_alias(model_config, "container_image", "docker_image")
+    network = str(_runtime_option_alias(model_config, "container_network", "docker_network", "bridge"))
+    add_hosts = _string_tuple(_runtime_option_alias(model_config, "container_add_hosts", "docker_add_hosts"))
+    if runtime == "docker":
+        if network not in {"bridge", "none"}:
+            from karenina.ports import AdapterUnavailableError
+
+            raise AdapterUnavailableError(
+                "agent_runtime container_network must be 'bridge' or 'none' for Docker",
+                reason="invalid_container_network",
+            )
+    else:
+        if network not in {"bridge", ""}:
+            from karenina.ports import AdapterUnavailableError
+
+            raise AdapterUnavailableError(
+                f"agent_runtime container_network={network!r} is Docker-only and is not supported for {runtime}",
+                reason="unsupported_container_network",
+            )
+        if add_hosts:
+            from karenina.ports import AdapterUnavailableError
+
+            raise AdapterUnavailableError(
+                f"agent_runtime container_add_hosts is Docker-only and is not supported for {runtime}",
+                reason="unsupported_container_add_hosts",
+            )
+
+    return ContainerRuntimeConfig(
+        runtime=runtime,
+        image=str(image) if image else None,
+        network=network or "bridge",
+        add_hosts=add_hosts,
+    )
 
 
 def _docker_command_output(result: subprocess.CompletedProcess[str]) -> str:
@@ -222,14 +320,131 @@ def preflight_docker_runtime(
         )
 
 
+def preflight_container_runtime(
+    config: ContainerRuntimeConfig,
+    *,
+    timeout: int = DOCKER_PREFLIGHT_TIMEOUT_SECONDS,
+    check_image: bool = True,
+) -> None:
+    """Validate a configured container runtime before an agent starts."""
+
+    if config.runtime == "docker":
+        preflight_docker_runtime(image=config.image, timeout=timeout, check_image=check_image)
+        return
+
+    executable = config.runtime
+    if shutil.which(executable) is None:
+        from karenina.ports import AdapterUnavailableError
+
+        raise AdapterUnavailableError(
+            f"{executable} is required for agent_runtime container_runtime='{config.runtime}', "
+            f"but the {executable} command was not found",
+            reason=f"{config.runtime}_unavailable",
+        )
+
+    if not check_image:
+        return
+    if not config.image:
+        from karenina.ports import AdapterUnavailableError
+
+        raise AdapterUnavailableError(
+            f"agent_runtime container_image is required when container_runtime='{config.runtime}'",
+            reason="missing_container_image",
+        )
+
+    image_path = Path(config.image).expanduser()
+    if image_path.suffix != ".sif" or not image_path.is_file():
+        from karenina.ports import AdapterUnavailableError
+
+        raise AdapterUnavailableError(
+            f"agent_runtime container_image for {config.runtime} must be an existing local .sif file: {config.image}",
+            reason="container_image_unavailable",
+        )
+
+
+def _env_flags_for_docker(env: dict[str, str | None]) -> list[str]:
+    flags: list[str] = []
+    for name, value in env.items():
+        if value is None:
+            flags.extend(["--env", name])
+        else:
+            flags.extend(["--env", f"{name}={value}"])
+    return flags
+
+
+def _env_flags_for_singularity(env: dict[str, str | None]) -> list[str]:
+    flags: list[str] = []
+    for name, value in env.items():
+        env_value = os.environ.get(name, "") if value is None else value
+        flags.extend(["--env", f"{name}={env_value}"])
+    return flags
+
+
+def build_container_command(
+    *,
+    config: ContainerRuntimeConfig,
+    host_workspace: str | Path,
+    argv: list[str],
+    env: dict[str, str | None] | None = None,
+    interactive: bool = False,
+) -> list[str]:
+    """Build a one-shot command for Docker, Singularity, or Apptainer."""
+
+    if not config.image:
+        from karenina.ports import AdapterUnavailableError
+
+        raise AdapterUnavailableError(
+            "agent_runtime container_image is required for container execution",
+            reason="missing_container_image",
+        )
+    host_workspace = str(Path(host_workspace).resolve())
+    env = env or {}
+
+    if config.runtime == "docker":
+        command = ["docker", "run", "--rm"]
+        if interactive:
+            command.append("-i")
+        command.extend(
+            [
+                "--network",
+                config.network,
+                "--workdir",
+                SANDBOX_WORKSPACE_PATH,
+                "--volume",
+                f"{host_workspace}:{SANDBOX_WORKSPACE_PATH}:rw",
+            ]
+        )
+        for host_mapping in config.add_hosts:
+            command.extend(["--add-host", host_mapping])
+        command.extend(_env_flags_for_docker(env))
+        command.extend(["--pids-limit", "256"])
+        if hasattr(os, "getuid") and hasattr(os, "getgid"):
+            command.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+        command.extend([config.image, *argv])
+        return command
+
+    command = [
+        config.runtime,
+        "exec",
+        "--bind",
+        f"{host_workspace}:{SANDBOX_WORKSPACE_PATH}:rw",
+        "--pwd",
+        SANDBOX_WORKSPACE_PATH,
+        *_env_flags_for_singularity(env),
+        config.image,
+        *argv,
+    ]
+    return command
+
+
 def _deepagents_capabilities(model_config: ModelConfig) -> PortCapabilities:
     backend = get_deepagents_backend(model_config)
     access_mode = get_agent_runtime_access_mode(model_config)
     return PortCapabilities(
         supports_system_prompt=True,
         supports_file_tools=True,
-        supports_code_execution=access_mode != "read_only" and backend in {"docker", "local_shell"},
-        uses_sandboxed_execution=backend == "docker",
+        supports_code_execution=access_mode != "read_only" and backend in {CONTAINER_BACKEND, "local_shell"},
+        uses_sandboxed_execution=backend == CONTAINER_BACKEND,
     )
 
 
@@ -240,7 +455,7 @@ def _claude_sdk_capabilities(model_config: ModelConfig) -> PortCapabilities:
         supports_system_prompt=True,
         supports_file_tools=True,
         supports_code_execution=access_mode != "read_only",
-        uses_sandboxed_execution=backend == "docker" or claude_sdk_sandbox_enabled(model_config),
+        uses_sandboxed_execution=backend == CONTAINER_BACKEND or claude_sdk_sandbox_enabled(model_config),
     )
 
 
@@ -263,7 +478,7 @@ def _default_map_path_for_prompt(
 def _deepagents_workspace_path_for_prompt(model_config: ModelConfig, workspace_path: Path | None) -> str | None:
     if workspace_path is None:
         return None
-    if get_deepagents_backend(model_config) == "docker":
+    if get_deepagents_backend(model_config) == CONTAINER_BACKEND:
         return SANDBOX_WORKSPACE_PATH
     return str(workspace_path)
 
@@ -275,7 +490,7 @@ def _deepagents_map_path_for_prompt(
 ) -> str | None:
     if path is None:
         return None
-    if get_deepagents_backend(model_config) != "docker" or workspace_path is None:
+    if get_deepagents_backend(model_config) != CONTAINER_BACKEND or workspace_path is None:
         return str(path)
 
     try:
@@ -291,7 +506,7 @@ def _deepagents_map_path_for_prompt(
 def _claude_sdk_workspace_path_for_prompt(model_config: ModelConfig, workspace_path: Path | None) -> str | None:
     if workspace_path is None:
         return None
-    if get_claude_sdk_backend(model_config) == "docker":
+    if get_claude_sdk_backend(model_config) == CONTAINER_BACKEND:
         return SANDBOX_WORKSPACE_PATH
     return str(workspace_path)
 
@@ -303,7 +518,7 @@ def _claude_sdk_map_path_for_prompt(
 ) -> str | None:
     if path is None:
         return None
-    if get_claude_sdk_backend(model_config) != "docker" or workspace_path is None:
+    if get_claude_sdk_backend(model_config) != CONTAINER_BACKEND or workspace_path is None:
         return str(path)
 
     try:

--- a/src/karenina/adapters/agent_runtime.py
+++ b/src/karenina/adapters/agent_runtime.py
@@ -423,13 +423,28 @@ def build_container_command(
         command.extend([config.image, *argv])
         return command
 
+    # Sandbox isolation: prevent the host filesystem from leaking host-installed
+    # Python packages into the model's sandbox.
+    #   --no-home              skips Singularity's default $HOME auto-mount
+    #   --no-mount bind-paths  drops system-default binds from singularity.conf
+    #                          (e.g. /homes, /hps/software, /nfs/*); only the
+    #                          explicit --bind below remains, so the model
+    #                          cannot reach $HOME/.local/.../site-packages
+    #                          either implicitly or via sys.path.insert.
+    #   PYTHONNOUSERSITE=1     belt-and-braces: ignore user-site even if a
+    #                          future caller adds a bind that exposes one.
     command = [
         config.runtime,
         "exec",
+        "--no-home",
+        "--no-mount",
+        "bind-paths",
         "--bind",
         f"{host_workspace}:{SANDBOX_WORKSPACE_PATH}:rw",
         "--pwd",
         SANDBOX_WORKSPACE_PATH,
+        "--env",
+        "PYTHONNOUSERSITE=1",
         *_env_flags_for_singularity(env),
         config.image,
         *argv,

--- a/src/karenina/adapters/agent_runtime.py
+++ b/src/karenina/adapters/agent_runtime.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import shutil
+import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,6 +19,7 @@ SANDBOX_WORKSPACE_PATH = "/workspace"
 AGENT_RUNTIME_EXTRA_KEY = "agent_runtime"
 AGENT_RUNTIME_ACCESS_MODES = {"read_write", "read_only"}
 CLAUDE_SDK_BACKENDS = {"native", "docker"}
+DOCKER_PREFLIGHT_TIMEOUT_SECONDS = 10
 
 
 @dataclass(frozen=True)
@@ -129,6 +132,94 @@ def get_agent_runtime_option(
     if legacy_attr and hasattr(model_config, legacy_attr):
         return getattr(model_config, legacy_attr)
     return default
+
+
+def _docker_command_output(result: subprocess.CompletedProcess[str]) -> str:
+    """Return compact Docker command output for preflight errors."""
+
+    output = "\n".join(part.strip() for part in (result.stderr, result.stdout) if part and part.strip())
+    if not output:
+        output = f"Docker command exited with status {result.returncode}"
+    max_chars = 1_000
+    if len(output) > max_chars:
+        return f"{output[:max_chars]}..."
+    return output
+
+
+def preflight_docker_runtime(
+    *,
+    image: str | None,
+    timeout: int = DOCKER_PREFLIGHT_TIMEOUT_SECONDS,
+    check_image: bool = True,
+) -> None:
+    """Validate that the host Docker runtime is ready before starting an agent.
+
+    The agent-facing Docker backends execute shell commands by wrapping them in
+    ``docker run``. If the daemon or configured image is unavailable, failing
+    during backend setup prevents wasted model turns where the agent repeatedly
+    retries normal shell commands.
+    """
+
+    if shutil.which("docker") is None:
+        from karenina.ports import AdapterUnavailableError
+
+        raise AdapterUnavailableError(
+            "Docker is required for agent_runtime backend='docker', but the docker command was not found",
+            reason="docker_unavailable",
+        )
+
+    try:
+        info = subprocess.run(  # noqa: S603
+            ["docker", "info"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as e:
+        from karenina.ports import AdapterUnavailableError
+
+        raise AdapterUnavailableError(
+            f"Docker daemon preflight timed out after {timeout} seconds while running 'docker info'",
+            reason="docker_daemon_unavailable",
+        ) from e
+
+    if info.returncode != 0:
+        from karenina.ports import AdapterUnavailableError
+
+        raise AdapterUnavailableError(
+            "Docker daemon is not reachable for agent_runtime backend='docker'. "
+            f"'docker info' failed: {_docker_command_output(info)}",
+            reason="docker_daemon_unavailable",
+        )
+
+    if not check_image or not image:
+        return
+
+    try:
+        inspect = subprocess.run(  # noqa: S603
+            ["docker", "image", "inspect", image],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as e:
+        from karenina.ports import AdapterUnavailableError
+
+        raise AdapterUnavailableError(
+            f"Docker image preflight timed out after {timeout} seconds while checking image '{image}'",
+            reason="docker_image_unavailable",
+        ) from e
+
+    if inspect.returncode != 0:
+        from karenina.ports import AdapterUnavailableError
+
+        raise AdapterUnavailableError(
+            "Docker image required by agent_runtime backend='docker' is not available locally: "
+            f"{image}. 'docker image inspect {image}' failed: {_docker_command_output(inspect)}",
+            reason="docker_image_unavailable",
+        )
 
 
 def _deepagents_capabilities(model_config: ModelConfig) -> PortCapabilities:

--- a/src/karenina/adapters/claude_agent_sdk/__init__.py
+++ b/src/karenina/adapters/claude_agent_sdk/__init__.py
@@ -54,6 +54,7 @@ __all__ = [
     "convert_mcp_config",
     # Usage extraction (sdk-007)
     "extract_sdk_usage",
+    "extract_sdk_usage_from_messages",
     # Trace utilities (sdk-008)
     "sdk_messages_to_raw_trace",
     "sdk_messages_to_trace_messages",
@@ -74,7 +75,10 @@ if TYPE_CHECKING:
         sdk_messages_to_raw_trace,
         sdk_messages_to_trace_messages,
     )
-    from karenina.adapters.claude_agent_sdk.usage import extract_sdk_usage
+    from karenina.adapters.claude_agent_sdk.usage import (
+        extract_sdk_usage,
+        extract_sdk_usage_from_messages,
+    )
 
 
 def __getattr__(name: str) -> Any:
@@ -117,6 +121,11 @@ def __getattr__(name: str) -> Any:
         from karenina.adapters.claude_agent_sdk.usage import extract_sdk_usage
 
         return extract_sdk_usage
+
+    if name == "extract_sdk_usage_from_messages":
+        from karenina.adapters.claude_agent_sdk.usage import extract_sdk_usage_from_messages
+
+        return extract_sdk_usage_from_messages
 
     if name == "sdk_messages_to_raw_trace":
         from karenina.adapters.claude_agent_sdk.trace import sdk_messages_to_raw_trace

--- a/src/karenina/adapters/claude_agent_sdk/agent.py
+++ b/src/karenina/adapters/claude_agent_sdk/agent.py
@@ -29,6 +29,7 @@ from karenina.adapters.agent_runtime import (
     get_agent_runtime_capabilities,
     get_agent_runtime_option,
     get_claude_sdk_backend,
+    preflight_docker_runtime,
 )
 from karenina.ports import (
     AdapterUnavailableError,
@@ -184,6 +185,7 @@ class ClaudeSDKAgentAdapter:
                 "agent_runtime docker_network must be 'bridge' or 'none'",
                 reason="invalid_claude_sdk_docker_network",
             )
+        preflight_docker_runtime(image=docker_image)
         env = {
             "KARENINA_CLAUDE_DOCKER_WORKSPACE": str(workspace_path.resolve()),
             "KARENINA_CLAUDE_DOCKER_IMAGE": docker_image,

--- a/src/karenina/adapters/claude_agent_sdk/agent.py
+++ b/src/karenina/adapters/claude_agent_sdk/agent.py
@@ -21,8 +21,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from karenina.adapters.agent_runtime import get_agent_runtime_capabilities, get_agent_runtime_option
 from karenina.ports import (
     AgentConfig,
     AgentPort,
@@ -101,11 +103,39 @@ class ClaudeSDKAgentAdapter:
         Returns:
             PortCapabilities with system_prompt=True.
         """
-        return PortCapabilities(
-            supports_system_prompt=True,
-            supports_file_tools=True,
-            supports_code_execution=True,
-        )
+        return get_agent_runtime_capabilities(self._config)
+
+    def _build_sandbox_settings(self) -> dict[str, Any] | None:
+        """Build Claude Code sandbox settings for Bash isolation."""
+
+        if not get_agent_runtime_option(
+            self._config,
+            "sandbox_enabled",
+            True,
+            legacy_attr="claude_sdk_sandbox_enabled",
+        ):
+            return None
+
+        return {
+            "enabled": True,
+            "failIfUnavailable": bool(
+                get_agent_runtime_option(
+                    self._config,
+                    "sandbox_fail_if_unavailable",
+                    True,
+                    legacy_attr="claude_sdk_sandbox_fail_if_unavailable",
+                )
+            ),
+            "autoAllowBashIfSandboxed": True,
+            "allowUnsandboxedCommands": bool(
+                get_agent_runtime_option(
+                    self._config,
+                    "allow_unsandboxed_commands",
+                    False,
+                    legacy_attr="claude_sdk_allow_unsandboxed_commands",
+                )
+            ),
+        }
 
     def _build_options(
         self,
@@ -128,8 +158,16 @@ class ClaudeSDKAgentAdapter:
         from claude_agent_sdk import ClaudeAgentOptions
 
         options_kwargs: dict[str, Any] = {
-            # Use bypassPermissions for batch/automated calls
-            "permission_mode": "bypassPermissions",
+            # Use sandbox-aware permissions by default. Do not use
+            # bypassPermissions here: allowed_tools does not constrain it.
+            "permission_mode": str(
+                get_agent_runtime_option(
+                    self._config,
+                    "permission_mode",
+                    "acceptEdits",
+                    legacy_attr="claude_sdk_permission_mode",
+                )
+            ),
             # Map AgentConfig.max_turns to SDK
             "max_turns": config.max_turns,
         }
@@ -173,11 +211,28 @@ class ClaudeSDKAgentAdapter:
             # SDK supports tool filtering via allowed_tools
             options_kwargs["allowed_tools"] = [t.name for t in tools]
 
+        sandbox_settings = self._build_sandbox_settings()
+        if sandbox_settings:
+            options_kwargs["sandbox"] = sandbox_settings
+
         # Apply any extra options from config
         if config.extra:
+            extra_permission_mode = config.extra.get("claude_sdk_permission_mode")
+            if extra_permission_mode:
+                options_kwargs["permission_mode"] = extra_permission_mode
+            elif config.extra.get("allow_unsafe_permission_mode_override") and "permission_mode" in config.extra:
+                options_kwargs["permission_mode"] = config.extra["permission_mode"]
+
             for key, value in config.extra.items():
                 # Don't override critical options
-                if key not in ("permission_mode", "max_turns", "mcp_servers", "allowed_tools"):
+                if key not in (
+                    "permission_mode",
+                    "claude_sdk_permission_mode",
+                    "allow_unsafe_permission_mode_override",
+                    "max_turns",
+                    "mcp_servers",
+                    "allowed_tools",
+                ):
                     options_kwargs[key] = value
 
         # Build env dict for Anthropic settings (api_key, base_url).
@@ -205,9 +260,10 @@ class ClaudeSDKAgentAdapter:
         # can still override this default.
         options_kwargs.setdefault("setting_sources", [])
 
-        # Wire workspace_path to SDK's cwd for filesystem isolation
-        if config.workspace_path:
-            options_kwargs["cwd"] = str(config.workspace_path)
+        # Wire cwd to the workspace boundary used by Claude Code permissions
+        # and native Bash sandboxing. When no workspace is supplied, use the
+        # current process directory instead of letting the SDK choose implicitly.
+        options_kwargs["cwd"] = str(config.workspace_path or Path.cwd())
 
         return ClaudeAgentOptions(**options_kwargs)
 

--- a/src/karenina/adapters/claude_agent_sdk/agent.py
+++ b/src/karenina/adapters/claude_agent_sdk/agent.py
@@ -25,11 +25,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from karenina.adapters.agent_runtime import (
+    CONTAINER_BACKEND,
     get_agent_runtime_access_mode,
     get_agent_runtime_capabilities,
     get_agent_runtime_option,
     get_claude_sdk_backend,
-    preflight_docker_runtime,
+    get_container_runtime_config,
+    preflight_container_runtime,
 )
 from karenina.ports import (
     AdapterUnavailableError,
@@ -59,7 +61,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 CLAUDE_SDK_READ_ONLY_TOOLS = ("Read", "Grep", "Glob", "LS")
-CLAUDE_SDK_DOCKER_WRAPPER = Path(__file__).with_name("docker_cli_wrapper.py")
+CLAUDE_SDK_CONTAINER_WRAPPER = Path(__file__).with_name("docker_cli_wrapper.py")
+CLAUDE_SDK_DOCKER_WRAPPER = CLAUDE_SDK_CONTAINER_WRAPPER
 ZAI_ANTHROPIC_BASE_URL_MARKER = "api.z.ai/api/anthropic"
 
 
@@ -123,7 +126,7 @@ class ClaudeSDKAgentAdapter:
     def _build_sandbox_settings(self) -> dict[str, Any] | None:
         """Build Claude Code sandbox settings for Bash isolation."""
 
-        if get_claude_sdk_backend(self._config) == "docker":
+        if get_claude_sdk_backend(self._config) == CONTAINER_BACKEND:
             return None
         if not get_agent_runtime_option(
             self._config,
@@ -165,38 +168,40 @@ class ClaudeSDKAgentAdapter:
             "UV_PROJECT_ENVIRONMENT": str(workspace_path / ".venv"),
         }
 
-    def _docker_wrapper_env(self, workspace_path: Path | None) -> dict[str, str]:
-        """Return environment required by the Docker CLI wrapper."""
+    def _container_wrapper_env(self, workspace_path: Path | None) -> dict[str, str]:
+        """Return environment required by the container CLI wrapper."""
 
         if workspace_path is None:
             raise AdapterUnavailableError(
-                "agent_runtime backend='docker' requires an AgentConfig.workspace_path",
+                "agent_runtime backend='container' requires an AgentConfig.workspace_path",
                 reason="missing_workspace",
             )
-        docker_image = str(get_agent_runtime_option(self._config, "docker_image", ""))
-        if not docker_image:
+        container_config = get_container_runtime_config(self._config)
+        if not container_config.image:
             raise AdapterUnavailableError(
-                "agent_runtime docker_image is required when claude_agent_sdk backend='docker'",
-                reason="missing_claude_sdk_docker_image",
+                "agent_runtime container_image is required when claude_agent_sdk backend='container'",
+                reason="missing_claude_sdk_container_image",
             )
-        docker_network = str(get_agent_runtime_option(self._config, "docker_network", "bridge"))
-        if docker_network not in {"bridge", "none"}:
-            raise AdapterUnavailableError(
-                "agent_runtime docker_network must be 'bridge' or 'none'",
-                reason="invalid_claude_sdk_docker_network",
-            )
-        preflight_docker_runtime(image=docker_image)
+        preflight_container_runtime(container_config)
         env = {
-            "KARENINA_CLAUDE_DOCKER_WORKSPACE": str(workspace_path.resolve()),
-            "KARENINA_CLAUDE_DOCKER_IMAGE": docker_image,
-            "KARENINA_CLAUDE_DOCKER_NETWORK": docker_network,
+            "KARENINA_CLAUDE_CONTAINER_WORKSPACE": str(workspace_path.resolve()),
+            "KARENINA_CLAUDE_CONTAINER_RUNTIME": container_config.runtime,
+            "KARENINA_CLAUDE_CONTAINER_IMAGE": container_config.image,
+            "KARENINA_CLAUDE_CONTAINER_NETWORK": container_config.network,
             "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
         }
-        docker_add_hosts = get_agent_runtime_option(self._config, "docker_add_hosts", None)
-        if isinstance(docker_add_hosts, str):
-            env["KARENINA_CLAUDE_DOCKER_ADD_HOSTS"] = docker_add_hosts
-        elif isinstance(docker_add_hosts, list):
-            env["KARENINA_CLAUDE_DOCKER_ADD_HOSTS"] = ",".join(str(item) for item in docker_add_hosts)
+        if container_config.add_hosts:
+            env["KARENINA_CLAUDE_CONTAINER_ADD_HOSTS"] = ",".join(container_config.add_hosts)
+        if container_config.runtime == "docker":
+            env.update(
+                {
+                    "KARENINA_CLAUDE_DOCKER_WORKSPACE": str(workspace_path.resolve()),
+                    "KARENINA_CLAUDE_DOCKER_IMAGE": container_config.image,
+                    "KARENINA_CLAUDE_DOCKER_NETWORK": container_config.network,
+                }
+            )
+            if container_config.add_hosts:
+                env["KARENINA_CLAUDE_DOCKER_ADD_HOSTS"] = ",".join(container_config.add_hosts)
         return env
 
     def _build_options(
@@ -222,12 +227,14 @@ class ClaudeSDKAgentAdapter:
         runtime_backend = get_claude_sdk_backend(self._config)
         access_mode = get_agent_runtime_access_mode(self._config)
         default_permission_mode = (
-            "bypassPermissions" if runtime_backend == "docker" and access_mode == "read_write" else "acceptEdits"
+            "bypassPermissions"
+            if runtime_backend == CONTAINER_BACKEND and access_mode == "read_write"
+            else "acceptEdits"
         )
 
         options_kwargs: dict[str, Any] = {
             # In native mode, use sandbox-aware permissions by default. For
-            # Docker read-write mode, the container is the execution boundary,
+            # Container read-write mode, the container is the execution boundary,
             # so non-interactive runs need Bash to execute without prompts.
             # Keep read-only mode on acceptEdits because bypassPermissions does
             # not respect allowed_tools.
@@ -342,9 +349,9 @@ class ClaudeSDKAgentAdapter:
         if parent_claude_config_dir:
             env_vars["CLAUDE_CONFIG_DIR"] = parent_claude_config_dir
 
-        if get_claude_sdk_backend(self._config) == "docker":
-            env_vars.update(self._docker_wrapper_env(workspace_path))
-            options_kwargs["cli_path"] = str(CLAUDE_SDK_DOCKER_WRAPPER)
+        if get_claude_sdk_backend(self._config) == CONTAINER_BACKEND:
+            env_vars.update(self._container_wrapper_env(workspace_path))
+            options_kwargs["cli_path"] = str(CLAUDE_SDK_CONTAINER_WRAPPER)
 
         if env_vars:
             options_kwargs["env"] = env_vars

--- a/src/karenina/adapters/claude_agent_sdk/agent.py
+++ b/src/karenina/adapters/claude_agent_sdk/agent.py
@@ -59,6 +59,11 @@ logger = logging.getLogger(__name__)
 
 CLAUDE_SDK_READ_ONLY_TOOLS = ("Read", "Grep", "Glob", "LS")
 CLAUDE_SDK_DOCKER_WRAPPER = Path(__file__).with_name("docker_cli_wrapper.py")
+ZAI_ANTHROPIC_BASE_URL_MARKER = "api.z.ai/api/anthropic"
+
+
+def _is_zai_anthropic_endpoint(base_url: str | None) -> bool:
+    return bool(base_url and ZAI_ANTHROPIC_BASE_URL_MARKER in base_url)
 
 
 class ClaudeSDKAgentAdapter:
@@ -242,9 +247,16 @@ class ClaudeSDKAgentAdapter:
         elif self._config.system_prompt:
             options_kwargs["system_prompt"] = self._config.system_prompt
 
-        # Add model specification if provided
-        if self._config.model_name:
-            options_kwargs["model"] = self._config.model_name
+        # Add model specification if provided. Z.ai maps Claude Code's internal
+        # Sonnet/Opus model names to GLM through ANTHROPIC_DEFAULT_* env vars;
+        # passing glm-* directly to Claude Code is rejected before the endpoint
+        # can apply that mapping.
+        configured_model_name = self._config.model_name or ""
+        model_name = configured_model_name
+        if _is_zai_anthropic_endpoint(self._config.anthropic_base_url) and configured_model_name.startswith("glm-"):
+            model_name = str((config.extra or {}).get("claude_sdk_model_name", "claude-sonnet-4-5"))
+        if model_name:
+            options_kwargs["model"] = model_name
 
         # Add MCP servers if provided
         if mcp_servers:
@@ -301,6 +313,7 @@ class ClaudeSDKAgentAdapter:
                     "max_turns",
                     "mcp_servers",
                     "allowed_tools",
+                    "claude_sdk_model_name",
                 ):
                     options_kwargs[key] = value
 
@@ -310,8 +323,14 @@ class ClaudeSDKAgentAdapter:
         workspace_path = config.workspace_path
         if self._config.anthropic_api_key:
             env_vars["ANTHROPIC_API_KEY"] = self._config.anthropic_api_key.get_secret_value()
+            if _is_zai_anthropic_endpoint(self._config.anthropic_base_url):
+                env_vars["ANTHROPIC_AUTH_TOKEN"] = self._config.anthropic_api_key.get_secret_value()
         if self._config.anthropic_base_url:
             env_vars["ANTHROPIC_BASE_URL"] = self._config.anthropic_base_url
+        if _is_zai_anthropic_endpoint(self._config.anthropic_base_url) and configured_model_name.startswith("glm-"):
+            env_vars.setdefault("ANTHROPIC_DEFAULT_SONNET_MODEL", configured_model_name)
+            env_vars.setdefault("ANTHROPIC_DEFAULT_OPUS_MODEL", configured_model_name)
+            env_vars.setdefault("API_TIMEOUT_MS", "3000000")
         env_vars.update(self._workspace_local_env(workspace_path))
         # Forward CLAUDE_CONFIG_DIR from the parent process so the subprocess does
         # not load the user's personal MCP servers from ~/.claude/. Combined with

--- a/src/karenina/adapters/claude_agent_sdk/agent.py
+++ b/src/karenina/adapters/claude_agent_sdk/agent.py
@@ -47,6 +47,7 @@ from karenina.ports import (
 )
 from karenina.ports.capabilities import PortCapabilities
 
+from .auth import subscription_auth_env
 from .mcp import convert_mcp_config
 from .messages import ClaudeSDKMessageConverter
 from .trace import sdk_messages_to_raw_trace
@@ -345,6 +346,8 @@ class ClaudeSDKAgentAdapter:
             env_vars["ANTHROPIC_API_KEY"] = self._config.anthropic_api_key.get_secret_value()
             if _is_zai_anthropic_endpoint(self._config.anthropic_base_url):
                 env_vars["ANTHROPIC_AUTH_TOKEN"] = self._config.anthropic_api_key.get_secret_value()
+        else:
+            env_vars.update(subscription_auth_env())
         if self._config.anthropic_base_url:
             env_vars["ANTHROPIC_BASE_URL"] = self._config.anthropic_base_url
         if _is_zai_anthropic_endpoint(self._config.anthropic_base_url) and configured_model_name.startswith("glm-"):
@@ -492,9 +495,7 @@ class ClaudeSDKAgentAdapter:
         if result_message:
             usage = extract_sdk_usage(result_message, model=self._config.model_name)
         else:
-            usage = extract_sdk_usage_from_messages(
-                collected_messages, model=self._config.model_name
-            )
+            usage = extract_sdk_usage_from_messages(collected_messages, model=self._config.model_name)
         turns = result_message.num_turns if result_message and hasattr(result_message, "num_turns") else 0
         actual_model = self._extract_actual_model(collected_messages) or self._config.model_name
         session_id = result_message.session_id if result_message and hasattr(result_message, "session_id") else None

--- a/src/karenina/adapters/claude_agent_sdk/agent.py
+++ b/src/karenina/adapters/claude_agent_sdk/agent.py
@@ -50,7 +50,12 @@ from karenina.ports.capabilities import PortCapabilities
 from .mcp import convert_mcp_config
 from .messages import ClaudeSDKMessageConverter
 from .trace import sdk_messages_to_raw_trace
-from .usage import extract_sdk_usage, extract_sdk_usage_from_messages
+from .usage import (
+    backfill_assistant_output_tokens,
+    collapse_partial_assistant_messages,
+    extract_sdk_usage,
+    extract_sdk_usage_from_messages,
+)
 
 if TYPE_CHECKING:
     from claude_agent_sdk import ClaudeAgentOptions, ResultMessage
@@ -247,6 +252,13 @@ class ClaudeSDKAgentAdapter:
             ),
             # Map AgentConfig.max_turns to SDK
             "max_turns": config.max_turns,
+            # Emit raw stream events alongside AssistantMessage objects so the
+            # caller can recover per-turn output_tokens from message_delta
+            # events. AssistantMessage.usage reflects only message_start state
+            # (output_tokens=0 on backends that defer the count to the delta),
+            # so without partials we cannot account for output tokens on a
+            # wall-clock timeout where no ResultMessage is ever emitted.
+            "include_partial_messages": True,
         }
 
         # Add system prompt if provided
@@ -447,6 +459,17 @@ class ClaudeSDKAgentAdapter:
         timeout_reached: bool = False,
     ) -> AgentResult:
         """Build an AgentResult from completed or partial SDK messages."""
+
+        # Collapse partial AssistantMessages to one per turn (the SDK emits
+        # one per content-block-stop, all sharing a message_id) so iterations
+        # and per-message usage reflect real LLM calls rather than partial
+        # snapshots. Then backfill output_tokens from message_delta
+        # StreamEvents into the surviving AssistantMessage.usage dicts BEFORE
+        # downstream consumers run. Both the trace converter and the aggregate
+        # usage summer read AssistantMessage.usage, so a single in-place patch
+        # fixes both.
+        collected_messages = collapse_partial_assistant_messages(collected_messages)
+        backfill_assistant_output_tokens(collected_messages)
 
         raw_trace = self._build_raw_trace(collected_messages)
         if limit_reached:

--- a/src/karenina/adapters/claude_agent_sdk/agent.py
+++ b/src/karenina/adapters/claude_agent_sdk/agent.py
@@ -101,7 +101,11 @@ class ClaudeSDKAgentAdapter:
         Returns:
             PortCapabilities with system_prompt=True.
         """
-        return PortCapabilities(supports_system_prompt=True)
+        return PortCapabilities(
+            supports_system_prompt=True,
+            supports_file_tools=True,
+            supports_code_execution=True,
+        )
 
     def _build_options(
         self,

--- a/src/karenina/adapters/claude_agent_sdk/agent.py
+++ b/src/karenina/adapters/claude_agent_sdk/agent.py
@@ -44,14 +44,13 @@ from karenina.ports import (
     Message,
     Role,
     Tool,
-    UsageMetadata,
 )
 from karenina.ports.capabilities import PortCapabilities
 
 from .mcp import convert_mcp_config
 from .messages import ClaudeSDKMessageConverter
 from .trace import sdk_messages_to_raw_trace
-from .usage import extract_sdk_usage
+from .usage import extract_sdk_usage, extract_sdk_usage_from_messages
 
 if TYPE_CHECKING:
     from claude_agent_sdk import ClaudeAgentOptions, ResultMessage
@@ -462,16 +461,17 @@ class ClaudeSDKAgentAdapter:
         ]
 
         final_response = self._extract_final_response(collected_messages, result_message)
-        usage = (
-            extract_sdk_usage(result_message, model=self._config.model_name)
-            if result_message
-            else UsageMetadata(
-                input_tokens=0,
-                output_tokens=0,
-                total_tokens=0,
-                model=self._config.model_name,
+        # Prefer the SDK-aggregated usage on clean exit; fall back to summing
+        # per-AssistantMessage usage when no ResultMessage was emitted (e.g.
+        # mid-stream cancellation via asyncio.wait_for). Without the fallback,
+        # wall-clock timeouts lose all token accounting even though the
+        # collected messages still carry per-call usage.
+        if result_message:
+            usage = extract_sdk_usage(result_message, model=self._config.model_name)
+        else:
+            usage = extract_sdk_usage_from_messages(
+                collected_messages, model=self._config.model_name
             )
-        )
         turns = result_message.num_turns if result_message and hasattr(result_message, "num_turns") else 0
         actual_model = self._extract_actual_model(collected_messages) or self._config.model_name
         session_id = result_message.session_id if result_message and hasattr(result_message, "session_id") else None

--- a/src/karenina/adapters/claude_agent_sdk/agent.py
+++ b/src/karenina/adapters/claude_agent_sdk/agent.py
@@ -24,8 +24,14 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from karenina.adapters.agent_runtime import get_agent_runtime_capabilities, get_agent_runtime_option
+from karenina.adapters.agent_runtime import (
+    get_agent_runtime_access_mode,
+    get_agent_runtime_capabilities,
+    get_agent_runtime_option,
+    get_claude_sdk_backend,
+)
 from karenina.ports import (
+    AdapterUnavailableError,
     AgentConfig,
     AgentPort,
     AgentResponseError,
@@ -50,6 +56,9 @@ if TYPE_CHECKING:
     from karenina.schemas.config import ModelConfig
 
 logger = logging.getLogger(__name__)
+
+CLAUDE_SDK_READ_ONLY_TOOLS = ("Read", "Grep", "Glob", "LS")
+CLAUDE_SDK_DOCKER_WRAPPER = Path(__file__).with_name("docker_cli_wrapper.py")
 
 
 class ClaudeSDKAgentAdapter:
@@ -108,6 +117,8 @@ class ClaudeSDKAgentAdapter:
     def _build_sandbox_settings(self) -> dict[str, Any] | None:
         """Build Claude Code sandbox settings for Bash isolation."""
 
+        if get_claude_sdk_backend(self._config) == "docker":
+            return None
         if not get_agent_runtime_option(
             self._config,
             "sandbox_enabled",
@@ -137,6 +148,50 @@ class ClaudeSDKAgentAdapter:
             ),
         }
 
+    def _workspace_local_env(self, workspace_path: Path | None) -> dict[str, str]:
+        """Return environment defaults that keep tool state inside a workspace."""
+
+        if workspace_path is None:
+            return {}
+        return {
+            "UV_CACHE_DIR": str(workspace_path / ".uv-cache"),
+            "XDG_CACHE_HOME": str(workspace_path / ".cache"),
+            "UV_PROJECT_ENVIRONMENT": str(workspace_path / ".venv"),
+        }
+
+    def _docker_wrapper_env(self, workspace_path: Path | None) -> dict[str, str]:
+        """Return environment required by the Docker CLI wrapper."""
+
+        if workspace_path is None:
+            raise AdapterUnavailableError(
+                "agent_runtime backend='docker' requires an AgentConfig.workspace_path",
+                reason="missing_workspace",
+            )
+        docker_image = str(get_agent_runtime_option(self._config, "docker_image", ""))
+        if not docker_image:
+            raise AdapterUnavailableError(
+                "agent_runtime docker_image is required when claude_agent_sdk backend='docker'",
+                reason="missing_claude_sdk_docker_image",
+            )
+        docker_network = str(get_agent_runtime_option(self._config, "docker_network", "bridge"))
+        if docker_network not in {"bridge", "none"}:
+            raise AdapterUnavailableError(
+                "agent_runtime docker_network must be 'bridge' or 'none'",
+                reason="invalid_claude_sdk_docker_network",
+            )
+        env = {
+            "KARENINA_CLAUDE_DOCKER_WORKSPACE": str(workspace_path.resolve()),
+            "KARENINA_CLAUDE_DOCKER_IMAGE": docker_image,
+            "KARENINA_CLAUDE_DOCKER_NETWORK": docker_network,
+            "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
+        }
+        docker_add_hosts = get_agent_runtime_option(self._config, "docker_add_hosts", None)
+        if isinstance(docker_add_hosts, str):
+            env["KARENINA_CLAUDE_DOCKER_ADD_HOSTS"] = docker_add_hosts
+        elif isinstance(docker_add_hosts, list):
+            env["KARENINA_CLAUDE_DOCKER_ADD_HOSTS"] = ",".join(str(item) for item in docker_add_hosts)
+        return env
+
     def _build_options(
         self,
         system_prompt: str | None,
@@ -157,14 +212,23 @@ class ClaudeSDKAgentAdapter:
         """
         from claude_agent_sdk import ClaudeAgentOptions
 
+        runtime_backend = get_claude_sdk_backend(self._config)
+        access_mode = get_agent_runtime_access_mode(self._config)
+        default_permission_mode = (
+            "bypassPermissions" if runtime_backend == "docker" and access_mode == "read_write" else "acceptEdits"
+        )
+
         options_kwargs: dict[str, Any] = {
-            # Use sandbox-aware permissions by default. Do not use
-            # bypassPermissions here: allowed_tools does not constrain it.
+            # In native mode, use sandbox-aware permissions by default. For
+            # Docker read-write mode, the container is the execution boundary,
+            # so non-interactive runs need Bash to execute without prompts.
+            # Keep read-only mode on acceptEdits because bypassPermissions does
+            # not respect allowed_tools.
             "permission_mode": str(
                 get_agent_runtime_option(
                     self._config,
                     "permission_mode",
-                    "acceptEdits",
+                    default_permission_mode,
                     legacy_attr="claude_sdk_permission_mode",
                 )
             ),
@@ -211,6 +275,11 @@ class ClaudeSDKAgentAdapter:
             # SDK supports tool filtering via allowed_tools
             options_kwargs["allowed_tools"] = [t.name for t in tools]
 
+        if get_agent_runtime_access_mode(self._config) == "read_only":
+            read_only_tools = list(CLAUDE_SDK_READ_ONLY_TOOLS)
+            options_kwargs["tools"] = read_only_tools
+            options_kwargs["allowed_tools"] = read_only_tools
+
         sandbox_settings = self._build_sandbox_settings()
         if sandbox_settings:
             options_kwargs["sandbox"] = sandbox_settings
@@ -237,11 +306,13 @@ class ClaudeSDKAgentAdapter:
 
         # Build env dict for Anthropic settings (api_key, base_url).
         # The Claude Agent SDK reads ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL from env.
-        env_vars: dict[str, str] = {}
+        env_vars: dict[str, str] = dict(options_kwargs.get("env") or {})
+        workspace_path = config.workspace_path
         if self._config.anthropic_api_key:
             env_vars["ANTHROPIC_API_KEY"] = self._config.anthropic_api_key.get_secret_value()
         if self._config.anthropic_base_url:
             env_vars["ANTHROPIC_BASE_URL"] = self._config.anthropic_base_url
+        env_vars.update(self._workspace_local_env(workspace_path))
         # Forward CLAUDE_CONFIG_DIR from the parent process so the subprocess does
         # not load the user's personal MCP servers from ~/.claude/. Combined with
         # setting_sources=[] below, this mitigates issue 089: 30-40s startup
@@ -249,6 +320,10 @@ class ClaudeSDKAgentAdapter:
         parent_claude_config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
         if parent_claude_config_dir:
             env_vars["CLAUDE_CONFIG_DIR"] = parent_claude_config_dir
+
+        if get_claude_sdk_backend(self._config) == "docker":
+            env_vars.update(self._docker_wrapper_env(workspace_path))
+            options_kwargs["cli_path"] = str(CLAUDE_SDK_DOCKER_WRAPPER)
 
         if env_vars:
             options_kwargs["env"] = env_vars
@@ -335,6 +410,55 @@ class ClaudeSDKAgentAdapter:
                 return msg.model
 
         return None
+
+    def _build_agent_result(
+        self,
+        collected_messages: list[Any],
+        result_message: Any | None,
+        *,
+        limit_reached: bool,
+        timeout_reached: bool = False,
+    ) -> AgentResult:
+        """Build an AgentResult from completed or partial SDK messages."""
+
+        raw_trace = self._build_raw_trace(collected_messages)
+        if limit_reached:
+            raw_trace += "\n\n[Note: Recursion limit reached - partial response shown]"
+        if timeout_reached:
+            raw_trace += "\n\n[Note: Agent timed out - partial trace shown]"
+
+        # Exclude user and system messages: system prompts are captured
+        # separately via tagged_messages injection.
+        trace_messages = [
+            m for m in self._converter.from_provider(collected_messages) if m.role not in (Role.USER, Role.SYSTEM)
+        ]
+
+        final_response = self._extract_final_response(collected_messages, result_message)
+        usage = (
+            extract_sdk_usage(result_message, model=self._config.model_name)
+            if result_message
+            else UsageMetadata(
+                input_tokens=0,
+                output_tokens=0,
+                total_tokens=0,
+                model=self._config.model_name,
+            )
+        )
+        turns = result_message.num_turns if result_message and hasattr(result_message, "num_turns") else 0
+        actual_model = self._extract_actual_model(collected_messages) or self._config.model_name
+        session_id = result_message.session_id if result_message and hasattr(result_message, "session_id") else None
+
+        return AgentResult(
+            final_response=final_response,
+            raw_trace=raw_trace,
+            trace_messages=trace_messages,
+            usage=usage,
+            turns=turns or len([m for m in trace_messages if m.role.value == "assistant"]),
+            limit_reached=limit_reached,
+            session_id=session_id,
+            actual_model=actual_model,
+            timeout_reached=timeout_reached,
+        )
 
     def _convert_mcp_servers(
         self,
@@ -453,6 +577,18 @@ class ClaudeSDKAgentAdapter:
                 await execute_agent()
 
         except TimeoutError as e:
+            if collected_messages:
+                logger.warning(
+                    "Claude SDK agent timed out after %ss with %d partial messages",
+                    config.timeout,
+                    len(collected_messages),
+                )
+                return self._build_agent_result(
+                    collected_messages,
+                    result_message,
+                    limit_reached=limit_reached,
+                    timeout_reached=True,
+                )
             raise AgentTimeoutError(f"Agent execution timed out after {config.timeout}s") from e
         except Exception as e:
             from .errors import wrap_sdk_error
@@ -467,53 +603,10 @@ class ClaudeSDKAgentAdapter:
         if result_message is None and not collected_messages:
             raise AgentResponseError("No messages received from SDK agent")
 
-        # Build raw_trace (legacy string format)
-        raw_trace = self._build_raw_trace(collected_messages)
-        if limit_reached:
-            raw_trace += "\n\n[Note: Recursion limit reached - partial response shown]"
-
-        # Build trace_messages (structured format)
-        # Exclude user and system messages: system prompts are captured
-        # separately via tagged_messages injection.
-        trace_messages = [
-            m for m in self._converter.from_provider(collected_messages) if m.role not in (Role.USER, Role.SYSTEM)
-        ]
-
-        # Extract final response
-        final_response = self._extract_final_response(collected_messages, result_message)
-
-        # Extract usage
-        usage = (
-            extract_sdk_usage(result_message, model=self._config.model_name)
-            if result_message
-            else UsageMetadata(
-                input_tokens=0,
-                output_tokens=0,
-                total_tokens=0,
-                model=self._config.model_name,
-            )
-        )
-
-        # Extract turns from ResultMessage
-        turns = result_message.num_turns if result_message and hasattr(result_message, "num_turns") else 0
-
-        # Extract actual model
-        actual_model = self._extract_actual_model(collected_messages) or self._config.model_name
-
-        # Session ID - SDK may provide one
-        session_id = None
-        if result_message and hasattr(result_message, "session_id"):
-            session_id = result_message.session_id
-
-        return AgentResult(
-            final_response=final_response,
-            raw_trace=raw_trace,
-            trace_messages=trace_messages,
-            usage=usage,
-            turns=turns or len([m for m in trace_messages if m.role.value == "assistant"]),
+        return self._build_agent_result(
+            collected_messages,
+            result_message,
             limit_reached=limit_reached,
-            session_id=session_id,
-            actual_model=actual_model,
         )
 
     def run(
@@ -546,7 +639,7 @@ class ClaudeSDKAgentAdapter:
         """
         from .llm import _run_in_fresh_loop
 
-        timeout = config.timeout if config and config.timeout else 600
+        timeout = (config.timeout + 30) if config and config.timeout else 600
         return _run_in_fresh_loop(
             self.arun,
             messages,

--- a/src/karenina/adapters/claude_agent_sdk/auth.py
+++ b/src/karenina/adapters/claude_agent_sdk/auth.py
@@ -1,0 +1,32 @@
+"""Authentication env helpers for the Claude Agent SDK adapter.
+
+When the parent ``ModelConfig`` provides no ``anthropic_api_key``, this module
+forwards subscription credentials such as ``CLAUDE_CODE_OAUTH_TOKEN`` from the
+host environment to the SDK subprocess. This lets users authenticate the SDK
+through their Claude subscription instead of an Anthropic API key.
+
+The forwarded variables are only added when no explicit API key is configured,
+to keep behavior predictable for callers that already pass credentials through
+the configuration object.
+"""
+
+from __future__ import annotations
+
+import os
+
+SUBSCRIPTION_AUTH_ENV_VARS: tuple[str, ...] = (
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_AUTH_TOKEN",
+)
+
+
+def subscription_auth_env() -> dict[str, str]:
+    """Return subscription auth env vars present in the host environment.
+
+    Returns:
+        Mapping of env variable name to value for every variable in
+        :data:`SUBSCRIPTION_AUTH_ENV_VARS` that is set on the host. The mapping
+        is empty when none are set.
+    """
+
+    return {name: os.environ[name] for name in SUBSCRIPTION_AUTH_ENV_VARS if name in os.environ}

--- a/src/karenina/adapters/claude_agent_sdk/docker_cli_wrapper.py
+++ b/src/karenina/adapters/claude_agent_sdk/docker_cli_wrapper.py
@@ -47,6 +47,7 @@ def _forward_env_dict() -> dict[str, str | None]:
         "CLAUDE_AGENT_SDK_VERSION",
         "CLAUDE_CODE_ENTRYPOINT",
         "CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING",
+        "CLAUDE_CODE_OAUTH_TOKEN",
         "CLAUDE_CODE_STREAM_CLOSE_TIMEOUT",
         "HTTP_PROXY",
         "HTTPS_PROXY",

--- a/src/karenina/adapters/claude_agent_sdk/docker_cli_wrapper.py
+++ b/src/karenina/adapters/claude_agent_sdk/docker_cli_wrapper.py
@@ -36,6 +36,11 @@ def _forward_env_flags() -> list[str]:
     passthrough = [
         "ANTHROPIC_BASE_URL",
         "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL",
+        "API_TIMEOUT_MS",
         "CLAUDE_AGENT_SDK_VERSION",
         "CLAUDE_CODE_ENTRYPOINT",
         "CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING",

--- a/src/karenina/adapters/claude_agent_sdk/docker_cli_wrapper.py
+++ b/src/karenina/adapters/claude_agent_sdk/docker_cli_wrapper.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Docker wrapper used as Claude Agent SDK ``cli_path``.
+
+The Claude Agent SDK expects ``cli_path`` to be an executable compatible with
+the Claude Code CLI. This wrapper preserves that contract while launching the
+real ``claude`` executable inside a configured Docker image.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+from contextlib import suppress
+from urllib.parse import urlparse
+
+SANDBOX_WORKSPACE_PATH = "/workspace"
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        print(f"{name} is required for Claude SDK Docker runtime", file=sys.stderr)
+        raise SystemExit(2)
+    return value
+
+
+def _env_flag(name: str, value: str | None = None) -> list[str]:
+    if value is None:
+        return ["--env", name]
+    return ["--env", f"{name}={value}"]
+
+
+def _forward_env_flags() -> list[str]:
+    flags: list[str] = []
+    passthrough = [
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_AGENT_SDK_VERSION",
+        "CLAUDE_CODE_ENTRYPOINT",
+        "CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING",
+        "CLAUDE_CODE_STREAM_CLOSE_TIMEOUT",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    ]
+    for name in passthrough:
+        if name in os.environ:
+            flags.extend(_env_flag(name))
+
+    flags.extend(
+        [
+            *_env_flag("HOME", "/tmp"),
+            *_env_flag("CLAUDE_CONFIG_DIR", os.environ.get("CLAUDE_CONFIG_DIR", "/tmp/claude-config")),
+            *_env_flag("UV_LINK_MODE", "copy"),
+            *_env_flag("UV_CACHE_DIR", "/tmp/uv-cache"),
+            *_env_flag(
+                "PATH",
+                "/workspace/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            ),
+        ]
+    )
+    return flags
+
+
+def _rewrite_workspace_args(args: list[str], host_workspace: str) -> list[str]:
+    return [arg.replace(host_workspace, SANDBOX_WORKSPACE_PATH) for arg in args]
+
+
+def _add_host_flags() -> list[str]:
+    flags: list[str] = []
+    configured = os.environ.get("KARENINA_CLAUDE_DOCKER_ADD_HOSTS")
+    if configured:
+        for host_mapping in configured.split(","):
+            host_mapping = host_mapping.strip()
+            if host_mapping:
+                flags.extend(["--add-host", host_mapping])
+
+    endpoint = os.environ.get("ANTHROPIC_BASE_URL")
+    if not endpoint:
+        return flags
+    hostname = urlparse(endpoint).hostname
+    if not hostname or hostname in {"localhost", "127.0.0.1", "::1"}:
+        return flags
+    try:
+        socket.inet_aton(hostname)
+        return flags
+    except OSError:
+        pass
+    with suppress(OSError):
+        flags.extend(["--add-host", f"{hostname}:{socket.gethostbyname(hostname)}"])
+    return flags
+
+
+def build_docker_command(argv: list[str] | None = None) -> list[str]:
+    """Build the Docker command for tests and for ``main``."""
+
+    argv = list(sys.argv[1:] if argv is None else argv)
+    host_workspace = _required_env("KARENINA_CLAUDE_DOCKER_WORKSPACE")
+    image = _required_env("KARENINA_CLAUDE_DOCKER_IMAGE")
+    network = os.environ.get("KARENINA_CLAUDE_DOCKER_NETWORK", "bridge")
+    if network not in {"bridge", "none"}:
+        print("KARENINA_CLAUDE_DOCKER_NETWORK must be 'bridge' or 'none'", file=sys.stderr)
+        raise SystemExit(2)
+
+    command = [
+        "docker",
+        "run",
+        "--rm",
+        "-i",
+        "--network",
+        network,
+        "--workdir",
+        SANDBOX_WORKSPACE_PATH,
+        "--volume",
+        f"{host_workspace}:{SANDBOX_WORKSPACE_PATH}:rw",
+        *_add_host_flags(),
+        *_forward_env_flags(),
+        "--pids-limit",
+        "256",
+    ]
+
+    if hasattr(os, "getuid") and hasattr(os, "getgid"):
+        command.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+
+    command.extend([image, "claude", *_rewrite_workspace_args(argv, host_workspace)])
+    return command
+
+
+def main() -> None:
+    command = build_docker_command()
+    os.execvp(command[0], command)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/karenina/adapters/claude_agent_sdk/docker_cli_wrapper.py
+++ b/src/karenina/adapters/claude_agent_sdk/docker_cli_wrapper.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Docker wrapper used as Claude Agent SDK ``cli_path``.
+"""Container wrapper used as Claude Agent SDK ``cli_path``.
 
 The Claude Agent SDK expects ``cli_path`` to be an executable compatible with
-the Claude Code CLI. This wrapper preserves that contract while launching the
-real ``claude`` executable inside a configured Docker image.
+the Claude Code CLI. This wrapper preserves that contract while launching
+the real ``claude`` executable inside a configured container image.
 """
 
 from __future__ import annotations
@@ -12,27 +12,30 @@ import os
 import socket
 import sys
 from contextlib import suppress
+from pathlib import Path
 from urllib.parse import urlparse
 
-SANDBOX_WORKSPACE_PATH = "/workspace"
+from karenina.adapters.agent_runtime import (
+    SANDBOX_WORKSPACE_PATH,
+    ContainerRuntimeConfig,
+)
+from karenina.adapters.agent_runtime import (
+    build_container_command as build_runtime_container_command,
+)
 
 
-def _required_env(name: str) -> str:
-    value = os.environ.get(name)
-    if not value:
-        print(f"{name} is required for Claude SDK Docker runtime", file=sys.stderr)
-        raise SystemExit(2)
-    return value
+def _env_with_legacy(preferred: str, legacy: str | None = None, default: str | None = None) -> str | None:
+    value = os.environ.get(preferred)
+    if value:
+        return value
+    if legacy:
+        value = os.environ.get(legacy)
+        if value:
+            return value
+    return default
 
 
-def _env_flag(name: str, value: str | None = None) -> list[str]:
-    if value is None:
-        return ["--env", name]
-    return ["--env", f"{name}={value}"]
-
-
-def _forward_env_flags() -> list[str]:
-    flags: list[str] = []
+def _forward_env_dict() -> dict[str, str | None]:
     passthrough = [
         "ANTHROPIC_BASE_URL",
         "ANTHROPIC_API_KEY",
@@ -52,23 +55,17 @@ def _forward_env_flags() -> list[str]:
         "https_proxy",
         "no_proxy",
     ]
-    for name in passthrough:
-        if name in os.environ:
-            flags.extend(_env_flag(name))
-
-    flags.extend(
-        [
-            *_env_flag("HOME", "/tmp"),
-            *_env_flag("CLAUDE_CONFIG_DIR", os.environ.get("CLAUDE_CONFIG_DIR", "/tmp/claude-config")),
-            *_env_flag("UV_LINK_MODE", "copy"),
-            *_env_flag("UV_CACHE_DIR", "/tmp/uv-cache"),
-            *_env_flag(
-                "PATH",
-                "/workspace/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-            ),
-        ]
+    env: dict[str, str | None] = {name: None for name in passthrough if name in os.environ}
+    env.update(
+        {
+            "HOME": "/tmp",
+            "CLAUDE_CONFIG_DIR": os.environ.get("CLAUDE_CONFIG_DIR", "/tmp/claude-config"),
+            "UV_LINK_MODE": "copy",
+            "UV_CACHE_DIR": "/tmp/uv-cache",
+            "PATH": "/workspace/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        }
     )
-    return flags
+    return env
 
 
 def _rewrite_workspace_args(args: list[str], host_workspace: str) -> list[str]:
@@ -77,7 +74,7 @@ def _rewrite_workspace_args(args: list[str], host_workspace: str) -> list[str]:
 
 def _add_host_flags() -> list[str]:
     flags: list[str] = []
-    configured = os.environ.get("KARENINA_CLAUDE_DOCKER_ADD_HOSTS")
+    configured = _env_with_legacy("KARENINA_CLAUDE_CONTAINER_ADD_HOSTS", "KARENINA_CLAUDE_DOCKER_ADD_HOSTS")
     if configured:
         for host_mapping in configured.split(","):
             host_mapping = host_mapping.strip()
@@ -100,43 +97,72 @@ def _add_host_flags() -> list[str]:
     return flags
 
 
-def build_docker_command(argv: list[str] | None = None) -> list[str]:
-    """Build the Docker command for tests and for ``main``."""
+def _container_config() -> ContainerRuntimeConfig:
+    runtime = _env_with_legacy("KARENINA_CLAUDE_CONTAINER_RUNTIME", default="docker") or "docker"
+    image = _env_with_legacy("KARENINA_CLAUDE_CONTAINER_IMAGE", "KARENINA_CLAUDE_DOCKER_IMAGE")
+    network = _env_with_legacy("KARENINA_CLAUDE_CONTAINER_NETWORK", "KARENINA_CLAUDE_DOCKER_NETWORK", "bridge")
+    add_hosts = _env_with_legacy("KARENINA_CLAUDE_CONTAINER_ADD_HOSTS", "KARENINA_CLAUDE_DOCKER_ADD_HOSTS")
+    return ContainerRuntimeConfig(
+        runtime=runtime,
+        image=image,
+        network=network or "bridge",
+        add_hosts=tuple(host.strip() for host in (add_hosts or "").split(",") if host.strip()),
+    )
+
+
+def build_container_command(argv: list[str] | None = None) -> list[str]:
+    """Build the configured container command for tests and for ``main``."""
 
     argv = list(sys.argv[1:] if argv is None else argv)
-    host_workspace = _required_env("KARENINA_CLAUDE_DOCKER_WORKSPACE")
-    image = _required_env("KARENINA_CLAUDE_DOCKER_IMAGE")
-    network = os.environ.get("KARENINA_CLAUDE_DOCKER_NETWORK", "bridge")
-    if network not in {"bridge", "none"}:
-        print("KARENINA_CLAUDE_DOCKER_NETWORK must be 'bridge' or 'none'", file=sys.stderr)
+    host_workspace = _env_with_legacy("KARENINA_CLAUDE_CONTAINER_WORKSPACE", "KARENINA_CLAUDE_DOCKER_WORKSPACE")
+    if not host_workspace:
+        print("KARENINA_CLAUDE_CONTAINER_WORKSPACE is required for Claude SDK container runtime", file=sys.stderr)
         raise SystemExit(2)
 
-    command = [
-        "docker",
-        "run",
-        "--rm",
-        "-i",
-        "--network",
-        network,
-        "--workdir",
-        SANDBOX_WORKSPACE_PATH,
-        "--volume",
-        f"{host_workspace}:{SANDBOX_WORKSPACE_PATH}:rw",
-        *_add_host_flags(),
-        *_forward_env_flags(),
-        "--pids-limit",
-        "256",
-    ]
+    config = _container_config()
+    if not config.image:
+        print("KARENINA_CLAUDE_CONTAINER_IMAGE is required for Claude SDK container runtime", file=sys.stderr)
+        raise SystemExit(2)
+    if config.runtime == "docker" and config.network not in {"bridge", "none"}:
+        print("KARENINA_CLAUDE_CONTAINER_NETWORK must be 'bridge' or 'none' for Docker", file=sys.stderr)
+        raise SystemExit(2)
+    if config.runtime != "docker" and config.add_hosts:
+        print("KARENINA_CLAUDE_CONTAINER_ADD_HOSTS is Docker-only", file=sys.stderr)
+        raise SystemExit(2)
+    if config.runtime != "docker" and Path(config.image).suffix != ".sif":
+        print("KARENINA_CLAUDE_CONTAINER_IMAGE must be a local .sif file for Singularity/Apptainer", file=sys.stderr)
+        raise SystemExit(2)
 
-    if hasattr(os, "getuid") and hasattr(os, "getgid"):
-        command.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+    add_hosts = list(config.add_hosts)
+    if config.runtime == "docker":
+        auto_hosts = _add_host_flags()
+        for index, token in enumerate(auto_hosts):
+            if token == "--add-host" and index + 1 < len(auto_hosts):
+                add_hosts.append(auto_hosts[index + 1])
+        config = ContainerRuntimeConfig(
+            runtime=config.runtime,
+            image=config.image,
+            network=config.network,
+            add_hosts=tuple(add_hosts),
+        )
 
-    command.extend([image, "claude", *_rewrite_workspace_args(argv, host_workspace)])
-    return command
+    return build_runtime_container_command(
+        config=config,
+        host_workspace=host_workspace,
+        argv=["claude", *_rewrite_workspace_args(argv, host_workspace)],
+        env=_forward_env_dict(),
+        interactive=True,
+    )
+
+
+def build_docker_command(argv: list[str] | None = None) -> list[str]:
+    """Compatibility alias for existing tests and imports."""
+
+    return build_container_command(argv)
 
 
 def main() -> None:
-    command = build_docker_command()
+    command = build_container_command()
     os.execvp(command[0], command)
 
 

--- a/src/karenina/adapters/claude_agent_sdk/llm.py
+++ b/src/karenina/adapters/claude_agent_sdk/llm.py
@@ -31,6 +31,7 @@ from karenina.ports.llm import StreamingLLMResponse
 from karenina.utils.errors import ErrorRegistry
 from karenina.utils.retry_policy import RetryExecutor, RetryPolicy
 
+from .auth import subscription_auth_env
 from .messages import ClaudeSDKMessageConverter
 from .usage import extract_sdk_usage
 
@@ -197,6 +198,8 @@ class ClaudeSDKLLMAdapter:
         env_vars: dict[str, str] = {}
         if self._config.anthropic_api_key:
             env_vars["ANTHROPIC_API_KEY"] = self._config.anthropic_api_key.get_secret_value()
+        else:
+            env_vars.update(subscription_auth_env())
         if self._config.anthropic_base_url:
             env_vars["ANTHROPIC_BASE_URL"] = self._config.anthropic_base_url
 

--- a/src/karenina/adapters/claude_agent_sdk/messages.py
+++ b/src/karenina/adapters/claude_agent_sdk/messages.py
@@ -169,6 +169,44 @@ class ClaudeSDKMessageConverter:
                 text_parts.append(block.text)
         return Message.user("\n".join(text_parts) if text_parts else "")
 
+    def _extract_assistant_usage(self, msg: AssistantMessage) -> dict[str, int] | None:
+        """Extract per-call usage metadata from an SDK AssistantMessage.
+
+        SDK AssistantMessage exposes an Anthropic-shaped usage dict with
+        input_tokens / output_tokens (always) and optional cache fields
+        (cache_read_input_tokens / cache_creation_input_tokens).
+
+        Mirrors the extraction logic in
+        ``claude_agent_sdk/trace.py::sdk_messages_to_trace_messages`` so the
+        Message-based production trace path carries the same per-turn
+        accounting as the direct-to-dict helper.
+
+        Args:
+            msg: SDK AssistantMessage instance.
+
+        Returns:
+            Dict with input_tokens / output_tokens (and any reported cache
+            fields), or None when no usage is reported (missing attribute
+            or empty/falsy dict).
+        """
+        usage_data = getattr(msg, "usage", None)
+        if not usage_data:
+            return None
+
+        per_call: dict[str, int] = {
+            "input_tokens": int(usage_data.get("input_tokens", 0) or 0),
+            "output_tokens": int(usage_data.get("output_tokens", 0) or 0),
+        }
+        # Only include cache fields when reported, so we can distinguish
+        # "not reported" from a real zero.
+        cache_read = usage_data.get("cache_read_input_tokens")
+        if cache_read is not None:
+            per_call["cache_read_input_tokens"] = int(cache_read)
+        cache_creation = usage_data.get("cache_creation_input_tokens")
+        if cache_creation is not None:
+            per_call["cache_creation_input_tokens"] = int(cache_creation)
+        return per_call
+
     def _convert_assistant_message(
         self,
         msg: AssistantMessage,
@@ -263,9 +301,18 @@ class ClaudeSDKMessageConverter:
             # Add tool calls
             content.extend(tool_calls)
 
+            # Extract per-call usage so it survives end-to-end into
+            # template.trace_messages[*].usage_metadata for both CSDK and
+            # DA interfaces.
+            usage_metadata = self._extract_assistant_usage(msg)
+
             result.insert(
                 0,
-                Message(role=Role.ASSISTANT, content=content),  # type: ignore[arg-type]
+                Message(
+                    role=Role.ASSISTANT,
+                    content=content,  # type: ignore[arg-type]
+                    usage_metadata=usage_metadata,
+                ),
             )
 
         return result

--- a/src/karenina/adapters/claude_agent_sdk/parser.py
+++ b/src/karenina/adapters/claude_agent_sdk/parser.py
@@ -87,6 +87,14 @@ def _derive_openai_base_url(anthropic_base_url: str) -> str:
     return f"{parsed.scheme}://{parsed.netloc}/v1"
 
 
+def _configured_openai_base_url(model_config: ModelConfig) -> str | None:
+    """Return an explicit OpenAI-compatible parser endpoint override, if configured."""
+
+    extra_kwargs = getattr(model_config, "extra_kwargs", None) or {}
+    value = extra_kwargs.get("claude_sdk_parser_openai_base_url")
+    return str(value) if value else None
+
+
 class ClaudeSDKParserAdapter:
     """Parser adapter using direct API calls for structured output.
 
@@ -156,7 +164,9 @@ class ClaudeSDKParserAdapter:
         if self._openai_client is None:
             from openai import AsyncOpenAI
 
-            base_url = _derive_openai_base_url(self._config.anthropic_base_url)  # type: ignore[arg-type]
+            base_url = _configured_openai_base_url(self._config) or _derive_openai_base_url(
+                self._config.anthropic_base_url  # type: ignore[arg-type]
+            )
             api_key = self._config.anthropic_api_key.get_secret_value() if self._config.anthropic_api_key else "EMPTY"
             kwargs: dict[str, Any] = {
                 "api_key": api_key,

--- a/src/karenina/adapters/claude_agent_sdk/trace.py
+++ b/src/karenina/adapters/claude_agent_sdk/trace.py
@@ -213,6 +213,27 @@ def sdk_messages_to_trace_messages(
                 if hasattr(msg, "model") and msg.model:
                     trace_msg["model"] = msg.model
 
+                # Add per-call usage metadata if present so post-hoc audit of
+                # token usage / cache hits per turn is preserved. SDK
+                # AssistantMessage exposes Anthropic-shaped usage dict with
+                # input_tokens / output_tokens (always) and optional cache
+                # fields (cache_read_input_tokens / cache_creation_input_tokens).
+                if hasattr(msg, "usage") and msg.usage:
+                    usage_data = msg.usage
+                    per_call_usage: dict[str, int] = {
+                        "input_tokens": int(usage_data.get("input_tokens", 0) or 0),
+                        "output_tokens": int(usage_data.get("output_tokens", 0) or 0),
+                    }
+                    # Only include cache fields when reported, so we can
+                    # distinguish "not reported" from a real zero.
+                    cache_read = usage_data.get("cache_read_input_tokens")
+                    if cache_read is not None:
+                        per_call_usage["cache_read_input_tokens"] = int(cache_read)
+                    cache_creation = usage_data.get("cache_creation_input_tokens")
+                    if cache_creation is not None:
+                        per_call_usage["cache_creation_input_tokens"] = int(cache_creation)
+                    trace_msg["usage_metadata"] = per_call_usage
+
                 result.append(trace_msg)
                 block_index += 1
 

--- a/src/karenina/adapters/claude_agent_sdk/usage.py
+++ b/src/karenina/adapters/claude_agent_sdk/usage.py
@@ -189,7 +189,7 @@ def backfill_assistant_output_tokens(messages: list[Any]) -> None:
             ``include_partial_messages=True`` option.
     """
     try:
-        from claude_agent_sdk import AssistantMessage, StreamEvent
+        from claude_agent_sdk import AssistantMessage, StreamEvent  # type: ignore[attr-defined]
     except ImportError:
         return
 
@@ -220,7 +220,7 @@ def backfill_assistant_output_tokens(messages: list[Any]) -> None:
         msg_id = getattr(msg, "message_id", None)
         if msg_id is None or msg_id not in delta_output_by_msgid:
             continue
-        current_usage = msg.usage or {}
+        current_usage = msg.usage or {}  # type: ignore[attr-defined]
         existing_output = int(current_usage.get("output_tokens", 0) or 0)
         if existing_output != 0:
             # Don't clobber a real non-zero value reported by canonical
@@ -228,7 +228,7 @@ def backfill_assistant_output_tokens(messages: list[Any]) -> None:
             continue
         patched = dict(current_usage)
         patched["output_tokens"] = delta_output_by_msgid[msg_id]
-        msg.usage = patched
+        msg.usage = patched  # type: ignore[attr-defined]
 
 
 def extract_sdk_usage_from_messages(

--- a/src/karenina/adapters/claude_agent_sdk/usage.py
+++ b/src/karenina/adapters/claude_agent_sdk/usage.py
@@ -85,61 +85,77 @@ def extract_sdk_usage(
 
 
 def collapse_partial_assistant_messages(messages: list[Any]) -> list[Any]:
-    """Collapse multiple partial ``AssistantMessage`` events to one per turn.
+    """Merge multiple partial ``AssistantMessage`` events into one per turn.
 
-    The SDK emits one ``AssistantMessage`` per ``content_block_stop`` event,
-    not per LLM turn. A single turn that produces a thinking block plus a
-    text block plus a tool-use block will surface as three ``AssistantMessage``
-    objects, all sharing the same ``message_id`` and the same input-token
-    count. Each successive emission carries more content blocks than the
-    previous one (it accumulates progress), so the LAST emission for a given
-    ``message_id`` is the most complete representation of the turn.
+    The CLI subprocess emits one ``AssistantMessage`` per ``content_block_stop``
+    event, not per LLM turn. A single turn that produces a thinking block plus
+    a text block plus a tool-use block surfaces as three ``AssistantMessage``
+    objects: each carrying only the single block that just finished, all
+    sharing the same ``message_id`` and the same ``message_start``-state usage
+    dict. The blocks do NOT accumulate across emissions — every emission
+    contains exactly one block.
 
-    Without this collapse:
-      * ``agent_metrics.iterations`` counts content blocks, not LLM turns
-        (a 22-turn run reports ~50 iterations).
+    Without merging:
+      * ``trace_messages`` (derived from the messages) has 2-3× the count
+        of real LLM turns; ``agent_metrics.iterations`` is inflated.
       * ``extract_sdk_usage_from_messages`` double- or triple-counts input
-        tokens on a wall-clock timeout where ``ResultMessage`` is absent.
-      * The raw trace shows the same turn split across multiple "AI Message"
-        sections.
+        tokens on a wall-clock timeout where ``ResultMessage`` is absent
+        (all emissions for one turn share the same input-token snapshot).
 
-    AssistantMessages with no ``message_id`` and all non-``AssistantMessage``
+    Naive de-duplication (keeping only the last per ``message_id``) would
+    drop the earlier blocks — typically losing thinking and text content
+    while preserving only the final tool-use block. To avoid that, this
+    helper merges all blocks for a given ``message_id`` into the LAST
+    emission's ``content`` list (preserving source order), then drops the
+    earlier emissions. The surviving emission keeps its own ``usage``,
+    ``model``, ``stop_reason``, etc. — these are stable across partials
+    sharing a ``message_id``.
+
+    AssistantMessages without a ``message_id`` and all non-``AssistantMessage``
     entries are passed through unchanged in their original positions. The
-    relative order of distinct turns is preserved: each turn appears at the
-    position of its LAST partial emission, so the resulting sequence still
-    interleaves correctly with surrounding ``StreamEvent`` / ``UserMessage``
-    / ``ResultMessage`` records.
+    relative order of distinct turns is preserved: each merged turn appears
+    at the position of its LAST partial emission, so the resulting sequence
+    still interleaves correctly with surrounding ``StreamEvent`` /
+    ``UserMessage`` / ``ResultMessage`` records.
 
     Args:
         messages: Mixed collection from ``ClaudeSDKClient.receive_response()``.
 
     Returns:
-        New list with at most one ``AssistantMessage`` per ``message_id``.
+        New list with at most one ``AssistantMessage`` per ``message_id``,
+        each carrying the concatenated content of all its partial emissions.
     """
     try:
         from claude_agent_sdk import AssistantMessage
     except ImportError:
         return list(messages)
 
-    # First pass: find the index of the LAST occurrence for each message_id.
+    # Pass 1: bucket content blocks by message_id and find the last
+    # emission's index for each id.
+    blocks_by_msgid: dict[str, list[Any]] = {}
     last_index_by_msgid: dict[str, int] = {}
     for i, msg in enumerate(messages):
-        if isinstance(msg, AssistantMessage):
-            mid = getattr(msg, "message_id", None)
-            if mid is not None:
-                last_index_by_msgid[mid] = i
+        if not isinstance(msg, AssistantMessage):
+            continue
+        mid = getattr(msg, "message_id", None)
+        if mid is None:
+            continue
+        blocks_by_msgid.setdefault(mid, []).extend(msg.content or [])
+        last_index_by_msgid[mid] = i
 
     if not last_index_by_msgid:
         return list(messages)
 
-    # Second pass: emit each entry, dropping earlier duplicates of any
-    # AssistantMessage that has a later occurrence with the same message_id.
+    # Pass 2: rewrite the last emission for each group with the merged
+    # block list, then emit each entry, dropping earlier partials.
     result: list[Any] = []
     for i, msg in enumerate(messages):
         if isinstance(msg, AssistantMessage):
             mid = getattr(msg, "message_id", None)
-            if mid is not None and last_index_by_msgid[mid] != i:
-                continue
+            if mid is not None:
+                if last_index_by_msgid[mid] != i:
+                    continue
+                msg.content = blocks_by_msgid[mid]
         result.append(msg)
     return result
 

--- a/src/karenina/adapters/claude_agent_sdk/usage.py
+++ b/src/karenina/adapters/claude_agent_sdk/usage.py
@@ -82,3 +82,75 @@ def extract_sdk_usage(
         cache_creation_tokens=int(cache_creation) if cache_creation is not None else None,
         model=model,
     )
+
+
+def extract_sdk_usage_from_messages(
+    messages: list[Any],
+    model: str | None = None,
+) -> UsageMetadata:
+    """Aggregate per-message usage from SDK AssistantMessage objects.
+
+    The SDK's ``ResultMessage`` is only emitted on a clean loop exit, so when
+    an agent run is cancelled mid-stream (e.g. ``asyncio.wait_for`` timeout)
+    no aggregate usage is available. Individual ``AssistantMessage`` objects
+    collected before the cancellation still carry their per-call ``usage``
+    dict though, so we can reconstruct the run-level totals by summing them.
+
+    This mirrors the per-message aggregation that
+    ``extract_deep_agents_usage`` performs for LangChain AIMessage objects.
+
+    Args:
+        messages: List of SDK message objects collected during the run.
+            Only ``AssistantMessage`` instances are considered; other types
+            (UserMessage, ResultMessage, etc.) are skipped.
+        model: Optional model name to record on the result.
+
+    Returns:
+        ``UsageMetadata`` with summed tokens. Cache fields are summed only
+        when at least one message reports them, otherwise left ``None``.
+
+    Notes:
+        Cost is intentionally NOT estimated here. SDK cost figures live on
+        the ``ResultMessage`` (``total_cost_usd``) which is absent in the
+        partial-trace scenarios this helper exists to handle.
+    """
+    try:
+        from claude_agent_sdk import AssistantMessage
+    except ImportError:
+        return UsageMetadata(model=model)
+
+    total_input = 0
+    total_output = 0
+    cache_read_total = 0
+    cache_creation_total = 0
+    saw_cache_read = False
+    saw_cache_creation = False
+
+    for msg in messages:
+        if not isinstance(msg, AssistantMessage):
+            continue
+        usage_data: dict[str, Any] | None = getattr(msg, "usage", None)
+        if not usage_data or not isinstance(usage_data, dict):
+            continue
+
+        total_input += int(usage_data.get("input_tokens", 0) or 0)
+        total_output += int(usage_data.get("output_tokens", 0) or 0)
+
+        cache_read = usage_data.get("cache_read_input_tokens")
+        if cache_read is not None:
+            cache_read_total += int(cache_read)
+            saw_cache_read = True
+
+        cache_creation = usage_data.get("cache_creation_input_tokens")
+        if cache_creation is not None:
+            cache_creation_total += int(cache_creation)
+            saw_cache_creation = True
+
+    return UsageMetadata(
+        input_tokens=total_input,
+        output_tokens=total_output,
+        total_tokens=total_input + total_output,
+        cache_read_tokens=cache_read_total if saw_cache_read else None,
+        cache_creation_tokens=cache_creation_total if saw_cache_creation else None,
+        model=model,
+    )

--- a/src/karenina/adapters/claude_agent_sdk/usage.py
+++ b/src/karenina/adapters/claude_agent_sdk/usage.py
@@ -84,6 +84,137 @@ def extract_sdk_usage(
     )
 
 
+def collapse_partial_assistant_messages(messages: list[Any]) -> list[Any]:
+    """Collapse multiple partial ``AssistantMessage`` events to one per turn.
+
+    The SDK emits one ``AssistantMessage`` per ``content_block_stop`` event,
+    not per LLM turn. A single turn that produces a thinking block plus a
+    text block plus a tool-use block will surface as three ``AssistantMessage``
+    objects, all sharing the same ``message_id`` and the same input-token
+    count. Each successive emission carries more content blocks than the
+    previous one (it accumulates progress), so the LAST emission for a given
+    ``message_id`` is the most complete representation of the turn.
+
+    Without this collapse:
+      * ``agent_metrics.iterations`` counts content blocks, not LLM turns
+        (a 22-turn run reports ~50 iterations).
+      * ``extract_sdk_usage_from_messages`` double- or triple-counts input
+        tokens on a wall-clock timeout where ``ResultMessage`` is absent.
+      * The raw trace shows the same turn split across multiple "AI Message"
+        sections.
+
+    AssistantMessages with no ``message_id`` and all non-``AssistantMessage``
+    entries are passed through unchanged in their original positions. The
+    relative order of distinct turns is preserved: each turn appears at the
+    position of its LAST partial emission, so the resulting sequence still
+    interleaves correctly with surrounding ``StreamEvent`` / ``UserMessage``
+    / ``ResultMessage`` records.
+
+    Args:
+        messages: Mixed collection from ``ClaudeSDKClient.receive_response()``.
+
+    Returns:
+        New list with at most one ``AssistantMessage`` per ``message_id``.
+    """
+    try:
+        from claude_agent_sdk import AssistantMessage
+    except ImportError:
+        return list(messages)
+
+    # First pass: find the index of the LAST occurrence for each message_id.
+    last_index_by_msgid: dict[str, int] = {}
+    for i, msg in enumerate(messages):
+        if isinstance(msg, AssistantMessage):
+            mid = getattr(msg, "message_id", None)
+            if mid is not None:
+                last_index_by_msgid[mid] = i
+
+    if not last_index_by_msgid:
+        return list(messages)
+
+    # Second pass: emit each entry, dropping earlier duplicates of any
+    # AssistantMessage that has a later occurrence with the same message_id.
+    result: list[Any] = []
+    for i, msg in enumerate(messages):
+        if isinstance(msg, AssistantMessage):
+            mid = getattr(msg, "message_id", None)
+            if mid is not None and last_index_by_msgid[mid] != i:
+                continue
+        result.append(msg)
+    return result
+
+
+def backfill_assistant_output_tokens(messages: list[Any]) -> None:
+    """Backfill ``output_tokens`` on ``AssistantMessage`` records in-place.
+
+    On backends where ``output_tokens`` is only finalised in the streaming
+    ``message_delta`` event (e.g. vLLM, sglang, and any non-canonical Anthropic
+    shim), ``AssistantMessage.usage`` reflects only ``message_start`` state and
+    reports ``output_tokens=0``. When the agent run is cancelled mid-stream
+    (wall-clock timeout) no ``ResultMessage`` is emitted, so per-message
+    aggregation is the only signal left — and it under-reports output tokens
+    to zero.
+
+    With ``ClaudeAgentOptions(include_partial_messages=True)`` the SDK exposes
+    the raw stream events as ``StreamEvent`` objects. This helper extracts the
+    final ``output_tokens`` from each ``message_delta`` event, correlates it
+    with the parent ``AssistantMessage`` by ``message_id``, and patches the
+    usage dict in place. Downstream consumers (trace conversion, aggregate
+    summation) see corrected per-call usage without further changes.
+
+    The patch is idempotent and never decreases a non-zero value: if the SDK
+    already reported a real output count (e.g. canonical Anthropic), the
+    delta value is ignored.
+
+    Args:
+        messages: Mixed collection of SDK message objects as collected from
+            ``ClaudeSDKClient.receive_response()``. ``StreamEvent`` objects
+            must be present for backfill to happen — that requires the
+            ``include_partial_messages=True`` option.
+    """
+    try:
+        from claude_agent_sdk import AssistantMessage, StreamEvent
+    except ImportError:
+        return
+
+    # Walk the event stream once to map message_id -> final output_tokens.
+    # In Anthropic's streaming protocol every message_delta belongs to the
+    # most recent message_start, so a single rolling pointer is enough.
+    delta_output_by_msgid: dict[str, int] = {}
+    current_msgid: str | None = None
+    for msg in messages:
+        if not isinstance(msg, StreamEvent):
+            continue
+        event = getattr(msg, "event", None) or {}
+        event_type = event.get("type")
+        if event_type == "message_start":
+            current_msgid = (event.get("message") or {}).get("id")
+        elif event_type == "message_delta" and current_msgid is not None:
+            usage = event.get("usage") or {}
+            output_tokens = usage.get("output_tokens")
+            if output_tokens is not None:
+                delta_output_by_msgid[current_msgid] = int(output_tokens)
+
+    if not delta_output_by_msgid:
+        return
+
+    for msg in messages:
+        if not isinstance(msg, AssistantMessage):
+            continue
+        msg_id = getattr(msg, "message_id", None)
+        if msg_id is None or msg_id not in delta_output_by_msgid:
+            continue
+        current_usage = msg.usage or {}
+        existing_output = int(current_usage.get("output_tokens", 0) or 0)
+        if existing_output != 0:
+            # Don't clobber a real non-zero value reported by canonical
+            # Anthropic endpoints.
+            continue
+        patched = dict(current_usage)
+        patched["output_tokens"] = delta_output_by_msgid[msg_id]
+        msg.usage = patched
+
+
 def extract_sdk_usage_from_messages(
     messages: list[Any],
     model: str | None = None,

--- a/src/karenina/adapters/claude_tool/agent.py
+++ b/src/karenina/adapters/claude_tool/agent.py
@@ -104,7 +104,11 @@ class ClaudeToolAgentAdapter:
         Returns:
             PortCapabilities with system_prompt=True.
         """
-        return PortCapabilities(supports_system_prompt=True)
+        return PortCapabilities(
+            supports_system_prompt=True,
+            supports_file_tools=True,
+            supports_code_execution=True,
+        )
 
     def _get_async_client(self) -> Any:
         """Get or create the async Anthropic client."""

--- a/src/karenina/adapters/langchain_deep_agents/__init__.py
+++ b/src/karenina/adapters/langchain_deep_agents/__init__.py
@@ -18,6 +18,7 @@ Utilities:
     - convert_mcp_to_tools: Convert MCPServerConfig to LangChain tools
     - extract_deep_agents_usage: Extract UsageMetadata from agent results
     - deep_agents_messages_to_raw_trace: Format messages as raw trace string
+    - deep_agents_messages_to_trace_messages: Structured trace_messages with per-call usage
 """
 
 from typing import TYPE_CHECKING, Any
@@ -31,6 +32,7 @@ __all__ = [
     "convert_mcp_to_tools",
     "extract_deep_agents_usage",
     "deep_agents_messages_to_raw_trace",
+    "deep_agents_messages_to_trace_messages",
     "wrap_deep_agents_error",
 ]
 
@@ -42,7 +44,10 @@ if TYPE_CHECKING:
     from karenina.adapters.langchain_deep_agents.mcp import convert_mcp_to_tools
     from karenina.adapters.langchain_deep_agents.messages import DeepAgentsMessageConverter
     from karenina.adapters.langchain_deep_agents.parser import DeepAgentsParserAdapter
-    from karenina.adapters.langchain_deep_agents.trace import deep_agents_messages_to_raw_trace
+    from karenina.adapters.langchain_deep_agents.trace import (
+        deep_agents_messages_to_raw_trace,
+        deep_agents_messages_to_trace_messages,
+    )
     from karenina.adapters.langchain_deep_agents.usage import extract_deep_agents_usage
 
 
@@ -57,6 +62,7 @@ def __getattr__(name: str) -> Any:
         "convert_mcp_to_tools": "karenina.adapters.langchain_deep_agents.mcp",
         "extract_deep_agents_usage": "karenina.adapters.langchain_deep_agents.usage",
         "deep_agents_messages_to_raw_trace": "karenina.adapters.langchain_deep_agents.trace",
+        "deep_agents_messages_to_trace_messages": "karenina.adapters.langchain_deep_agents.trace",
         "wrap_deep_agents_error": "karenina.adapters.langchain_deep_agents.errors",
     }
 

--- a/src/karenina/adapters/langchain_deep_agents/agent.py
+++ b/src/karenina/adapters/langchain_deep_agents/agent.py
@@ -20,6 +20,7 @@ from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any, cast
 
 from karenina.adapters.agent_runtime import (
+    get_agent_runtime_access_mode,
     get_agent_runtime_capabilities,
     get_agent_runtime_option,
     get_deepagents_backend,
@@ -143,6 +144,7 @@ class DeepAgentsAgentAdapter:
         """Create the DeepAgents backend configured for this model."""
 
         backend = get_deepagents_backend(self._config)
+        access_mode = get_agent_runtime_access_mode(self._config)
         if backend == "docker":
             if workspace_path is None:
                 raise AdapterUnavailableError(
@@ -151,13 +153,18 @@ class DeepAgentsAgentAdapter:
                 )
             from .docker_backend import DockerSandboxBackend
 
-            return DockerSandboxBackend(
+            docker_backend = DockerSandboxBackend(
                 root_dir=workspace_path,
                 image=str(get_agent_runtime_option(self._config, "docker_image", "")),
                 network=str(get_agent_runtime_option(self._config, "docker_network", "bridge")),
                 timeout=_runtime_int_option(self._config, "execute_timeout", 120),
                 max_output_bytes=_runtime_int_option(self._config, "execute_max_output_bytes", 100_000),
             )
+            if access_mode == "read_only":
+                from .read_only_backend import ReadOnlyBackend
+
+                return ReadOnlyBackend(docker_backend)
+            return docker_backend
 
         if backend == "local_shell":
             if workspace_path is None:
@@ -171,22 +178,37 @@ class DeepAgentsAgentAdapter:
                 "Using unsafe DeepAgents LocalShellBackend with root_dir=%s",
                 workspace_path,
             )
-            return LocalShellBackend(
+            local_backend = LocalShellBackend(
                 root_dir=str(workspace_path),
                 virtual_mode=True,
                 timeout=_runtime_int_option(self._config, "execute_timeout", 120),
                 max_output_bytes=_runtime_int_option(self._config, "execute_max_output_bytes", 100_000),
                 inherit_env=True,
             )
+            if access_mode == "read_only":
+                from .read_only_backend import ReadOnlyBackend
+
+                return ReadOnlyBackend(local_backend)
+            return local_backend
 
         from deepagents.backends import FilesystemBackend
 
         if workspace_path:
             logger.info("Using FilesystemBackend with root_dir=%s", workspace_path)
-            return FilesystemBackend(root_dir=str(workspace_path), virtual_mode=True)
+            filesystem_backend = FilesystemBackend(root_dir=str(workspace_path), virtual_mode=True)
+            if access_mode == "read_only":
+                from .read_only_backend import ReadOnlyBackend
+
+                return ReadOnlyBackend(filesystem_backend)
+            return filesystem_backend
 
         logger.info("Using FilesystemBackend with default root (cwd)")
-        return FilesystemBackend(virtual_mode=True)
+        filesystem_backend = FilesystemBackend(virtual_mode=True)
+        if access_mode == "read_only":
+            from .read_only_backend import ReadOnlyBackend
+
+            return ReadOnlyBackend(filesystem_backend)
+        return filesystem_backend
 
     def _build_raw_trace(
         self,

--- a/src/karenina/adapters/langchain_deep_agents/agent.py
+++ b/src/karenina/adapters/langchain_deep_agents/agent.py
@@ -19,6 +19,11 @@ import logging
 from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any
 
+from karenina.adapters.agent_runtime import (
+    get_agent_runtime_capabilities,
+    get_agent_runtime_option,
+    get_deepagents_backend,
+)
 from karenina.ports import (
     AdapterUnavailableError,
     AgentConfig,
@@ -35,7 +40,6 @@ from karenina.ports.capabilities import PortCapabilities
 from .errors import wrap_deep_agents_error
 from .initialization import create_chat_model
 from .messages import DeepAgentsMessageConverter
-from .runtime import get_deepagents_backend, get_deepagents_capabilities
 from .trace import deep_agents_messages_to_raw_trace
 from .usage import extract_actual_model, extract_deep_agents_usage
 
@@ -47,6 +51,15 @@ if TYPE_CHECKING:
 _create_deep_agent = None
 
 logger = logging.getLogger(__name__)
+
+
+def _runtime_int_option(model_config: ModelConfig, key: str, default: int) -> int:
+    """Read an integer runtime option from ModelConfig.extra_kwargs."""
+
+    raw_value = get_agent_runtime_option(model_config, key, default)
+    if isinstance(raw_value, int | float | str):
+        return int(raw_value)
+    raise TypeError(f"agent_runtime option '{key}' must be an integer-compatible value")
 
 
 class DeepAgentsAgentAdapter:
@@ -96,7 +109,7 @@ class DeepAgentsAgentAdapter:
         Returns:
             PortCapabilities implied by the configured DeepAgents backend.
         """
-        return get_deepagents_capabilities(self._config)
+        return get_agent_runtime_capabilities(self._config)
 
     def _build_backend(self, workspace_path: Any) -> Any:
         """Create the DeepAgents backend configured for this model."""
@@ -105,23 +118,23 @@ class DeepAgentsAgentAdapter:
         if backend == "docker":
             if workspace_path is None:
                 raise AdapterUnavailableError(
-                    "deepagents_backend='docker' requires an AgentConfig.workspace_path",
+                    "agent_runtime backend='docker' requires an AgentConfig.workspace_path",
                     reason="missing_workspace",
                 )
             from .docker_backend import DockerSandboxBackend
 
             return DockerSandboxBackend(
                 root_dir=workspace_path,
-                image=self._config.deepagents_docker_image or "",
-                network=self._config.deepagents_docker_network,
-                timeout=self._config.deepagents_execute_timeout,
-                max_output_bytes=self._config.deepagents_execute_max_output_bytes,
+                image=str(get_agent_runtime_option(self._config, "docker_image", "")),
+                network=str(get_agent_runtime_option(self._config, "docker_network", "bridge")),
+                timeout=_runtime_int_option(self._config, "execute_timeout", 120),
+                max_output_bytes=_runtime_int_option(self._config, "execute_max_output_bytes", 100_000),
             )
 
         if backend == "local_shell":
             if workspace_path is None:
                 raise AdapterUnavailableError(
-                    "deepagents_backend='local_shell' requires an AgentConfig.workspace_path",
+                    "agent_runtime backend='local_shell' requires an AgentConfig.workspace_path",
                     reason="missing_workspace",
                 )
             from deepagents.backends import LocalShellBackend
@@ -133,8 +146,8 @@ class DeepAgentsAgentAdapter:
             return LocalShellBackend(
                 root_dir=str(workspace_path),
                 virtual_mode=True,
-                timeout=self._config.deepagents_execute_timeout,
-                max_output_bytes=self._config.deepagents_execute_max_output_bytes,
+                timeout=_runtime_int_option(self._config, "execute_timeout", 120),
+                max_output_bytes=_runtime_int_option(self._config, "execute_max_output_bytes", 100_000),
                 inherit_env=True,
             )
 

--- a/src/karenina/adapters/langchain_deep_agents/agent.py
+++ b/src/karenina/adapters/langchain_deep_agents/agent.py
@@ -17,7 +17,7 @@ import asyncio
 import concurrent.futures
 import logging
 from contextlib import AsyncExitStack
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from karenina.adapters.agent_runtime import (
     get_agent_runtime_capabilities,
@@ -36,6 +36,7 @@ from karenina.ports import (
     UsageMetadata,
 )
 from karenina.ports.capabilities import PortCapabilities
+from karenina.utils.retry_policy import RetryPolicy
 
 from .errors import wrap_deep_agents_error
 from .initialization import create_chat_model
@@ -51,6 +52,33 @@ if TYPE_CHECKING:
 _create_deep_agent = None
 
 logger = logging.getLogger(__name__)
+
+
+def _run_in_fresh_loop(
+    coro_func: Any,
+    *args: Any,
+    timeout: float = 600,
+) -> Any:
+    """Run an async callable in a dedicated thread with a fresh event loop.
+
+    DeepAgents runs a LangGraph async task graph backed by LangChain chat
+    models. Some OpenAI-compatible async transports are loop-affine; running
+    multiple DeepAgents calls through Karenina's shared BlockingPortal can
+    surface httpcore errors such as "Event is bound to a different event loop".
+    Keeping each synchronous DeepAgents invocation on its own loop avoids
+    sharing loop-bound SDK state across answerer/judge calls.
+    """
+
+    def _target() -> Any:
+        return asyncio.run(coro_func(*args))
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future: concurrent.futures.Future[Any] = executor.submit(_target)
+        # The coroutine enforces the user-facing agent timeout with
+        # asyncio.wait_for and can return a partial trace. Give that inner
+        # timeout a short grace period so this wrapper does not race it and
+        # replace the partial result with a bare concurrent.futures.TimeoutError.
+        return future.result(timeout=timeout + 30)
 
 
 def _runtime_int_option(model_config: ModelConfig, key: str, default: int) -> int:
@@ -268,8 +296,13 @@ class DeepAgentsAgentAdapter:
         elif not system_prompt and self._config.system_prompt:
             system_prompt = self._config.system_prompt
 
-        # Initialize model
-        chat_model = create_chat_model(self._config)
+        # Initialize model. Agent loops need SDK-level retries at the model
+        # call boundary; retrying the whole agent can repeat workspace writes.
+        retry_policy = self._config.retry_policy or RetryPolicy()
+        chat_model = create_chat_model(
+            self._config,
+            max_retries=retry_policy.derive_sdk_max_retries(),
+        )
 
         # Build agent kwargs
         agent_kwargs: dict[str, Any] = {"model": chat_model}
@@ -466,29 +499,18 @@ class DeepAgentsAgentAdapter:
             AgentTimeoutError: If execution exceeds the timeout.
             AgentResponseError: If the response is malformed or invalid.
         """
-        from karenina.benchmark.verification.executor import get_async_portal
-
-        portal = get_async_portal()
-
-        if portal is not None:
-            return portal.call(self.arun, messages, tools, mcp_servers, config)
-
-        # No portal: check if we're in an async context
-        try:
-            asyncio.get_running_loop()
-            # We're in an async context: use ThreadPoolExecutor
-
-            def run_in_thread() -> AgentResult:
-                return asyncio.run(self.arun(messages, tools, mcp_servers, config))
-
-            timeout = config.timeout if config and config.timeout else 600
-            with concurrent.futures.ThreadPoolExecutor() as executor:
-                future = executor.submit(run_in_thread)
-                return future.result(timeout=timeout)
-
-        except RuntimeError:
-            # No event loop running, safe to use asyncio.run
-            return asyncio.run(self.arun(messages, tools, mcp_servers, config))
+        timeout = config.timeout if config and config.timeout else 600
+        return cast(
+            AgentResult,
+            _run_in_fresh_loop(
+                self.arun,
+                messages,
+                tools,
+                mcp_servers,
+                config,
+                timeout=timeout,
+            ),
+        )
 
     async def aclose(self) -> None:
         """Close underlying resources.

--- a/src/karenina/adapters/langchain_deep_agents/agent.py
+++ b/src/karenina/adapters/langchain_deep_agents/agent.py
@@ -20,9 +20,11 @@ from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any, cast
 
 from karenina.adapters.agent_runtime import (
+    CONTAINER_BACKEND,
     get_agent_runtime_access_mode,
     get_agent_runtime_capabilities,
     get_agent_runtime_option,
+    get_container_runtime_config,
     get_deepagents_backend,
 )
 from karenina.ports import (
@@ -145,26 +147,25 @@ class DeepAgentsAgentAdapter:
 
         backend = get_deepagents_backend(self._config)
         access_mode = get_agent_runtime_access_mode(self._config)
-        if backend == "docker":
+        if backend == CONTAINER_BACKEND:
             if workspace_path is None:
                 raise AdapterUnavailableError(
-                    "agent_runtime backend='docker' requires an AgentConfig.workspace_path",
+                    "agent_runtime backend='container' requires an AgentConfig.workspace_path",
                     reason="missing_workspace",
                 )
-            from .docker_backend import DockerSandboxBackend
+            from .docker_backend import ContainerSandboxBackend
 
-            docker_backend = DockerSandboxBackend(
+            container_backend = ContainerSandboxBackend(
                 root_dir=workspace_path,
-                image=str(get_agent_runtime_option(self._config, "docker_image", "")),
-                network=str(get_agent_runtime_option(self._config, "docker_network", "bridge")),
+                container_config=get_container_runtime_config(self._config),
                 timeout=_runtime_int_option(self._config, "execute_timeout", 120),
                 max_output_bytes=_runtime_int_option(self._config, "execute_max_output_bytes", 100_000),
             )
             if access_mode == "read_only":
                 from .read_only_backend import ReadOnlyBackend
 
-                return ReadOnlyBackend(docker_backend)
-            return docker_backend
+                return ReadOnlyBackend(container_backend)
+            return container_backend
 
         if backend == "local_shell":
             if workspace_path is None:

--- a/src/karenina/adapters/langchain_deep_agents/agent.py
+++ b/src/karenina/adapters/langchain_deep_agents/agent.py
@@ -20,11 +20,11 @@ from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any
 
 from karenina.ports import (
+    AdapterUnavailableError,
     AgentConfig,
     AgentExecutionError,
     AgentResponseError,
     AgentResult,
-    AgentTimeoutError,
     MCPServerConfig,
     Message,
     Tool,
@@ -35,6 +35,7 @@ from karenina.ports.capabilities import PortCapabilities
 from .errors import wrap_deep_agents_error
 from .initialization import create_chat_model
 from .messages import DeepAgentsMessageConverter
+from .runtime import get_deepagents_backend, get_deepagents_capabilities
 from .trace import deep_agents_messages_to_raw_trace
 from .usage import extract_actual_model, extract_deep_agents_usage
 
@@ -93,9 +94,85 @@ class DeepAgentsAgentAdapter:
         """Declare adapter capabilities.
 
         Returns:
-            PortCapabilities with system_prompt=True.
+            PortCapabilities implied by the configured DeepAgents backend.
         """
-        return PortCapabilities(supports_system_prompt=True)
+        return get_deepagents_capabilities(self._config)
+
+    def _build_backend(self, workspace_path: Any) -> Any:
+        """Create the DeepAgents backend configured for this model."""
+
+        backend = get_deepagents_backend(self._config)
+        if backend == "docker":
+            if workspace_path is None:
+                raise AdapterUnavailableError(
+                    "deepagents_backend='docker' requires an AgentConfig.workspace_path",
+                    reason="missing_workspace",
+                )
+            from .docker_backend import DockerSandboxBackend
+
+            return DockerSandboxBackend(
+                root_dir=workspace_path,
+                image=self._config.deepagents_docker_image or "",
+                network=self._config.deepagents_docker_network,
+                timeout=self._config.deepagents_execute_timeout,
+                max_output_bytes=self._config.deepagents_execute_max_output_bytes,
+            )
+
+        if backend == "local_shell":
+            if workspace_path is None:
+                raise AdapterUnavailableError(
+                    "deepagents_backend='local_shell' requires an AgentConfig.workspace_path",
+                    reason="missing_workspace",
+                )
+            from deepagents.backends import LocalShellBackend
+
+            logger.warning(
+                "Using unsafe DeepAgents LocalShellBackend with root_dir=%s",
+                workspace_path,
+            )
+            return LocalShellBackend(
+                root_dir=str(workspace_path),
+                virtual_mode=True,
+                timeout=self._config.deepagents_execute_timeout,
+                max_output_bytes=self._config.deepagents_execute_max_output_bytes,
+                inherit_env=True,
+            )
+
+        from deepagents.backends import FilesystemBackend
+
+        if workspace_path:
+            logger.info("Using FilesystemBackend with root_dir=%s", workspace_path)
+            return FilesystemBackend(root_dir=str(workspace_path), virtual_mode=True)
+
+        logger.info("Using FilesystemBackend with default root (cwd)")
+        return FilesystemBackend(virtual_mode=True)
+
+    def _build_raw_trace(
+        self,
+        lc_messages: list[Any],
+        subgraph_results: dict[tuple[Any, ...], dict[str, Any]],
+        *,
+        limit_reached: bool,
+        timeout_reached: bool,
+    ) -> str:
+        """Build a raw trace, including any streamed subgraph state."""
+
+        raw_trace = deep_agents_messages_to_raw_trace(lc_messages) if lc_messages else ""
+        subgraph_trace_parts = []
+        for namespace, subgraph_result in subgraph_results.items():
+            subgraph_messages = subgraph_result.get("messages", [])
+            subgraph_trace = deep_agents_messages_to_raw_trace(subgraph_messages)
+            if subgraph_trace:
+                namespace_text = " / ".join(str(part) for part in namespace)
+                subgraph_trace_parts.append(f"--- Subgraph Trace: {namespace_text} ---\n{subgraph_trace}")
+        if subgraph_trace_parts:
+            parts = [part for part in [raw_trace, *subgraph_trace_parts] if part]
+            raw_trace = "\n\n".join(parts).strip()
+        if limit_reached:
+            raw_trace += "\n\n[Note: Recursion limit reached, partial response shown]"
+        if timeout_reached:
+            raw_trace += "\n\n[Note: Wall-clock timeout reached, partial response shown]"
+        return raw_trace.strip()
 
     def _extract_final_response(self, lc_messages: list[Any]) -> str:
         """Extract final text response from the last AIMessage.
@@ -186,21 +263,7 @@ class DeepAgentsAgentAdapter:
         if system_prompt:
             agent_kwargs["system_prompt"] = system_prompt
 
-        # Configure backend for real filesystem access when workspace is available
-        workspace_path = config.workspace_path
-        if workspace_path:
-            from deepagents.backends import FilesystemBackend
-
-            agent_kwargs["backend"] = FilesystemBackend(root_dir=str(workspace_path))
-            logger.info("Using FilesystemBackend with root_dir=%s", workspace_path)
-        else:
-            # Default: use FilesystemBackend rooted at cwd for real filesystem access.
-            # StateBackend (virtual/in-memory) is NOT suitable for benchmarking because
-            # the agent cannot see real files on disk.
-            from deepagents.backends import FilesystemBackend
-
-            agent_kwargs["backend"] = FilesystemBackend()
-            logger.info("Using FilesystemBackend with default root (cwd)")
+        agent_kwargs["backend"] = self._build_backend(config.workspace_path)
 
         # Pass through extra config to create_deep_agent
         if config.extra:
@@ -219,7 +282,9 @@ class DeepAgentsAgentAdapter:
         # cleanup can wrap errors in ExceptionGroup if an exception propagates
         # through the exit stack.
         result: dict[str, Any] = {}
+        subgraph_results: dict[tuple[Any, ...], dict[str, Any]] = {}
         limit_reached = False
+        timeout_reached = False
         deferred_error: Exception | None = None
 
         async with AsyncExitStack() as exit_stack:
@@ -261,8 +326,23 @@ class DeepAgentsAgentAdapter:
 
                 # Execute agent
                 async def execute_agent() -> None:
-                    nonlocal result, limit_reached
-                    result = await agent.ainvoke(invoke_input, config=langgraph_config)
+                    nonlocal result, subgraph_results, limit_reached
+                    async for chunk in agent.astream(
+                        invoke_input,
+                        config=langgraph_config,
+                        stream_mode="values",
+                        subgraphs=True,
+                    ):
+                        namespace: tuple[Any, ...] = ()
+                        state = chunk
+                        if isinstance(chunk, tuple) and len(chunk) == 2:
+                            namespace_raw, state = chunk
+                            namespace = tuple(namespace_raw)
+                        if isinstance(state, dict):
+                            if namespace:
+                                subgraph_results[namespace] = state
+                            else:
+                                result = state
                     if result.get("is_last_step", False):
                         limit_reached = True
 
@@ -272,9 +352,9 @@ class DeepAgentsAgentAdapter:
                     else:
                         await execute_agent()
 
-                except TimeoutError as e:
-                    deferred_error = AgentTimeoutError(f"Agent execution timed out after {config.timeout}s")
-                    deferred_error.__cause__ = e
+                except TimeoutError:
+                    timeout_reached = True
+                    logger.warning("Agent timed out after %ss; returning partial trace", config.timeout)
                 except Exception as e:
                     mapped_error, was_limit = wrap_deep_agents_error(e)
                     if was_limit:
@@ -292,26 +372,36 @@ class DeepAgentsAgentAdapter:
         # Extract messages from result
         lc_messages: list[Any] = result.get("messages", [])
 
-        if not lc_messages and not limit_reached:
+        if not lc_messages and not limit_reached and not timeout_reached:
             raise AgentResponseError("No messages received from Deep Agents")
 
         # If limit was reached but no messages, return a partial result
-        if not lc_messages and limit_reached:
+        if not lc_messages and (limit_reached or timeout_reached):
+            raw_trace = self._build_raw_trace(
+                lc_messages,
+                subgraph_results,
+                limit_reached=limit_reached,
+                timeout_reached=timeout_reached,
+            )
             return AgentResult(
-                final_response="[Agent hit recursion limit before producing a response]",
-                raw_trace="[Note: Recursion limit reached, no response produced]",
+                final_response="[Agent stopped before producing a final response]",
+                raw_trace=raw_trace or "[Note: Agent stopped before producing trace messages]",
                 trace_messages=[],
                 usage=UsageMetadata(model=self._config.model_name),
                 turns=0,
-                limit_reached=True,
+                limit_reached=limit_reached,
                 session_id=None,
                 actual_model=self._config.model_name,
+                timeout_reached=timeout_reached,
             )
 
         # Build raw_trace (legacy string format)
-        raw_trace = deep_agents_messages_to_raw_trace(lc_messages)
-        if limit_reached:
-            raw_trace += "\n\n[Note: Recursion limit reached, partial response shown]"
+        raw_trace = self._build_raw_trace(
+            lc_messages,
+            subgraph_results,
+            limit_reached=limit_reached,
+            timeout_reached=timeout_reached,
+        )
 
         # Build trace_messages (structured format)
         trace_messages = self._converter.from_provider(lc_messages)
@@ -337,6 +427,7 @@ class DeepAgentsAgentAdapter:
             limit_reached=limit_reached,
             session_id=None,
             actual_model=actual_model,
+            timeout_reached=timeout_reached,
         )
 
     def run(

--- a/src/karenina/adapters/langchain_deep_agents/docker_backend.py
+++ b/src/karenina/adapters/langchain_deep_agents/docker_backend.py
@@ -1,8 +1,7 @@
-"""Docker-backed DeepAgents sandbox backend."""
+"""Container-backed DeepAgents sandbox backend."""
 
 from __future__ import annotations
 
-import os
 import subprocess
 import uuid
 from pathlib import Path
@@ -11,52 +10,48 @@ from typing import cast
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 
-from karenina.adapters.agent_runtime import preflight_docker_runtime
+from karenina.adapters.agent_runtime import (
+    SANDBOX_WORKSPACE_PATH,
+    ContainerRuntimeConfig,
+    build_container_command,
+    preflight_container_runtime,
+)
 from karenina.ports import AdapterUnavailableError
 
-SANDBOX_WORKSPACE_PATH = "/workspace"
 
-
-class DockerSandboxBackend(FilesystemBackend, SandboxBackendProtocol):  # type: ignore[misc]
-    """DeepAgents backend that maps a host workspace to `/workspace` in Docker."""
+class ContainerSandboxBackend(FilesystemBackend, SandboxBackendProtocol):  # type: ignore[misc]
+    """DeepAgents backend that maps a host workspace to `/workspace` in a container."""
 
     def __init__(
         self,
         *,
         root_dir: str | Path,
-        image: str,
-        network: str = "bridge",
+        container_config: ContainerRuntimeConfig,
         timeout: int = 120,
         max_output_bytes: int = 100_000,
     ) -> None:
-        if not image:
+        if not container_config.image:
             raise AdapterUnavailableError(
-                "agent_runtime docker_image is required when backend='docker'",
-                reason="missing_deepagents_docker_image",
-            )
-        if network not in {"bridge", "none"}:
-            raise AdapterUnavailableError(
-                "agent_runtime docker_network must be 'bridge' or 'none'",
-                reason="invalid_deepagents_docker_network",
+                "agent_runtime container_image is required when backend='container'",
+                reason="missing_deepagents_container_image",
             )
         self._host_workspace = Path(root_dir).resolve()
         if not self._host_workspace.is_dir():
             raise AdapterUnavailableError(
-                f"Docker sandbox workspace does not exist: {self._host_workspace}",
+                f"Container sandbox workspace does not exist: {self._host_workspace}",
                 reason="missing_workspace",
             )
-        preflight_docker_runtime(image=image)
+        preflight_container_runtime(container_config)
 
         super().__init__(
             root_dir=self._host_workspace,
             virtual_mode=True,
             max_file_size_mb=10,
         )
-        self._image = image
-        self._network = network
+        self._container_config = container_config
         self._default_timeout = timeout
         self._max_output_bytes = max_output_bytes
-        self._sandbox_id = f"docker-{uuid.uuid4().hex[:8]}"
+        self._sandbox_id = f"{container_config.runtime}-{uuid.uuid4().hex[:8]}"
 
     @property
     def id(self) -> str:
@@ -88,39 +83,17 @@ class DockerSandboxBackend(FilesystemBackend, SandboxBackendProtocol):  # type: 
 
         return command.replace(str(self._host_workspace), SANDBOX_WORKSPACE_PATH)
 
-    def _docker_command(self, command: str) -> list[str]:
-        docker_cmd = [
-            "docker",
-            "run",
-            "--rm",
-            "--network",
-            self._network,
-            "--workdir",
-            SANDBOX_WORKSPACE_PATH,
-            "--volume",
-            f"{self._host_workspace}:{SANDBOX_WORKSPACE_PATH}:rw",
-            "--env",
-            "UV_LINK_MODE=copy",
-            "--env",
-            "UV_CACHE_DIR=/tmp/uv-cache",
-            "--env",
-            "PATH=/workspace/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-            "--pids-limit",
-            "256",
-        ]
-
-        if hasattr(os, "getuid") and hasattr(os, "getgid"):
-            docker_cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
-
-        docker_cmd.extend(
-            [
-                self._image,
-                "/bin/sh",
-                "-lc",
-                self._command_for_container(command),
-            ]
+    def _container_command(self, command: str) -> list[str]:
+        return build_container_command(
+            config=self._container_config,
+            host_workspace=self._host_workspace,
+            argv=["/bin/sh", "-lc", self._command_for_container(command)],
+            env={
+                "UV_LINK_MODE": "copy",
+                "UV_CACHE_DIR": "/tmp/uv-cache",
+                "PATH": "/workspace/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            },
         )
-        return docker_cmd
 
     def execute(
         self,
@@ -147,7 +120,7 @@ class DockerSandboxBackend(FilesystemBackend, SandboxBackendProtocol):  # type: 
 
         try:
             result = subprocess.run(  # noqa: S603
-                self._docker_command(command),
+                self._container_command(command),
                 check=False,
                 capture_output=True,
                 text=True,
@@ -187,4 +160,28 @@ class DockerSandboxBackend(FilesystemBackend, SandboxBackendProtocol):  # type: 
             output=output,
             exit_code=result.returncode,
             truncated=truncated,
+        )
+
+
+class DockerSandboxBackend(ContainerSandboxBackend):
+    """Compatibility wrapper for callers importing the old Docker backend."""
+
+    def __init__(
+        self,
+        *,
+        root_dir: str | Path,
+        image: str,
+        network: str = "bridge",
+        timeout: int = 120,
+        max_output_bytes: int = 100_000,
+    ) -> None:
+        super().__init__(
+            root_dir=root_dir,
+            container_config=ContainerRuntimeConfig(
+                runtime="docker",
+                image=image,
+                network=network,
+            ),
+            timeout=timeout,
+            max_output_bytes=max_output_bytes,
         )

--- a/src/karenina/adapters/langchain_deep_agents/docker_backend.py
+++ b/src/karenina/adapters/langchain_deep_agents/docker_backend.py
@@ -1,0 +1,195 @@
+"""Docker-backed DeepAgents sandbox backend."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+from typing import cast
+
+from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
+
+from karenina.ports import AdapterUnavailableError
+
+SANDBOX_WORKSPACE_PATH = "/workspace"
+
+
+class DockerSandboxBackend(FilesystemBackend, SandboxBackendProtocol):  # type: ignore[misc]
+    """DeepAgents backend that maps a host workspace to `/workspace` in Docker."""
+
+    def __init__(
+        self,
+        *,
+        root_dir: str | Path,
+        image: str,
+        network: str = "bridge",
+        timeout: int = 120,
+        max_output_bytes: int = 100_000,
+    ) -> None:
+        if not image:
+            raise AdapterUnavailableError(
+                "deepagents_docker_image is required when deepagents_backend='docker'",
+                reason="missing_deepagents_docker_image",
+            )
+        if network not in {"bridge", "none"}:
+            raise AdapterUnavailableError(
+                "deepagents_docker_network must be 'bridge' or 'none'",
+                reason="invalid_deepagents_docker_network",
+            )
+        if shutil.which("docker") is None:
+            raise AdapterUnavailableError(
+                "Docker is required for deepagents_backend='docker', but the docker command was not found",
+                reason="docker_unavailable",
+            )
+
+        self._host_workspace = Path(root_dir).resolve()
+        if not self._host_workspace.is_dir():
+            raise AdapterUnavailableError(
+                f"Docker sandbox workspace does not exist: {self._host_workspace}",
+                reason="missing_workspace",
+            )
+
+        super().__init__(
+            root_dir=self._host_workspace,
+            virtual_mode=True,
+            max_file_size_mb=10,
+        )
+        self._image = image
+        self._network = network
+        self._default_timeout = timeout
+        self._max_output_bytes = max_output_bytes
+        self._sandbox_id = f"docker-{uuid.uuid4().hex[:8]}"
+
+    @property
+    def id(self) -> str:
+        """Unique sandbox id."""
+
+        return self._sandbox_id
+
+    def _strip_workspace_prefix(self, path: str) -> str:
+        """Normalize `/workspace` paths to FilesystemBackend virtual paths."""
+
+        if path == SANDBOX_WORKSPACE_PATH:
+            return "/"
+        prefix = f"{SANDBOX_WORKSPACE_PATH}/"
+        if path.startswith(prefix):
+            return "/" + path.removeprefix(prefix)
+        return path
+
+    def _resolve_path(self, key: str) -> Path:
+        return cast(Path, super()._resolve_path(self._strip_workspace_prefix(key)))
+
+    def _to_virtual_path(self, path: Path) -> str:
+        virtual_path = super()._to_virtual_path(path)
+        if virtual_path == "/":
+            return SANDBOX_WORKSPACE_PATH
+        return f"{SANDBOX_WORKSPACE_PATH}{virtual_path}"
+
+    def _command_for_container(self, command: str) -> str:
+        """Map any leaked host workspace path to `/workspace`."""
+
+        return command.replace(str(self._host_workspace), SANDBOX_WORKSPACE_PATH)
+
+    def _docker_command(self, command: str) -> list[str]:
+        docker_cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "--network",
+            self._network,
+            "--workdir",
+            SANDBOX_WORKSPACE_PATH,
+            "--volume",
+            f"{self._host_workspace}:{SANDBOX_WORKSPACE_PATH}:rw",
+            "--env",
+            "UV_LINK_MODE=copy",
+            "--env",
+            "UV_CACHE_DIR=/tmp/uv-cache",
+            "--env",
+            "PATH=/workspace/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "--pids-limit",
+            "256",
+        ]
+
+        if hasattr(os, "getuid") and hasattr(os, "getgid"):
+            docker_cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+
+        docker_cmd.extend(
+            [
+                self._image,
+                "/bin/sh",
+                "-lc",
+                self._command_for_container(command),
+            ]
+        )
+        return docker_cmd
+
+    def execute(
+        self,
+        command: str,
+        *,
+        timeout: int | None = None,
+    ) -> ExecuteResponse:
+        """Execute a shell command inside a one-shot Docker container."""
+
+        if not command or not isinstance(command, str):
+            return ExecuteResponse(
+                output="Error: Command must be a non-empty string.",
+                exit_code=1,
+                truncated=False,
+            )
+
+        effective_timeout = timeout if timeout is not None else self._default_timeout
+        if effective_timeout <= 0:
+            return ExecuteResponse(
+                output=f"Error: timeout must be positive, got {effective_timeout}",
+                exit_code=1,
+                truncated=False,
+            )
+
+        try:
+            result = subprocess.run(  # noqa: S603
+                self._docker_command(command),
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=effective_timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return ExecuteResponse(
+                output=f"Error: Command timed out after {effective_timeout} seconds.",
+                exit_code=124,
+                truncated=False,
+            )
+        except Exception as e:  # noqa: BLE001
+            return ExecuteResponse(
+                output=f"Error executing Docker command ({type(e).__name__}): {e}",
+                exit_code=1,
+                truncated=False,
+            )
+
+        output_parts = []
+        if result.stdout:
+            output_parts.append(result.stdout)
+        if result.stderr:
+            stderr_lines = result.stderr.strip().split("\n")
+            output_parts.extend(f"[stderr] {line}" for line in stderr_lines)
+        output = "\n".join(output_parts) if output_parts else "<no output>"
+
+        truncated = False
+        if len(output) > self._max_output_bytes:
+            output = output[: self._max_output_bytes]
+            output += f"\n\n... Output truncated at {self._max_output_bytes} bytes."
+            truncated = True
+
+        if result.returncode != 0:
+            output = f"{output.rstrip()}\n\nExit code: {result.returncode}"
+
+        return ExecuteResponse(
+            output=output,
+            exit_code=result.returncode,
+            truncated=truncated,
+        )

--- a/src/karenina/adapters/langchain_deep_agents/docker_backend.py
+++ b/src/karenina/adapters/langchain_deep_agents/docker_backend.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 import uuid
 from pathlib import Path
@@ -12,6 +11,7 @@ from typing import cast
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 
+from karenina.adapters.agent_runtime import preflight_docker_runtime
 from karenina.ports import AdapterUnavailableError
 
 SANDBOX_WORKSPACE_PATH = "/workspace"
@@ -39,18 +39,13 @@ class DockerSandboxBackend(FilesystemBackend, SandboxBackendProtocol):  # type: 
                 "agent_runtime docker_network must be 'bridge' or 'none'",
                 reason="invalid_deepagents_docker_network",
             )
-        if shutil.which("docker") is None:
-            raise AdapterUnavailableError(
-                "Docker is required for agent_runtime backend='docker', but the docker command was not found",
-                reason="docker_unavailable",
-            )
-
         self._host_workspace = Path(root_dir).resolve()
         if not self._host_workspace.is_dir():
             raise AdapterUnavailableError(
                 f"Docker sandbox workspace does not exist: {self._host_workspace}",
                 reason="missing_workspace",
             )
+        preflight_docker_runtime(image=image)
 
         super().__init__(
             root_dir=self._host_workspace,

--- a/src/karenina/adapters/langchain_deep_agents/docker_backend.py
+++ b/src/karenina/adapters/langchain_deep_agents/docker_backend.py
@@ -31,17 +31,17 @@ class DockerSandboxBackend(FilesystemBackend, SandboxBackendProtocol):  # type: 
     ) -> None:
         if not image:
             raise AdapterUnavailableError(
-                "deepagents_docker_image is required when deepagents_backend='docker'",
+                "agent_runtime docker_image is required when backend='docker'",
                 reason="missing_deepagents_docker_image",
             )
         if network not in {"bridge", "none"}:
             raise AdapterUnavailableError(
-                "deepagents_docker_network must be 'bridge' or 'none'",
+                "agent_runtime docker_network must be 'bridge' or 'none'",
                 reason="invalid_deepagents_docker_network",
             )
         if shutil.which("docker") is None:
             raise AdapterUnavailableError(
-                "Docker is required for deepagents_backend='docker', but the docker command was not found",
+                "Docker is required for agent_runtime backend='docker', but the docker command was not found",
                 reason="docker_unavailable",
             )
 

--- a/src/karenina/adapters/langchain_deep_agents/initialization.py
+++ b/src/karenina/adapters/langchain_deep_agents/initialization.py
@@ -79,10 +79,11 @@ def create_chat_model(model_config: ModelConfig, **kwargs: Any) -> Any:
 
     model_kwargs.update(kwargs)
 
-    # Suppress SDK-level retries. Retry logic is handled by RetryExecutor
-    # at the adapter layer to ensure unified retry behavior across all adapters.
-    # Placed after kwargs merge to ensure SDK retries stay at 0.
-    model_kwargs["max_retries"] = 0
+    # Suppress SDK-level retries unless a caller explicitly opts in. The
+    # single-turn LLM/parser paths use RetryExecutor at the adapter layer.
+    # Agent loops instead need model-call retries inside LangGraph, because
+    # retrying the entire agent can repeat workspace side effects.
+    model_kwargs.setdefault("max_retries", 0)
 
     return init_chat_model(
         model=model_config.model_name,

--- a/src/karenina/adapters/langchain_deep_agents/initialization.py
+++ b/src/karenina/adapters/langchain_deep_agents/initialization.py
@@ -13,6 +13,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from langchain.chat_models import init_chat_model
+from pydantic import SecretStr
 
 from karenina.ports import AdapterUnavailableError
 
@@ -20,6 +21,15 @@ if TYPE_CHECKING:
     from karenina.schemas.config import ModelConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_openai_endpoint_url(base_url: str) -> str:
+    """Normalize OpenAI-compatible endpoint URLs to include /v1."""
+
+    url = base_url.rstrip("/")
+    if url.endswith("/v1"):
+        return url
+    return f"{url}/v1"
 
 
 def create_chat_model(model_config: ModelConfig, **kwargs: Any) -> Any:
@@ -55,6 +65,17 @@ def create_chat_model(model_config: ModelConfig, **kwargs: Any) -> Any:
             model_kwargs["default_request_timeout"] = model_config.request_timeout
         else:
             model_kwargs["request_timeout"] = model_config.request_timeout
+    if model_config.endpoint_base_url is not None:
+        if model_config.endpoint_api_key is None:
+            raise AdapterUnavailableError(
+                "endpoint_api_key is required when endpoint_base_url is set for langchain_deep_agents",
+                reason="missing_endpoint_api_key",
+            )
+        model_kwargs["base_url"] = _normalize_openai_endpoint_url(model_config.endpoint_base_url)
+        endpoint_api_key = model_config.endpoint_api_key
+        model_kwargs["api_key"] = (
+            endpoint_api_key.get_secret_value() if isinstance(endpoint_api_key, SecretStr) else endpoint_api_key
+        )
 
     model_kwargs.update(kwargs)
 

--- a/src/karenina/adapters/langchain_deep_agents/initialization.py
+++ b/src/karenina/adapters/langchain_deep_agents/initialization.py
@@ -23,10 +23,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _normalize_openai_endpoint_url(base_url: str) -> str:
-    """Normalize OpenAI-compatible endpoint URLs to include /v1."""
+def _normalize_openai_endpoint_url(base_url: str, *, mode: str = "auto_v1") -> str:
+    """Normalize OpenAI-compatible endpoint URLs.
+
+    Most local OpenAI-compatible servers expose ``/v1``. Some hosted APIs,
+    such as Z.ai's coding endpoint, use a provider-specific version segment
+    as the final OpenAI SDK base URL and must be passed through unchanged.
+    """
 
     url = base_url.rstrip("/")
+    if mode == "raw":
+        return url
+    if mode != "auto_v1":
+        raise AdapterUnavailableError(
+            "extra_kwargs['endpoint_base_url_mode'] must be 'auto_v1' or 'raw'",
+            reason="invalid_endpoint_base_url_mode",
+        )
     if url.endswith("/v1"):
         return url
     return f"{url}/v1"
@@ -71,7 +83,12 @@ def create_chat_model(model_config: ModelConfig, **kwargs: Any) -> Any:
                 "endpoint_api_key is required when endpoint_base_url is set for langchain_deep_agents",
                 reason="missing_endpoint_api_key",
             )
-        model_kwargs["base_url"] = _normalize_openai_endpoint_url(model_config.endpoint_base_url)
+        extra_kwargs = model_config.extra_kwargs or {}
+        endpoint_base_url_mode = str(extra_kwargs.get("endpoint_base_url_mode", "auto_v1"))
+        model_kwargs["base_url"] = _normalize_openai_endpoint_url(
+            model_config.endpoint_base_url,
+            mode=endpoint_base_url_mode,
+        )
         endpoint_api_key = model_config.endpoint_api_key
         model_kwargs["api_key"] = (
             endpoint_api_key.get_secret_value() if isinstance(endpoint_api_key, SecretStr) else endpoint_api_key

--- a/src/karenina/adapters/langchain_deep_agents/messages.py
+++ b/src/karenina/adapters/langchain_deep_agents/messages.py
@@ -10,7 +10,15 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from karenina.ports import Content, Message, Role, TextContent, ToolResultContent, ToolUseContent
+from karenina.ports import (
+    Content,
+    Message,
+    Role,
+    TextContent,
+    ThinkingContent,
+    ToolResultContent,
+    ToolUseContent,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +140,15 @@ class DeepAgentsMessageConverter:
     def _convert_ai_message(self, msg: Any) -> Message:
         """Convert a LangGraph AIMessage to a karenina Message.
 
-        Handles text content, structured content blocks, and tool calls.
+        Handles text content, structured content blocks, tool calls, and
+        chain-of-thought reasoning. Reasoning is sourced from the same
+        locations as ``trace.deep_agents_messages_to_raw_trace``:
+        ``additional_kwargs["reasoning_content"]``, ``additional_kwargs
+        ["reasoning"]``, or content-list entries with ``type == "thinking"``.
+        Putting it on the unified Message preserves parity with the CSDK
+        adapter, which already emits ``ThinkingContent`` here so downstream
+        consumers walking ``Message.content`` see reasoning identically
+        across adapters.
 
         Args:
             msg: LangGraph AIMessage instance.
@@ -141,6 +157,16 @@ class DeepAgentsMessageConverter:
             Karenina Message with Role.ASSISTANT.
         """
         content_blocks: list[Content] = []
+
+        # Place ThinkingContent first so the block order matches CSDK
+        # (thinking -> text -> tool_use), which downstream rendering relies on.
+        additional = getattr(msg, "additional_kwargs", None) or {}
+        if isinstance(additional, dict):
+            for key in ("reasoning_content", "reasoning"):
+                value = additional.get(key)
+                if isinstance(value, str) and value.strip():
+                    content_blocks.append(ThinkingContent(thinking=value))
+                    break
 
         if isinstance(msg.content, str) and msg.content:
             content_blocks.append(TextContent(text=msg.content))
@@ -159,6 +185,21 @@ class DeepAgentsMessageConverter:
                                 input=block.get("input", {}),
                             )
                         )
+                    elif block.get("type") == "thinking":
+                        thinking_text = block.get("thinking") or ""
+                        if isinstance(thinking_text, str) and thinking_text.strip():
+                            # Anthropic-style thinking block in content list:
+                            # prefer this over an additional_kwargs duplicate.
+                            content_blocks = [
+                                b for b in content_blocks if not isinstance(b, ThinkingContent)
+                            ]
+                            content_blocks.insert(
+                                0,
+                                ThinkingContent(
+                                    thinking=thinking_text,
+                                    signature=block.get("signature"),
+                                ),
+                            )
 
         if hasattr(msg, "tool_calls") and msg.tool_calls:
             for tc in msg.tool_calls:

--- a/src/karenina/adapters/langchain_deep_agents/messages.py
+++ b/src/karenina/adapters/langchain_deep_agents/messages.py
@@ -102,7 +102,17 @@ class DeepAgentsMessageConverter:
                 result.append(Message.user(msg.content if isinstance(msg.content, str) else str(msg.content)))
 
             elif isinstance(msg, AIMessage):
-                result.append(self._convert_ai_message(msg))
+                converted = self._convert_ai_message(msg)
+                # Attach per-call usage so it propagates into
+                # template.trace_messages[*].usage_metadata via to_dict().
+                # Reuse the extraction helper from trace.py to keep the two
+                # paths consistent.
+                from karenina.adapters.langchain_deep_agents.trace import (
+                    _extract_ai_usage_metadata,
+                )
+
+                converted.usage_metadata = _extract_ai_usage_metadata(msg)
+                result.append(converted)
 
             elif isinstance(msg, ToolMessage):
                 content = msg.content if isinstance(msg.content, str) else str(msg.content)

--- a/src/karenina/adapters/langchain_deep_agents/read_only_backend.py
+++ b/src/karenina/adapters/langchain_deep_agents/read_only_backend.py
@@ -1,0 +1,101 @@
+"""Read-only wrapper for DeepAgents backends."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+from deepagents.backends.protocol import (
+    EditResult,
+    FileDownloadResponse,
+    FileInfo,
+    FileUploadResponse,
+    GrepMatch,
+    WriteResult,
+)
+
+
+class ReadOnlyBackend:
+    """Backend wrapper that delegates reads but blocks mutation and execution.
+
+    This intentionally does not expose an ``execute`` method, so DeepAgents
+    should not construct a shell execution tool for this backend.
+    """
+
+    def __init__(self, delegate: Any) -> None:
+        self.delegate = delegate
+
+    def ls_info(self, path: str) -> list[FileInfo]:
+        return cast(list[FileInfo], self.delegate.ls_info(path))
+
+    async def als_info(self, path: str) -> list[FileInfo]:
+        return await asyncio.to_thread(self.ls_info, path)
+
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> str:
+        return cast(str, self.delegate.read(file_path, offset, limit))
+
+    async def aread(self, file_path: str, offset: int = 0, limit: int = 2000) -> str:
+        return await asyncio.to_thread(self.read, file_path, offset, limit)
+
+    def grep_raw(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+    ) -> list[GrepMatch] | str:
+        return cast(list[GrepMatch] | str, self.delegate.grep_raw(pattern, path, glob))
+
+    async def agrep_raw(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+    ) -> list[GrepMatch] | str:
+        return await asyncio.to_thread(self.grep_raw, pattern, path, glob)
+
+    def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+        return cast(list[FileInfo], self.delegate.glob_info(pattern, path))
+
+    async def aglob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+        return await asyncio.to_thread(self.glob_info, pattern, path)
+
+    def write(self, file_path: str, content: str) -> WriteResult:  # noqa: ARG002
+        return WriteResult(error=f"Read-only backend: writing '{file_path}' is not allowed.")
+
+    async def awrite(self, file_path: str, content: str) -> WriteResult:
+        return await asyncio.to_thread(self.write, file_path, content)
+
+    def edit(
+        self,
+        file_path: str,
+        old_string: str,  # noqa: ARG002
+        new_string: str,  # noqa: ARG002
+        replace_all: bool = False,  # noqa: ARG002, FBT001, FBT002
+    ) -> EditResult:
+        return EditResult(error=f"Read-only backend: editing '{file_path}' is not allowed.")
+
+    async def aedit(
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,  # noqa: FBT001, FBT002
+    ) -> EditResult:
+        return await asyncio.to_thread(self.edit, file_path, old_string, new_string, replace_all)
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        return [FileUploadResponse(path=path, error="permission_denied") for path, _content in files]
+
+    async def aupload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        return await asyncio.to_thread(self.upload_files, files)
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        return cast(list[FileDownloadResponse], self.delegate.download_files(paths))
+
+    async def adownload_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        return await asyncio.to_thread(self.download_files, paths)
+
+    def __getattr__(self, name: str) -> Any:
+        if name in {"execute", "aexecute"}:
+            raise AttributeError(name)
+        return getattr(self.delegate, name)

--- a/src/karenina/adapters/langchain_deep_agents/runtime.py
+++ b/src/karenina/adapters/langchain_deep_agents/runtime.py
@@ -1,64 +1,21 @@
-"""Runtime helpers for the LangChain DeepAgents adapter."""
+"""Compatibility wrapper for DeepAgents runtime helpers."""
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import TYPE_CHECKING
+from karenina.adapters.agent_runtime import (
+    SANDBOX_WORKSPACE_PATH,
+    get_agent_runtime_capabilities,
+    get_deepagents_backend,
+    map_path_for_prompt,
+    workspace_path_for_prompt,
+)
 
-from karenina.ports.capabilities import PortCapabilities
+get_deepagents_capabilities = get_agent_runtime_capabilities
 
-if TYPE_CHECKING:
-    from karenina.schemas.config import ModelConfig
-
-
-SANDBOX_WORKSPACE_PATH = "/workspace"
-
-
-def get_deepagents_backend(model_config: ModelConfig) -> str:
-    """Return the configured DeepAgents backend name."""
-
-    return getattr(model_config, "deepagents_backend", "filesystem")
-
-
-def get_deepagents_capabilities(model_config: ModelConfig) -> PortCapabilities:
-    """Return agent capabilities implied by the DeepAgents backend."""
-
-    backend = get_deepagents_backend(model_config)
-    return PortCapabilities(
-        supports_system_prompt=True,
-        supports_file_tools=True,
-        supports_code_execution=backend in {"docker", "local_shell"},
-        uses_sandboxed_execution=backend == "docker",
-    )
-
-
-def workspace_path_for_prompt(model_config: ModelConfig, workspace_path: Path | None) -> str | None:
-    """Return the workspace path that should be shown to the model."""
-
-    if workspace_path is None:
-        return None
-    if get_deepagents_backend(model_config) == "docker":
-        return SANDBOX_WORKSPACE_PATH
-    return str(workspace_path)
-
-
-def map_path_for_prompt(
-    model_config: ModelConfig,
-    path: Path | None,
-    workspace_path: Path | None,
-) -> str | None:
-    """Map a host workspace path to the sandbox-visible path when needed."""
-
-    if path is None:
-        return None
-    if get_deepagents_backend(model_config) != "docker" or workspace_path is None:
-        return str(path)
-
-    try:
-        rel = path.resolve().relative_to(workspace_path.resolve())
-    except ValueError:
-        return str(path)
-
-    if rel.as_posix() == ".":
-        return SANDBOX_WORKSPACE_PATH
-    return f"{SANDBOX_WORKSPACE_PATH}/{rel.as_posix()}"
+__all__ = [
+    "SANDBOX_WORKSPACE_PATH",
+    "get_deepagents_backend",
+    "get_deepagents_capabilities",
+    "map_path_for_prompt",
+    "workspace_path_for_prompt",
+]

--- a/src/karenina/adapters/langchain_deep_agents/runtime.py
+++ b/src/karenina/adapters/langchain_deep_agents/runtime.py
@@ -1,0 +1,64 @@
+"""Runtime helpers for the LangChain DeepAgents adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from karenina.ports.capabilities import PortCapabilities
+
+if TYPE_CHECKING:
+    from karenina.schemas.config import ModelConfig
+
+
+SANDBOX_WORKSPACE_PATH = "/workspace"
+
+
+def get_deepagents_backend(model_config: ModelConfig) -> str:
+    """Return the configured DeepAgents backend name."""
+
+    return getattr(model_config, "deepagents_backend", "filesystem")
+
+
+def get_deepagents_capabilities(model_config: ModelConfig) -> PortCapabilities:
+    """Return agent capabilities implied by the DeepAgents backend."""
+
+    backend = get_deepagents_backend(model_config)
+    return PortCapabilities(
+        supports_system_prompt=True,
+        supports_file_tools=True,
+        supports_code_execution=backend in {"docker", "local_shell"},
+        uses_sandboxed_execution=backend == "docker",
+    )
+
+
+def workspace_path_for_prompt(model_config: ModelConfig, workspace_path: Path | None) -> str | None:
+    """Return the workspace path that should be shown to the model."""
+
+    if workspace_path is None:
+        return None
+    if get_deepagents_backend(model_config) == "docker":
+        return SANDBOX_WORKSPACE_PATH
+    return str(workspace_path)
+
+
+def map_path_for_prompt(
+    model_config: ModelConfig,
+    path: Path | None,
+    workspace_path: Path | None,
+) -> str | None:
+    """Map a host workspace path to the sandbox-visible path when needed."""
+
+    if path is None:
+        return None
+    if get_deepagents_backend(model_config) != "docker" or workspace_path is None:
+        return str(path)
+
+    try:
+        rel = path.resolve().relative_to(workspace_path.resolve())
+    except ValueError:
+        return str(path)
+
+    if rel.as_posix() == ".":
+        return SANDBOX_WORKSPACE_PATH
+    return f"{SANDBOX_WORKSPACE_PATH}/{rel.as_posix()}"

--- a/src/karenina/adapters/langchain_deep_agents/trace.py
+++ b/src/karenina/adapters/langchain_deep_agents/trace.py
@@ -3,6 +3,10 @@
 Converts LangGraph BaseMessage lists into karenina's raw trace format:
 a delimited string for backward compatibility with existing infrastructure
 (regex highlighting, database storage, trace validation).
+
+Also exposes a structured trace_messages builder that returns the
+list[dict] shape consumed by the frontend TraceMessage component and
+preserves per-call usage_metadata on assistant entries.
 """
 
 from __future__ import annotations
@@ -12,6 +16,56 @@ import logging
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_ai_usage_metadata(msg: Any) -> dict[str, int] | None:
+    """Extract per-call usage metadata from a LangChain AIMessage.
+
+    Prefers AIMessage.usage_metadata (the modern LangChain standard with
+    input_tokens / output_tokens keys). Falls back to
+    response_metadata.token_usage (older LangChain shape with
+    prompt_tokens / completion_tokens) and renames the keys.
+
+    Mirrors the per-message extraction logic in
+    `langchain_deep_agents/usage.py:extract_deep_agents_usage` but
+    returns the per-message dict instead of aggregating.
+
+    Args:
+        msg: A LangGraph AIMessage instance.
+
+    Returns:
+        Dict with input_tokens / output_tokens (and any cache fields
+        propagated from usage_metadata when present), or None when no
+        usage information is reported.
+    """
+    usage_meta = getattr(msg, "usage_metadata", None)
+    if usage_meta and isinstance(usage_meta, dict):
+        per_call: dict[str, int] = {
+            "input_tokens": int(usage_meta.get("input_tokens", 0) or 0),
+            "output_tokens": int(usage_meta.get("output_tokens", 0) or 0),
+        }
+        # If the prompt-cache middleware is in use, LangChain may expose
+        # Anthropic-shaped cache fields here. Forward them when present.
+        cache_read = usage_meta.get("cache_read_input_tokens")
+        if cache_read is not None:
+            per_call["cache_read_input_tokens"] = int(cache_read)
+        cache_creation = usage_meta.get("cache_creation_input_tokens")
+        if cache_creation is not None:
+            per_call["cache_creation_input_tokens"] = int(cache_creation)
+        return per_call
+
+    resp_meta = getattr(msg, "response_metadata", None)
+    if resp_meta and isinstance(resp_meta, dict):
+        token_usage = resp_meta.get("token_usage")
+        if isinstance(token_usage, dict) and (
+            "prompt_tokens" in token_usage or "completion_tokens" in token_usage
+        ):
+            return {
+                "input_tokens": int(token_usage.get("prompt_tokens", 0) or 0),
+                "output_tokens": int(token_usage.get("completion_tokens", 0) or 0),
+            }
+
+    return None
 
 
 def deep_agents_messages_to_raw_trace(
@@ -90,3 +144,99 @@ def _extract_ai_text(msg: Any) -> str:
         return "\n".join(text_parts)
 
     return ""
+
+
+def deep_agents_messages_to_trace_messages(
+    messages: list[Any],
+    include_user_messages: bool = False,
+) -> list[dict[str, Any]]:
+    """Convert LangGraph messages to structured TraceMessage list.
+
+    Produces the structured list[dict] format consumed by the frontend
+    TraceMessage component. Each assistant entry preserves per-call
+    usage_metadata when the underlying AIMessage reports it (so
+    post-hoc audits of token usage / cache hits per turn remain possible).
+
+    Args:
+        messages: List of LangGraph BaseMessage objects.
+        include_user_messages: If True, include HumanMessage entries. Defaults
+            to False to match the existing raw_trace behavior.
+
+    Returns:
+        List of TraceMessage dicts with role, content, block_index, and
+        optional tool_calls, tool_result, and usage_metadata fields.
+    """
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+    if not messages:
+        return []
+
+    result: list[dict[str, Any]] = []
+    block_index = 0
+
+    for msg in messages:
+        if isinstance(msg, SystemMessage):
+            continue
+
+        if isinstance(msg, HumanMessage):
+            if include_user_messages:
+                content = msg.content if isinstance(msg.content, str) else str(msg.content)
+                if content:
+                    result.append(
+                        {
+                            "role": "user",
+                            "content": content,
+                            "block_index": block_index,
+                        }
+                    )
+                    block_index += 1
+            continue
+
+        if isinstance(msg, AIMessage):
+            text = _extract_ai_text(msg)
+            tool_calls: list[dict[str, Any]] = []
+            if hasattr(msg, "tool_calls") and msg.tool_calls:
+                for tc in msg.tool_calls:
+                    tool_calls.append(
+                        {
+                            "id": tc.get("id", ""),
+                            "name": tc.get("name", "unknown"),
+                            "input": tc.get("args", {}) if isinstance(tc.get("args"), dict) else {},
+                        }
+                    )
+
+            if text or tool_calls:
+                trace_msg: dict[str, Any] = {
+                    "role": "assistant",
+                    "content": text,
+                    "block_index": block_index,
+                }
+
+                if tool_calls:
+                    trace_msg["tool_calls"] = tool_calls
+
+                usage_metadata = _extract_ai_usage_metadata(msg)
+                if usage_metadata is not None:
+                    trace_msg["usage_metadata"] = usage_metadata
+
+                result.append(trace_msg)
+                block_index += 1
+            continue
+
+        if isinstance(msg, ToolMessage):
+            content = msg.content if isinstance(msg.content, str) else str(msg.content)
+            tool_use_id = getattr(msg, "tool_call_id", "") or ""
+            result.append(
+                {
+                    "role": "tool",
+                    "content": content,
+                    "block_index": block_index,
+                    "tool_result": {
+                        "tool_use_id": tool_use_id,
+                        "is_error": False,
+                    },
+                }
+            )
+            block_index += 1
+
+    return result

--- a/src/karenina/adapters/langchain_deep_agents/trace.py
+++ b/src/karenina/adapters/langchain_deep_agents/trace.py
@@ -101,6 +101,10 @@ def deep_agents_messages_to_raw_trace(
             continue
 
         if isinstance(msg, AIMessage):
+            thinking = _extract_thinking_content(msg)
+            if thinking:
+                parts.append(f"--- Thinking ---\n{thinking}")
+
             text = _extract_ai_text(msg)
 
             if text:
@@ -118,6 +122,45 @@ def deep_agents_messages_to_raw_trace(
             parts.append(f"--- Tool Result ---\n{content}")
 
     return "\n\n".join(parts)
+
+
+def _extract_thinking_content(msg: Any) -> str:
+    """Extract reasoning / thinking content from a LangChain AIMessage.
+
+    LangChain has no single canonical location for chain-of-thought content
+    across providers. Check, in priority order:
+
+    1. ``additional_kwargs["reasoning_content"]`` — vLLM's OpenAI-compatible
+       endpoint emits ``delta.reasoning_content`` for thinking models
+       (qwen3, deepseek-r1, etc.); recent langchain_openai surfaces it here.
+    2. ``additional_kwargs["reasoning"]`` — alternate naming used by some
+       providers / older LangChain wrappers.
+    3. Anthropic-style content blocks with ``type == "thinking"`` inside
+       ``msg.content`` when the model is invoked through an Anthropic
+       wrapper. The ``thinking`` key holds the text.
+
+    Returns an empty string when none of these surface a reasoning trace,
+    so the caller can skip the ``--- Thinking ---`` section entirely.
+    """
+    additional = getattr(msg, "additional_kwargs", None) or {}
+    if isinstance(additional, dict):
+        for key in ("reasoning_content", "reasoning"):
+            value = additional.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+
+    content = getattr(msg, "content", None)
+    if isinstance(content, list):
+        thinking_parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "thinking":
+                text = block.get("thinking") or ""
+                if isinstance(text, str) and text.strip():
+                    thinking_parts.append(text)
+        if thinking_parts:
+            return "\n".join(thinking_parts)
+
+    return ""
 
 
 def _extract_ai_text(msg: Any) -> str:
@@ -194,6 +237,7 @@ def deep_agents_messages_to_trace_messages(
 
         if isinstance(msg, AIMessage):
             text = _extract_ai_text(msg)
+            thinking = _extract_thinking_content(msg)
             tool_calls: list[dict[str, Any]] = []
             if hasattr(msg, "tool_calls") and msg.tool_calls:
                 for tc in msg.tool_calls:
@@ -205,7 +249,7 @@ def deep_agents_messages_to_trace_messages(
                         }
                     )
 
-            if text or tool_calls:
+            if text or tool_calls or thinking:
                 trace_msg: dict[str, Any] = {
                     "role": "assistant",
                     "content": text,
@@ -214,6 +258,12 @@ def deep_agents_messages_to_trace_messages(
 
                 if tool_calls:
                     trace_msg["tool_calls"] = tool_calls
+
+                if thinking:
+                    # Mirror the CSDK structured-trace shape so downstream
+                    # consumers (frontend trace component, evaluators) can
+                    # treat reasoning identically across adapters.
+                    trace_msg["thinking"] = {"thinking": thinking}
 
                 usage_metadata = _extract_ai_usage_metadata(msg)
                 if usage_metadata is not None:

--- a/src/karenina/adapters/langchain_deep_agents/trace.py
+++ b/src/karenina/adapters/langchain_deep_agents/trace.py
@@ -11,7 +11,6 @@ preserves per-call usage_metadata on assistant entries.
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
 
@@ -74,15 +73,21 @@ def deep_agents_messages_to_raw_trace(
 ) -> str:
     """Convert LangGraph messages to raw trace string format.
 
-    Produces delimited trace compatible with existing karenina infrastructure
-    (regex highlighting, database storage, backward compatibility).
+    Produces the canonical karenina trace format shared by the langchain,
+    claude_agent_sdk, and manual adapters: one ``--- AI Message ---``
+    section per turn carrying the text followed by an inline ``Tool Calls:``
+    block, and ``--- Tool Message (call_id: <id>) ---`` for each tool
+    result. Thinking content surfaces as a separate ``--- Thinking ---``
+    section before the AI Message for that turn.
 
     Args:
         messages: List of LangGraph BaseMessage objects.
         include_user_messages: If True, include HumanMessage in trace.
 
     Returns:
-        Formatted trace string with --- delimiters.
+        Formatted trace string with ``---`` delimiters compatible with
+        regex highlighting, database storage, and the trace-evaluation
+        infrastructure shared with the other adapters.
     """
     from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
@@ -106,20 +111,28 @@ def deep_agents_messages_to_raw_trace(
                 parts.append(f"--- Thinking ---\n{thinking}")
 
             text = _extract_ai_text(msg)
+            tool_calls = getattr(msg, "tool_calls", None) or []
 
-            if text:
-                parts.append(f"--- AI Message ---\n{text}")
-
-            if hasattr(msg, "tool_calls") and msg.tool_calls:
-                for tc in msg.tool_calls:
-                    tool_name = tc.get("name", "unknown")
-                    tool_input = tc.get("args", {})
-                    input_str = json.dumps(tool_input, indent=2) if tool_input else "{}"
-                    parts.append(f"--- Tool Call ---\nTool: {tool_name}\nInput: {input_str}")
+            if text or tool_calls:
+                content_parts: list[str] = []
+                if text:
+                    content_parts.append(text)
+                if tool_calls:
+                    content_parts.append("\nTool Calls:")
+                    for tc in tool_calls:
+                        tool_name = tc.get("name", "unknown")
+                        tool_id = tc.get("id", "unknown")
+                        tool_args = tc.get("args", {})
+                        content_parts.append(f"  {tool_name} (call_{tool_id})")
+                        content_parts.append(f"   Call ID: {tool_id}")
+                        if tool_args:
+                            content_parts.append(f"   Args: {tool_args}")
+                parts.append("--- AI Message ---\n" + "\n".join(content_parts))
 
         elif isinstance(msg, ToolMessage):
             content = msg.content if isinstance(msg.content, str) else str(msg.content)
-            parts.append(f"--- Tool Result ---\n{content}")
+            tool_call_id = getattr(msg, "tool_call_id", "unknown") or "unknown"
+            parts.append(f"--- Tool Message (call_id: {tool_call_id}) ---\n{content}")
 
     return "\n\n".join(parts)
 

--- a/src/karenina/adapters/registry.py
+++ b/src/karenina/adapters/registry.py
@@ -268,6 +268,9 @@ class AdapterSpec:
         availability_checker: Function to check if this adapter is available.
         fallback_interface: Interface to fall back to if this one is unavailable.
         routes_to: If set, this interface routes to another (e.g., "openrouter" -> "langchain").
+        runtime_profile: Optional runtime behavior profile for shared agent
+            prompt/capability helpers. External adapters can provide this to
+            integrate with sandbox path mapping without changing core code.
 
     Example:
         >>> spec = AdapterSpec(
@@ -294,6 +297,10 @@ class AdapterSpec:
 
     # Routing (for interfaces that delegate to another)
     routes_to: str | None = None
+
+    # Optional runtime behavior extension hook. Kept as Any to avoid coupling
+    # the adapter registry to agent-only helper types at import time.
+    runtime_profile: Any | None = None
 
     # Additional metadata
     supports_mcp: bool = False
@@ -368,6 +375,10 @@ class AdapterRegistry:
             logger.warning(f"Overwriting existing adapter spec for interface: {spec.interface}")
 
         cls._specs[spec.interface] = spec
+        if spec.runtime_profile is not None:
+            from karenina.adapters.agent_runtime import register_agent_runtime_profile
+
+            register_agent_runtime_profile(spec.interface, spec.runtime_profile, force=force)
         logger.debug(f"Registered adapter: {spec.interface} ({spec.description})")
         return spec
 

--- a/src/karenina/benchmark/verification/__init__.py
+++ b/src/karenina/benchmark/verification/__init__.py
@@ -13,6 +13,7 @@ from .executor import (
 )
 from .extension import extend_template_run
 from .sinks import (
+    AgenticProgressiveFileSink,
     CompositeSink,
     DBSink,
     InMemorySink,
@@ -49,6 +50,7 @@ __all__ = [
     # Sinks
     "ResultSink",
     "ProgressiveFileSink",
+    "AgenticProgressiveFileSink",
     "CompositeSink",
     "DBSink",
     "InMemorySink",

--- a/src/karenina/benchmark/verification/batch_runner.py
+++ b/src/karenina/benchmark/verification/batch_runner.py
@@ -375,6 +375,9 @@ def execute_task(
             workspace_root=task.get("workspace_root"),
             workspace_copy=task.get("workspace_copy", True),
             workspace_cleanup=task.get("workspace_cleanup", True),
+            workspace_output_mode=task.get("workspace_output_mode", "none"),
+            workspace_output_dir=task.get("workspace_output_dir"),
+            workspace_output_exclude_patterns=task.get("workspace_output_exclude_patterns"),
             question_workspace_path=task.get("question_workspace_path"),
             # Agentic rubric evaluation
             agentic_rubric_strategy=task.get("agentic_rubric_strategy", "individual"),
@@ -598,6 +601,15 @@ def run_verification_batch(
             sink.on_finalize(all_complete=all_complete)
         except Exception:  # noqa: BLE001
             logger.warning("Sink on_finalize raised; continuing", exc_info=True)
+
+    workspace_output_dir: Path | None = config.workspace_output_dir
+    if all_complete and config.workspace_output_mode != "none" and workspace_output_dir is not None:
+        from karenina.benchmark.verification.workspace_capture import compact_manifest
+
+        try:
+            compact_manifest(workspace_output_dir)
+        except Exception:  # noqa: BLE001
+            logger.warning("Workspace capture manifest compaction raised; continuing", exc_info=True)
 
     # Convert dict to VerificationResultSet
     result_list = list(results.values())

--- a/src/karenina/benchmark/verification/evaluators/rubric/agentic_trait.py
+++ b/src/karenina/benchmark/verification/evaluators/rubric/agentic_trait.py
@@ -14,6 +14,7 @@ from typing import Any, cast
 from pydantic import BaseModel
 
 from karenina.adapters import get_agent, get_llm, get_parser
+from karenina.adapters.langchain_deep_agents.runtime import map_path_for_prompt, workspace_path_for_prompt
 from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
 from karenina.ports import AgentConfig, Message, PortCapabilities
@@ -123,9 +124,31 @@ class AgenticTraitEvaluator:
         Returns:
             Raw investigation trace string.
         """
+        agent = None
+        capabilities = PortCapabilities()
+        needs_tools = (
+            trait.context_mode != "trace_only"
+            or workspace_path is not None
+            or (trait.materialize_trace and trace_file_path is not None)
+        )
+        if needs_tools:
+            agent = get_agent(self._model_config)
+            capabilities = agent.capabilities
+
+        if capabilities.supports_code_execution:
+            execution_text = (
+                "You may inspect files and execute commands in the sandboxed workspace."
+                if capabilities.uses_sandboxed_execution
+                else "You may inspect files and execute commands in the configured workspace."
+            )
+        elif capabilities.supports_file_tools:
+            execution_text = "You may inspect files, but command execution is not available."
+        else:
+            execution_text = "Use only the response text supplied in the prompt."
         system_text = (
             "You are an evaluation agent investigating the quality of an LLM response. "
             f"Your task: {trait.description}\n\n"
+            f"{execution_text}\n\n"
             "After investigating, summarize your findings clearly. Your investigation "
             f"trace will be parsed into a {trait.kind} result."
         )
@@ -135,8 +158,13 @@ class AgenticTraitEvaluator:
 
         if trait.context_mode in ("trace_and_workspace", "trace_only") and raw_llm_response:
             if trait.materialize_trace and trace_file_path:
+                prompt_trace_path = map_path_for_prompt(
+                    self._model_config,
+                    trace_file_path,
+                    Path(workspace_path) if workspace_path else None,
+                )
                 trace_content = (
-                    f"The full agent trace is saved to: {trace_file_path}\n"
+                    f"The full agent trace is saved to: {prompt_trace_path}\n"
                     "Use file tools (grep, search, read) to examine it."
                 )
             else:
@@ -144,7 +172,8 @@ class AgenticTraitEvaluator:
             user_parts.append(f"\n--- ANSWERING AGENT TRACE ---\n{trace_content}\n--- END TRACE ---")
 
         if workspace_path and trait.context_mode != "trace_only":
-            user_parts.append(f"\nWorkspace directory: {workspace_path}")
+            prompt_workspace = workspace_path_for_prompt(self._model_config, Path(workspace_path))
+            user_parts.append(f"\nWorkspace directory: {prompt_workspace}")
 
         user_text = "\n".join(user_parts)
 
@@ -152,7 +181,7 @@ class AgenticTraitEvaluator:
         assembler = PromptAssembler(
             task=PromptTask.RUBRIC_AGENTIC_TRAIT_INVESTIGATION,
             interface=self._model_config.interface,
-            capabilities=PortCapabilities(),
+            capabilities=capabilities,
         )
         user_instructions = (
             self._prompt_config.get_for_task(PromptTask.RUBRIC_AGENTIC_TRAIT_INVESTIGATION.value)
@@ -165,19 +194,11 @@ class AgenticTraitEvaluator:
             user_instructions=user_instructions,
         )
 
-        # For trace_only without workspace and without materialized trace file,
-        # use LLMPort (no tools needed; trace is inlined in the prompt).
-        # When materialize_trace is active with a file path, the agent needs
-        # file tools to read the trace, so AgentPort is still required.
-        needs_tools = (
-            trait.context_mode != "trace_only"
-            or workspace_path is not None
-            or (trait.materialize_trace and trace_file_path is not None)
-        )
         if not needs_tools:
             return self._run_llm_investigation(trait, messages)
 
-        return self._run_agent_investigation(trait, messages, workspace_path)
+        assert agent is not None
+        return self._run_agent_investigation(trait, messages, workspace_path, agent=agent)
 
     def _run_llm_investigation(
         self,
@@ -205,9 +226,12 @@ class AgenticTraitEvaluator:
         trait: AgenticRubricTrait,
         messages: list[Message],
         workspace_path: Path | str | None,
+        *,
+        agent: Any | None = None,
     ) -> str:
         """Run investigation via AgentPort (multi-turn with tools)."""
-        agent = get_agent(self._model_config)
+        if agent is None:
+            agent = get_agent(self._model_config)
 
         agent_config = AgentConfig(
             max_turns=trait.max_turns,

--- a/src/karenina/benchmark/verification/evaluators/rubric/agentic_trait.py
+++ b/src/karenina/benchmark/verification/evaluators/rubric/agentic_trait.py
@@ -14,7 +14,7 @@ from typing import Any, cast
 from pydantic import BaseModel
 
 from karenina.adapters import get_agent, get_llm, get_parser
-from karenina.adapters.langchain_deep_agents.runtime import map_path_for_prompt, workspace_path_for_prompt
+from karenina.adapters.agent_runtime import map_path_for_prompt, workspace_path_for_prompt
 from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
 from karenina.ports import AgentConfig, Message, PortCapabilities

--- a/src/karenina/benchmark/verification/evaluators/template/evaluator.py
+++ b/src/karenina/benchmark/verification/evaluators/template/evaluator.py
@@ -17,7 +17,11 @@ from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
 from karenina.benchmark.verification.prompts.parsing.parsing_instructions import TemplatePromptBuilder
 from karenina.benchmark.verification.utils import prepare_evaluation_input
-from karenina.benchmark.verification.utils.schema_builder import build_parsing_schema
+from karenina.benchmark.verification.utils.schema_builder import (
+    build_extraction_relaxed_class,
+    build_parsing_schema,
+    rebuild_strict_answer_with_null_fields,
+)
 from karenina.ports import LLMPort
 from karenina.schemas.config import ModelConfig
 from karenina.schemas.entities import BaseAnswer
@@ -311,9 +315,16 @@ class TemplateEvaluator:
                 },
             )
 
-            # 3. Parse via adapter (returns ParsePortResult with usage)
-            parse_port_result = self._parser.parse_to_pydantic(messages, self.answer_class)
-            parsed = parse_port_result.parsed
+            # 3. Parse via adapter (returns ParsePortResult with usage).
+            # Use a relaxed extraction class so a null verified field does not
+            # reject the whole record. The strict Answer instance tracks those
+            # fields via _null_fields for tri-valued field_results.
+            extraction_class = build_extraction_relaxed_class(self.answer_class)
+            parse_port_result = self._parser.parse_to_pydantic(messages, extraction_class)
+            parsed = rebuild_strict_answer_with_null_fields(
+                self.answer_class,
+                parse_port_result.parsed,
+            )
 
             if isinstance(parsed, self.answer_class):
                 result.parsed_answer = parsed

--- a/src/karenina/benchmark/verification/executor.py
+++ b/src/karenina/benchmark/verification/executor.py
@@ -48,6 +48,11 @@ _INFRA_FAILURE_CATEGORIES: frozenset[FailureCategory] = frozenset(
     }
 )
 
+
+def _is_parser_stage(stage: str | None) -> bool:
+    return stage in {"parse_template", "ParseTemplate", "AgenticParseTemplate"}
+
+
 # Bound (seconds) on each adapter.aclose() call issued via the worker portal
 # before the portal is torn down. A stuck aclose must not wedge the finally
 # block. Mirrors the pattern in langchain/parser.py:297-312. Tests can
@@ -283,7 +288,7 @@ class VerificationExecutor:
 
             failure = result.metadata.failure
             if failure is not None:
-                if failure.category in _INFRA_FAILURE_CATEGORIES:
+                if failure.category in _INFRA_FAILURE_CATEGORIES and not _is_parser_stage(failure.stage):
                     skipped += 1
                     continue
                 if failure.stage == "TraceValidationAutoFail":

--- a/src/karenina/benchmark/verification/runner.py
+++ b/src/karenina/benchmark/verification/runner.py
@@ -98,6 +98,9 @@ def run_single_model_verification(
     workspace_root: Path | None = None,
     workspace_copy: bool = True,
     workspace_cleanup: bool = True,
+    workspace_output_mode: str = "none",
+    workspace_output_dir: Path | None = None,
+    workspace_output_exclude_patterns: list[str] | None = None,
     question_workspace_path: str | None = None,
     # Agentic rubric evaluation configuration
     agentic_rubric_strategy: str = "individual",
@@ -224,6 +227,9 @@ def run_single_model_verification(
         workspace_root=workspace_root,
         workspace_copy=workspace_copy,
         workspace_cleanup=workspace_cleanup,
+        workspace_output_mode=workspace_output_mode,
+        workspace_output_dir=workspace_output_dir,
+        workspace_output_exclude_patterns=workspace_output_exclude_patterns or [],
         # Agentic Rubric
         agentic_rubric_strategy=agentic_rubric_strategy,
         agentic_rubric_parallel=agentic_rubric_parallel,

--- a/src/karenina/benchmark/verification/scenario_executor.py
+++ b/src/karenina/benchmark/verification/scenario_executor.py
@@ -128,8 +128,22 @@ class ScenarioExecutor:
             combo ordering. Errors are (description, exception) tuples.
         """
         if self.parallel:
-            return self._run_parallel(combos, config, global_rubric, run_name, progress_callback, workspace_root)
-        return self._run_sequential(combos, config, global_rubric, run_name, progress_callback, workspace_root)
+            results, errors = self._run_parallel(
+                combos, config, global_rubric, run_name, progress_callback, workspace_root
+            )
+        else:
+            results, errors = self._run_sequential(
+                combos, config, global_rubric, run_name, progress_callback, workspace_root
+            )
+
+        if not errors and config.workspace_output_mode != "none" and config.workspace_output_dir is not None:
+            from karenina.benchmark.verification.workspace_capture import compact_manifest
+
+            try:
+                compact_manifest(config.workspace_output_dir)
+            except Exception:  # noqa: BLE001
+                logger.warning("Workspace capture manifest compaction raised; continuing", exc_info=True)
+        return results, errors
 
     def _run_sequential(
         self,

--- a/src/karenina/benchmark/verification/sinks.py
+++ b/src/karenina/benchmark/verification/sinks.py
@@ -5,12 +5,15 @@ as each task completes. It is the single extension point for progressive
 save, crash recovery, database auto-save, and any other per-result
 persistence the caller may need.
 
-Three implementations live here:
+Four implementations live here:
 
 - :class:`ProgressiveFileSink`: appends each completed result to a JSONL
   sidecar and maintains a :file:`.state` manifest, so a crashed run can be
   resumed via :func:`VerificationConfig.skip_triples`. Replaces the legacy
   `ProgressiveSaveManager` full-rewrite strategy.
+- :class:`AgenticProgressiveFileSink`: extends the progressive file sink with
+  readable trace sidecars and parser-failure retry semantics for agentic
+  workspace runs.
 - :class:`CompositeSink`: fans out to several sinks in order; used when a
   single run wants both file progressive-save and database auto-save.
 - :class:`InMemorySink`: test-friendly sink that just buffers results.
@@ -32,9 +35,11 @@ from typing import Any, Protocol, runtime_checkable
 from karenina.benchmark.verification.stages.helpers.results_exporter import (
     export_verification_results_json_stream,
 )
+from karenina.benchmark.verification.workspace_capture import safe_path_component
 from karenina.schemas import VerificationConfig, VerificationResult
 from karenina.schemas.entities import Rubric
 from karenina.schemas.results import VerificationResultSet
+from karenina.schemas.results.failure import FailureCategory
 from karenina.schemas.verification import VerificationJob
 from karenina.utils.file_ops import atomic_write
 from karenina.utils.progressive_save import TaskIdentifier
@@ -71,6 +76,36 @@ def _is_content_failure(failure: Any) -> bool:
     return bool(_failure_attr(failure, "group") == "content" or _failure_attr(failure, "category") == "content")
 
 
+def _is_parser_stage(stage: str | None) -> bool:
+    return stage in {"parse_template", "ParseTemplate", "AgenticParseTemplate"}
+
+
+def _has_usable_answer_trace(result: VerificationResult) -> bool:
+    template = result.template
+    if template is None:
+        return False
+    return bool((template.raw_llm_response or "").strip())
+
+
+def _is_retryable_parser_failure(result: VerificationResult) -> bool:
+    """Return True when a result should checkpoint answer output, not skip resume.
+
+    Agentic workspace runs can fail after answer generation, during the
+    investigation or structured extraction/parser phase. Those rows contain a
+    useful answer trace and workspace artifacts, so resume should rehydrate the
+    answer cache and retry parsing/verification instead of rerunning the
+    answerer or treating the task as terminal.
+    """
+
+    failure = result.metadata.failure
+    if failure is None or not _has_usable_answer_trace(result):
+        return False
+
+    category = _failure_attr(failure, "category")
+    stage = _failure_attr(failure, "stage")
+    return bool(category == FailureCategory.PARSING.value or _is_parser_stage(stage))
+
+
 def _export_scenario_turn(row: VerificationResult) -> dict[str, Any]:
     template = row.template
     return {
@@ -102,6 +137,36 @@ def _scenario_manifest_key(result: VerificationResult, manifest: Iterable[str]) 
     if fallback in candidates:
         return fallback
     return fallback
+
+
+def _dedupe_latest_by_manifest_key(
+    rows: Iterable[VerificationResult],
+    *,
+    manifest: Iterable[str] = (),
+) -> list[VerificationResult]:
+    """Keep the latest row for each manifest key while preserving first-key order."""
+
+    latest: dict[str, VerificationResult] = {}
+    order: list[str] = []
+    for row in rows:
+        key = _scenario_manifest_key(row, manifest)
+        if key not in latest:
+            order.append(key)
+        latest[key] = row
+    return [latest[key] for key in order]
+
+
+def _count_success_failure(rows: Iterable[VerificationResult]) -> tuple[int, int]:
+    """Count passing and failing rows using the structured failure marker."""
+
+    successful = 0
+    failed = 0
+    for row in rows:
+        if row.metadata.failure is None:
+            successful += 1
+        else:
+            failed += 1
+    return successful, failed
 
 
 def _reconstruct_scenario_results_for_export(
@@ -492,6 +557,11 @@ class ProgressiveFileSink:
         """Total tasks in the manifest."""
         return len(self._manifest)
 
+    @property
+    def task_manifest(self) -> list[str]:
+        """Task manifest keys recorded for this run."""
+        return list(self._manifest)
+
     def get_all_results(self) -> list[VerificationResult]:
         """Return a shallow copy of buffered completed results."""
         return list(self._results)
@@ -547,13 +617,17 @@ class ProgressiveFileSink:
         """
         target = output_path or self.output_path
         now = time.time()
+        results = list(_read_jsonl_results(self.jsonl_path)) if self.jsonl_path.exists() else []
+        latest_rows = _dedupe_latest_by_manifest_key(results, manifest=self._manifest)
+        successful_count, failed_count = _count_success_failure(latest_rows)
         job = VerificationJob(
             job_id=f"progressive-{int(self._start_time or now)}",
             run_name="progressive",
             status="completed",
             config=self.config,
             total_questions=self.total_tasks,
-            successful_count=self.completed_count,
+            successful_count=successful_count,
+            failed_count=failed_count,
             start_time=self._start_time,
             end_time=now,
         )
@@ -561,7 +635,6 @@ class ProgressiveFileSink:
         # called before any on_result (e.g. the empty-run case), in which case
         # jsonl_path was never created; guard is mandatory because
         # _read_jsonl_results opens the path unconditionally.
-        results = list(_read_jsonl_results(self.jsonl_path)) if self.jsonl_path.exists() else []
         scenario_results = _reconstruct_scenario_results_for_export(results, manifest=self._manifest)
         export_verification_results_json_stream(
             job,
@@ -581,6 +654,193 @@ class ProgressiveFileSink:
                     path.unlink()
             except OSError as e:
                 logger.warning("Failed to remove %s: %s", path, e)
+
+
+# ---------------------------------------------------------------------------
+# AgenticProgressiveFileSink
+# ---------------------------------------------------------------------------
+
+
+class AgenticProgressiveFileSink(ProgressiveFileSink):
+    """Progressive sink for agentic workspace benchmarks.
+
+    This sink keeps the standard JSONL + state resume machinery, adds readable
+    trace sidecars, and treats parser-stage failures with a usable answer trace
+    as resumable checkpoints. On resume those rows are exposed through
+    :meth:`iter_results` for answer-cache hydration, but omitted from
+    :meth:`completed_triples` so parsing can be retried.
+    """
+
+    def __init__(
+        self,
+        output_path: Path,
+        config: VerificationConfig,
+        benchmark_path: str,
+        global_rubric: Rubric | None = None,
+        *,
+        trace_output_dir: Path | None = None,
+        trace_layout: str = "question",
+        keep_progress_sidecars: bool = False,
+        write_partial_export: bool = True,
+    ) -> None:
+        super().__init__(
+            output_path=output_path,
+            config=config,
+            benchmark_path=benchmark_path,
+            global_rubric=global_rubric,
+        )
+        if trace_layout not in {"question", "result"}:
+            raise ValueError("trace_layout must be 'question' or 'result'")
+        self.trace_output_dir = trace_output_dir
+        self.trace_layout = trace_layout
+        self.keep_progress_sidecars = keep_progress_sidecars
+        self.write_partial_export = write_partial_export
+
+    @classmethod
+    def load_for_resume(
+        cls,
+        state_path: Path,
+        *,
+        global_rubric: Rubric | None = None,
+        trace_output_dir: Path | None = None,
+        trace_layout: str = "question",
+        keep_progress_sidecars: bool = False,
+        write_partial_export: bool = True,
+    ) -> AgenticProgressiveFileSink:
+        base = ProgressiveFileSink.load_for_resume(state_path, global_rubric=global_rubric)
+        sink = cls(
+            output_path=base.output_path,
+            config=base.config,
+            benchmark_path=base.benchmark_path,
+            global_rubric=base.global_rubric,
+            trace_output_dir=trace_output_dir,
+            trace_layout=trace_layout,
+            keep_progress_sidecars=keep_progress_sidecars,
+            write_partial_export=write_partial_export,
+        )
+        sink._manifest = base.task_manifest
+        sink._completed = set(base._completed)
+        sink._failed = set(base._failed)
+        sink._start_time = base._start_time
+        sink._config_hash = base._config_hash
+        sink._results = base.get_all_results()
+        return sink
+
+    def completed_triples(self) -> set[TripleKey]:
+        """Return only terminal completed triples.
+
+        Parser-stage failures are intentionally excluded so resume retries
+        parsing while :meth:`iter_results` still exposes their answer traces
+        for cache hydration.
+        """
+
+        latest_rows = _dedupe_latest_by_manifest_key(self._results, manifest=self._manifest)
+        retryable = {
+            _scenario_manifest_key(result, self._manifest)
+            for result in latest_rows
+            if _is_retryable_parser_failure(result)
+        }
+        out: set[TripleKey] = set()
+        for key in self._completed - retryable:
+            try:
+                ident = TaskIdentifier.from_key(key)
+            except ValueError:
+                logger.warning("Skipping malformed task key in sink: %r", key)
+                continue
+            out.add(
+                (
+                    ident.question_id,
+                    ident.answering_canonical_key,
+                    ident.parsing_canonical_key,
+                    ident.replicate,
+                )
+            )
+        return out
+
+    def on_result(self, result: VerificationResult) -> None:
+        if not is_completed_result(result):
+            return
+        super().on_result(result)
+        self._write_trace_sidecars(result)
+
+    def on_finalize(self, *, all_complete: bool) -> None:
+        effective_all_complete = all_complete and not self._has_retryable_parser_failures()
+        if effective_all_complete:
+            self.write_final_export(is_complete=True)
+            if not self.keep_progress_sidecars:
+                self._delete_sidecars()
+            logger.info("AgenticProgressiveFileSink finalized: full export at %s", self.output_path)
+            return
+
+        if self.write_partial_export:
+            self.write_final_export(is_complete=False)
+        self._save_state()
+        logger.info(
+            "AgenticProgressiveFileSink left state in place for resume: %d/%d complete",
+            len(self._completed),
+            len(self._manifest),
+        )
+
+    def get_latest_result_set(self) -> VerificationResultSet:
+        """Return one latest result per task key, matching final export rows."""
+
+        return VerificationResultSet(results=_dedupe_latest_by_manifest_key(self._results, manifest=self._manifest))
+
+    def write_final_export(self, output_path: Path | None = None, *, is_complete: bool | None = None) -> Path:
+        target = output_path or self.output_path
+        now = time.time()
+        rows = list(_read_jsonl_results(self.jsonl_path)) if self.jsonl_path.exists() else []
+        latest_rows = _dedupe_latest_by_manifest_key(rows, manifest=self._manifest)
+        successful_count, failed_count = _count_success_failure(latest_rows)
+        job = VerificationJob(
+            job_id=f"progressive-{int(self._start_time or now)}",
+            run_name="progressive",
+            status="completed",
+            config=self.config,
+            total_questions=self.total_tasks,
+            successful_count=successful_count,
+            failed_count=failed_count,
+            start_time=self._start_time,
+            end_time=now,
+        )
+        scenario_results = _reconstruct_scenario_results_for_export(latest_rows, manifest=self._manifest)
+        export_verification_results_json_stream(
+            job,
+            iter(latest_rows),
+            self.global_rubric,
+            is_complete=is_complete
+            if is_complete is not None
+            else not self._has_retryable_parser_failures(latest_rows),
+            scenario_results=scenario_results or None,
+            out_path=target,
+        )
+        return target
+
+    def _has_retryable_parser_failures(self, rows: Iterable[VerificationResult] | None = None) -> bool:
+        source = (
+            list(rows) if rows is not None else _dedupe_latest_by_manifest_key(self._results, manifest=self._manifest)
+        )
+        return any(_is_retryable_parser_failure(result) for result in source)
+
+    def _trace_dir_for_result(self, result: VerificationResult) -> Path | None:
+        if self.trace_output_dir is None:
+            return None
+        question = safe_path_component(result.metadata.question_id)
+        if self.trace_layout == "result":
+            result_id = safe_path_component(result.metadata.result_id)
+            return self.trace_output_dir / f"{question}__{result_id}"
+        return self.trace_output_dir / question
+
+    def _write_trace_sidecars(self, result: VerificationResult) -> None:
+        trace_dir = self._trace_dir_for_result(result)
+        template = result.template
+        if trace_dir is None or template is None:
+            return
+        trace_dir.mkdir(parents=True, exist_ok=True)
+        if template.raw_llm_response:
+            atomic_write(trace_dir / "answering_trace.txt", template.raw_llm_response)
+        if template.investigation_trace:
+            atomic_write(trace_dir / "investigation_trace.txt", template.investigation_trace)
 
 
 # ---------------------------------------------------------------------------

--- a/src/karenina/benchmark/verification/stages/core/base.py
+++ b/src/karenina/benchmark/verification/stages/core/base.py
@@ -389,6 +389,10 @@ class VerificationContext:
     workspace_root: Path | None = None
     workspace_copy: bool = True
     workspace_cleanup: bool = True
+    workspace_output_mode: str = "none"
+    workspace_output_dir: Path | None = None
+    workspace_output_exclude_patterns: list[str] = field(default_factory=list)
+    workspace_output_baseline: dict[str, dict[str, Any]] | None = None
 
     # Artifacts (populated by stages)
     artifacts: dict[str, Any] = field(default_factory=dict)

--- a/src/karenina/benchmark/verification/stages/pipeline/agentic_parse_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/agentic_parse_template.py
@@ -10,7 +10,7 @@ import logging
 from typing import Any
 
 from karenina.adapters import get_agent, get_parser
-from karenina.adapters.langchain_deep_agents.runtime import workspace_path_for_prompt
+from karenina.adapters.agent_runtime import workspace_path_for_prompt
 from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
 from karenina.benchmark.verification.utils.schema_builder import build_parsing_schema

--- a/src/karenina/benchmark/verification/stages/pipeline/agentic_parse_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/agentic_parse_template.py
@@ -10,10 +10,11 @@ import logging
 from typing import Any
 
 from karenina.adapters import get_agent, get_parser
+from karenina.adapters.langchain_deep_agents.runtime import workspace_path_for_prompt
 from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
 from karenina.benchmark.verification.utils.schema_builder import build_parsing_schema
-from karenina.ports import AgentConfig, PortCapabilities
+from karenina.ports import AgentConfig
 from karenina.schemas.entities.answer import BaseAnswer
 from karenina.schemas.verification.model_identity import ModelIdentity
 
@@ -93,12 +94,19 @@ class AgenticParseTemplateStage(BaseVerificationStage):
 
         # Step 1: Investigation
         try:
-            investigation_trace = self._run_investigation(context, clean_schema)
+            investigation_trace, investigation_limit_reached = self._run_investigation(context, clean_schema)
         except Exception as e:
             context.mark_error(f"Agentic investigation failed: {e}")
             return
 
         context.set_artifact(ArtifactKeys.INVESTIGATION_TRACE, investigation_trace)
+        context.set_result_field(
+            ArtifactKeys.INVESTIGATION_TRACE,
+            investigation_trace,
+        )
+        if investigation_limit_reached:
+            context.mark_error("Agentic investigation hit the turn limit before producing a reliable report")
+            return
 
         # Step 2: Extraction
         try:
@@ -125,10 +133,6 @@ class AgenticParseTemplateStage(BaseVerificationStage):
         context.set_artifact(ArtifactKeys.DEEP_JUDGMENT_PERFORMED, False)
 
         context.set_result_field(
-            ArtifactKeys.INVESTIGATION_TRACE,
-            investigation_trace,
-        )
-        context.set_result_field(
             ArtifactKeys.AGENTIC_PARSING_PERFORMED,
             True,
         )
@@ -139,7 +143,7 @@ class AgenticParseTemplateStage(BaseVerificationStage):
         self,
         context: VerificationContext,
         clean_schema: dict[str, Any],
-    ) -> str:
+    ) -> tuple[str, bool]:
         """Run investigation agent with tools.
 
         Args:
@@ -147,20 +151,31 @@ class AgenticParseTemplateStage(BaseVerificationStage):
             clean_schema: Pre-built JSON schema for the answer template.
 
         Returns:
-            Raw trace from the investigation agent.
+            Raw trace from the investigation agent and whether it hit the turn limit.
         """
         agent = get_agent(context.parsing_model)
         schema_json = json.dumps(clean_schema, indent=2)
+        capabilities = agent.capabilities
+        if capabilities.supports_code_execution:
+            execution_text = (
+                "You have access to file tools and can execute code in a sandboxed workspace."
+                if capabilities.uses_sandboxed_execution
+                else "You have access to file tools and can execute code."
+            )
+            rerun_text = (
+                "You may re-run existing scripts to confirm their output, "
+                "but do NOT re-implement the task from scratch or write your own solution."
+            )
+        else:
+            execution_text = "You have access to file tools, but command execution is not available."
+            rerun_text = "Inspect existing scripts, output files, logs, and data, but do not claim to have re-run code."
 
         system_text = (
             "You are a verification agent evaluating whether an AI coding "
-            "assistant correctly completed a task. You have access to the "
-            "file system and can execute code.\n\n"
+            f"assistant correctly completed a task. {execution_text}\n\n"
             "Your job is to evaluate the artifacts the assistant left in the "
             "workspace (scripts, output files, logs, data). Read and inspect "
-            "these artifacts to determine the results. You may re-run existing "
-            "scripts to confirm their output, but do NOT re-implement the task "
-            "from scratch or write your own solution. If the workspace contains "
+            f"these artifacts to determine the results. {rerun_text} If the workspace contains "
             "no usable artifacts, report that you could not verify the results.\n\n"
             "Report your findings as a JSON object matching this schema:\n"
             f"{schema_json}"
@@ -177,8 +192,9 @@ class AgenticParseTemplateStage(BaseVerificationStage):
             user_parts.append(f"\n--- ANSWERING AGENT TRACE ---\n{raw_trace}\n--- END TRACE ---")
 
         if context.workspace_path and context.agentic_judge_context != "trace_only":
+            prompt_workspace = workspace_path_for_prompt(context.parsing_model, context.workspace_path)
             user_parts.append(
-                f"\nWorkspace directory: {context.workspace_path}",
+                f"\nWorkspace directory: {prompt_workspace}",
             )
 
         user_text = "\n".join(user_parts)
@@ -187,7 +203,7 @@ class AgenticParseTemplateStage(BaseVerificationStage):
         assembler = PromptAssembler(
             task=PromptTask.AGENTIC_PARSING_INVESTIGATION,
             interface=context.parsing_model.interface,
-            capabilities=PortCapabilities(),
+            capabilities=capabilities,
         )
         user_instructions = (
             context.prompt_config.get_for_task(PromptTask.AGENTIC_PARSING_INVESTIGATION.value)
@@ -214,7 +230,7 @@ class AgenticParseTemplateStage(BaseVerificationStage):
                 result.turns,
                 result.limit_reached,
             )
-            return result.raw_trace
+            return result.raw_trace, result.limit_reached
         finally:
             close_adapter(agent)
 

--- a/src/karenina/benchmark/verification/stages/pipeline/agentic_parse_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/agentic_parse_template.py
@@ -13,7 +13,11 @@ from karenina.adapters import get_agent, get_parser
 from karenina.adapters.agent_runtime import workspace_path_for_prompt
 from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
-from karenina.benchmark.verification.utils.schema_builder import build_parsing_schema
+from karenina.benchmark.verification.utils.schema_builder import (
+    build_extraction_relaxed_class,
+    build_parsing_schema,
+    rebuild_strict_answer_with_null_fields,
+)
 from karenina.ports import AgentConfig, UsageMetadata
 from karenina.schemas.entities.answer import BaseAnswer
 from karenina.schemas.verification.model_identity import ModelIdentity
@@ -301,8 +305,22 @@ class AgenticParseTemplateStage(BaseVerificationStage):
         )
 
         try:
-            parse_result = parser.parse_to_pydantic(messages, answer_class)
-            return parse_result.parsed, parse_result.usage
+            # Parse against a relaxed sibling class where each VerifiedField is
+            # Optional[T] = None. This lets the LLM return null for individual
+            # sub-questions ("couldn't compute X") without the whole record
+            # failing pydantic validation. After parsing, we reconstruct the
+            # strict template via model_construct (skipping null fields) and
+            # carry the set of null fields as private metadata so downstream
+            # verification reports them as None rather than False, preventing
+            # accidental matches against a False ground truth.
+            extraction_class = build_extraction_relaxed_class(answer_class)
+            parse_result = parser.parse_to_pydantic(messages, extraction_class)
+            strict_instance = rebuild_strict_answer_with_null_fields(
+                answer_class,
+                parse_result.parsed,
+            )
+
+            return strict_instance, parse_result.usage
         finally:
             close_adapter(parser)
 

--- a/src/karenina/benchmark/verification/stages/pipeline/agentic_parse_template.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/agentic_parse_template.py
@@ -14,7 +14,7 @@ from karenina.adapters.agent_runtime import workspace_path_for_prompt
 from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
 from karenina.benchmark.verification.utils.schema_builder import build_parsing_schema
-from karenina.ports import AgentConfig
+from karenina.ports import AgentConfig, UsageMetadata
 from karenina.schemas.entities.answer import BaseAnswer
 from karenina.schemas.verification.model_identity import ModelIdentity
 
@@ -89,16 +89,30 @@ class AgenticParseTemplateStage(BaseVerificationStage):
         """Run investigation then extraction."""
         answer_class = context.get_artifact(ArtifactKeys.ANSWER)
         parsing_model = context.parsing_model
+        parsing_model_str = ModelIdentity.from_model_config(
+            parsing_model,
+            role="parsing",
+        ).display_string
+        usage_tracker = self.get_or_create_usage_tracker(context)
 
         clean_schema = build_parsing_schema(answer_class)
 
         # Step 1: Investigation
         try:
-            investigation_trace, investigation_limit_reached = self._run_investigation(context, clean_schema)
+            investigation_trace, investigation_limit_reached, investigation_usage = self._run_investigation(
+                context, clean_schema
+            )
         except Exception as e:
             context.mark_error(f"Agentic investigation failed: {e}")
             return
 
+        self._track_usage(
+            usage_tracker,
+            "agentic_parsing_investigation",
+            parsing_model_str,
+            investigation_usage,
+        )
+        context.set_artifact(ArtifactKeys.USAGE_TRACKER, usage_tracker)
         context.set_artifact(ArtifactKeys.INVESTIGATION_TRACE, investigation_trace)
         context.set_result_field(
             ArtifactKeys.INVESTIGATION_TRACE,
@@ -110,7 +124,7 @@ class AgenticParseTemplateStage(BaseVerificationStage):
 
         # Step 2: Extraction
         try:
-            parsed_answer = self._run_extraction(
+            parsed_answer, extraction_usage = self._run_extraction(
                 context,
                 answer_class,
                 investigation_trace,
@@ -120,14 +134,17 @@ class AgenticParseTemplateStage(BaseVerificationStage):
             context.mark_error(f"Agentic extraction failed: {e}")
             return
 
-        # Store results
-        model_str = ModelIdentity.from_model_config(
-            parsing_model,
-            role="parsing",
-        ).display_string
+        self._track_usage(
+            usage_tracker,
+            "agentic_parsing_extraction",
+            parsing_model_str,
+            extraction_usage,
+        )
+        context.set_artifact(ArtifactKeys.USAGE_TRACKER, usage_tracker)
 
+        # Store results
         context.set_artifact(ArtifactKeys.PARSED_ANSWER, parsed_answer)
-        context.set_artifact(ArtifactKeys.PARSING_MODEL_STR, model_str)
+        context.set_artifact(ArtifactKeys.PARSING_MODEL_STR, parsing_model_str)
         context.set_artifact(ArtifactKeys.AGENTIC_PARSING_PERFORMED, True)
         context.set_artifact(ArtifactKeys.TEMPLATE_EVALUATOR, None)
         context.set_artifact(ArtifactKeys.DEEP_JUDGMENT_PERFORMED, False)
@@ -143,7 +160,7 @@ class AgenticParseTemplateStage(BaseVerificationStage):
         self,
         context: VerificationContext,
         clean_schema: dict[str, Any],
-    ) -> tuple[str, bool]:
+    ) -> tuple[str, bool, UsageMetadata]:
         """Run investigation agent with tools.
 
         Args:
@@ -151,32 +168,31 @@ class AgenticParseTemplateStage(BaseVerificationStage):
             clean_schema: Pre-built JSON schema for the answer template.
 
         Returns:
-            Raw trace from the investigation agent and whether it hit the turn limit.
+            Raw trace from the investigation agent, whether it hit the turn
+            limit, and token usage from the investigation agent call.
         """
         agent = get_agent(context.parsing_model)
         schema_json = json.dumps(clean_schema, indent=2)
         capabilities = agent.capabilities
         if capabilities.supports_code_execution:
             execution_text = (
-                "You have access to file tools and can execute code in a sandboxed workspace."
+                "You have access to file tools. Code execution may be available, but do not use it for this check."
                 if capabilities.uses_sandboxed_execution
-                else "You have access to file tools and can execute code."
-            )
-            rerun_text = (
-                "You may re-run existing scripts to confirm their output, "
-                "but do NOT re-implement the task from scratch or write your own solution."
+                else "You have access to file tools. Code execution may be available, but do not use it for this check."
             )
         else:
             execution_text = "You have access to file tools, but command execution is not available."
-            rerun_text = "Inspect existing scripts, output files, logs, and data, but do not claim to have re-run code."
 
         system_text = (
             "You are a verification agent evaluating whether an AI coding "
             f"assistant correctly completed a task. {execution_text}\n\n"
-            "Your job is to evaluate the artifacts the assistant left in the "
-            "workspace (scripts, output files, logs, data). Read and inspect "
-            f"these artifacts to determine the results. {rerun_text} If the workspace contains "
-            "no usable artifacts, report that you could not verify the results.\n\n"
+            "Be parsimonious. Look only for artifacts that appear to contain final "
+            "reported results, such as result files, summaries, reports, tables, "
+            "or final answer JSON/CSV/TXT/Markdown outputs. Read those artifacts "
+            "and extract the values they report. Do not run scripts, notebooks, "
+            "or commands. Do not re-compute the task, repair code, or create new "
+            "files. If you cannot find a usable final-results artifact, report "
+            "that you could not verify the results.\n\n"
             "Report your findings as a JSON object matching this schema:\n"
             f"{schema_json}"
         )
@@ -230,7 +246,7 @@ class AgenticParseTemplateStage(BaseVerificationStage):
                 result.turns,
                 result.limit_reached,
             )
-            return result.raw_trace, result.limit_reached
+            return result.raw_trace, result.limit_reached, result.usage
         finally:
             close_adapter(agent)
 
@@ -240,7 +256,7 @@ class AgenticParseTemplateStage(BaseVerificationStage):
         answer_class: type[BaseAnswer],
         investigation_trace: str,
         clean_schema: dict[str, Any],
-    ) -> BaseAnswer:
+    ) -> tuple[BaseAnswer, UsageMetadata]:
         """Extract structured answer from investigation findings.
 
         Args:
@@ -250,7 +266,7 @@ class AgenticParseTemplateStage(BaseVerificationStage):
             clean_schema: Pre-built JSON schema for the answer template.
 
         Returns:
-            Parsed answer instance.
+            Parsed answer instance and token usage from the extraction call.
         """
         parser = get_parser(context.parsing_model)
         schema_json = json.dumps(clean_schema, indent=2)
@@ -286,6 +302,18 @@ class AgenticParseTemplateStage(BaseVerificationStage):
 
         try:
             parse_result = parser.parse_to_pydantic(messages, answer_class)
-            return parse_result.parsed
+            return parse_result.parsed, parse_result.usage
         finally:
             close_adapter(parser)
+
+    @staticmethod
+    def _track_usage(
+        usage_tracker: Any,
+        stage_name: str,
+        model_str: str,
+        usage: UsageMetadata,
+    ) -> None:
+        """Track non-empty token usage for one agentic parsing substage."""
+        usage_dict = usage.to_dict()
+        if usage_dict.get("input_tokens", 0) > 0 or usage_dict.get("output_tokens", 0) > 0:
+            usage_tracker.track_call(stage_name, model_str, usage_dict)

--- a/src/karenina/benchmark/verification/stages/pipeline/agentic_rubric_evaluation.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/agentic_rubric_evaluation.py
@@ -11,10 +11,10 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from karenina.adapters.langchain_deep_agents.runtime import workspace_path_for_prompt
 from karenina.adapters.registry import AdapterRegistry, close_adapter
 from karenina.benchmark.verification.evaluators import AgenticTraitEvaluator
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask
-from karenina.ports import PortCapabilities
 from karenina.schemas.config.models import ModelConfig
 from karenina.schemas.entities.rubric import AgenticRubricTrait
 
@@ -288,10 +288,22 @@ class AgenticRubricEvaluationStage(BaseVerificationStage):
             from karenina.ports import AgentConfig
 
             agent = get_agent(first_model)
+            capabilities = agent.capabilities
+            if capabilities.supports_code_execution:
+                access_text = (
+                    "You have access to tools and can examine files, execute code in the sandbox, "
+                    "and navigate the workspace."
+                    if capabilities.uses_sandboxed_execution
+                    else "You have access to tools and can examine files, run code, and navigate the workspace."
+                )
+            else:
+                access_text = (
+                    "You have access to tools and can examine files and navigate the workspace, "
+                    "but command execution is not available."
+                )
             system_text = (
                 "You are an evaluation agent investigating the quality of an LLM "
-                "response. You have access to tools and can examine files, run "
-                "code, and navigate the workspace.\n\n"
+                f"response. {access_text}\n\n"
                 "Evaluate ALL of the following criteria:\n"
                 f"{combined_description}\n\n"
                 "After investigating, report your findings for each criterion "
@@ -304,7 +316,8 @@ class AgenticRubricEvaluationStage(BaseVerificationStage):
                 user_parts.append(f"\n--- ANSWERING AGENT TRACE ---\n{raw_response}\n--- END TRACE ---")
 
             if workspace_path and include_workspace:
-                user_parts.append(f"\nWorkspace directory: {workspace_path}")
+                prompt_workspace = workspace_path_for_prompt(first_model, workspace_path)
+                user_parts.append(f"\nWorkspace directory: {prompt_workspace}")
 
             user_text = "\n".join(user_parts)
 
@@ -312,7 +325,7 @@ class AgenticRubricEvaluationStage(BaseVerificationStage):
             assembler = PromptAssembler(
                 task=PromptTask.RUBRIC_AGENTIC_TRAIT_INVESTIGATION,
                 interface=first_model.interface,
-                capabilities=PortCapabilities(),
+                capabilities=capabilities,
             )
             user_instructions = (
                 context.prompt_config.get_for_task(PromptTask.RUBRIC_AGENTIC_TRAIT_INVESTIGATION.value)

--- a/src/karenina/benchmark/verification/stages/pipeline/agentic_rubric_evaluation.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/agentic_rubric_evaluation.py
@@ -11,7 +11,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from karenina.adapters.langchain_deep_agents.runtime import workspace_path_for_prompt
+from karenina.adapters.agent_runtime import workspace_path_for_prompt
 from karenina.adapters.registry import AdapterRegistry, close_adapter
 from karenina.benchmark.verification.evaluators import AgenticTraitEvaluator
 from karenina.benchmark.verification.prompts import PromptAssembler, PromptTask

--- a/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/finalize_result.py
@@ -12,6 +12,10 @@ from karenina.benchmark.verification.failure_classifier import (
     collect_caveats,
 )
 from karenina.benchmark.verification.utils.llm_invocation import _split_parsed_response
+from karenina.benchmark.verification.workspace_capture import (
+    DEFAULT_WORKSPACE_OUTPUT_EXCLUDES,
+    capture_workspace,
+)
 from karenina.schemas.verification import VerificationResult
 
 from ..core.base import ArtifactKeys, BaseVerificationStage, VerificationContext
@@ -441,6 +445,23 @@ class FinalizeResultStage(BaseVerificationStage):
 
         # Store final result
         context.set_artifact(ArtifactKeys.FINAL_RESULT, result)
+
+        # Capture workspace sidecars before cleanup so cleanup can remain enabled.
+        if context.workspace_output_mode != "none":
+            exclude_patterns = []
+            if context.workspace_output_mode == "produced":
+                exclude_patterns = [
+                    *DEFAULT_WORKSPACE_OUTPUT_EXCLUDES,
+                    *context.workspace_output_exclude_patterns,
+                ]
+            capture_workspace(
+                mode=context.workspace_output_mode,  # type: ignore[arg-type]
+                output_dir=context.workspace_output_dir,
+                workspace_path=context.workspace_path,
+                baseline=context.workspace_output_baseline,
+                result=result,
+                exclude_patterns=exclude_patterns,
+            )
 
         # Clean up workspace working copies (never originals)
         if context.workspace_path and context.workspace_cleanup and context.workspace_is_copy:

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -13,6 +13,7 @@ import traceback
 from typing import Any
 
 from karenina.adapters import get_agent, get_llm
+from karenina.adapters.langchain_deep_agents.runtime import workspace_path_for_prompt
 from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.utils.llm_invocation import _construct_few_shot_prompt
 from karenina.benchmark.verification.utils.trace_agent_metrics import extract_agent_metrics_from_messages
@@ -428,11 +429,20 @@ class GenerateAnswerStage(BaseVerificationStage):
             # knows where its files are instead of searching the filesystem.
             user_prompt = constructed_prompt
             if context.workspace_path:
+                prompt_workspace = workspace_path_for_prompt(answering_model, context.workspace_path)
                 user_prompt += (
-                    f"\n\nWorkspace directory: {context.workspace_path}\n"
+                    f"\n\nWorkspace directory: {prompt_workspace}\n"
                     "All input data files are in this directory. "
                     "Save any output files here as well."
                 )
+                if use_agent and answering_agent is not None:
+                    capabilities = answering_agent.capabilities
+                    if capabilities.supports_code_execution and capabilities.uses_sandboxed_execution:
+                        user_prompt += " You can execute commands in this sandboxed workspace."
+                    elif capabilities.supports_code_execution:
+                        user_prompt += " You can execute commands in the configured local workspace."
+                    elif capabilities.supports_file_tools:
+                        user_prompt += " You can inspect files, but command execution is not available."
             adapter_messages.append(Message.user(user_prompt))
 
             # Store the full conversation input for curation trace display

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import time
 import traceback
+from pathlib import Path
 from typing import Any
 
 from karenina.adapters import get_agent, get_llm
@@ -19,9 +20,15 @@ from karenina.benchmark.verification.utils.llm_invocation import _construct_few_
 from karenina.benchmark.verification.utils.trace_agent_metrics import extract_agent_metrics_from_messages
 from karenina.benchmark.verification.utils.trace_usage_tracker import UsageTracker
 from karenina.benchmark.verification.utils.usage_helpers import should_mark_usage_unavailable
+from karenina.benchmark.verification.workspace_capture import (
+    DEFAULT_WORKSPACE_OUTPUT_EXCLUDES,
+    safe_path_component,
+    snapshot_workspace,
+)
 from karenina.ports import AgentConfig, AgentPort, LLMPort, Message, Role
 from karenina.replay.exceptions import ReplayMissError
 from karenina.replay.ports_message_hydration import hydrate_trace_messages
+from karenina.schemas.verification import VerificationResultMetadata
 from karenina.schemas.verification.model_identity import ModelIdentity
 from karenina.utils.errors import ErrorCategory
 
@@ -193,6 +200,8 @@ class GenerateAnswerStage(BaseVerificationStage):
         if root is None:
             raise RuntimeError("workspace_root must be set when agentic_parsing is True")
 
+        output_workspace = self._output_workspace_path(context)
+
         # Build unique suffix (replicate-safe for parallel execution)
         timestamp = time.strftime("%Y%m%dT%H%M%S")
         suffix = f"run_{timestamp}_pid{os.getpid()}"
@@ -209,10 +218,13 @@ class GenerateAnswerStage(BaseVerificationStage):
                 )
 
             if context.workspace_copy:
-                working = root / f"{context.question_workspace_path}_{suffix}"
+                working = output_workspace or root / f"{context.question_workspace_path}_{suffix}"
+                if working.exists():
+                    shutil.rmtree(working)
+                working.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copytree(source, working)
                 context.workspace_path = working
-                context.workspace_is_copy = True
+                context.workspace_is_copy = output_workspace is None
                 logger.info("Copied workspace %s to %s", source, working)
             else:
                 context.workspace_path = source
@@ -220,11 +232,40 @@ class GenerateAnswerStage(BaseVerificationStage):
                 logger.info("Using workspace in place: %s", source)
         else:
             # No pre-existing workspace; create empty directory
-            working = root / f"{context.question_id}_{suffix}"
+            working = output_workspace or root / f"{context.question_id}_{suffix}"
+            if working.exists():
+                shutil.rmtree(working)
             working.mkdir(parents=True, exist_ok=True)
             context.workspace_path = working
-            context.workspace_is_copy = True
+            context.workspace_is_copy = output_workspace is None
             logger.info("Created workspace: %s", working)
+
+    @staticmethod
+    def _output_workspace_path(context: VerificationContext) -> Path | None:
+        """Return the direct output workspace path for full capture mode."""
+
+        if context.workspace_output_mode != "full" or context.workspace_output_dir is None:
+            return None
+
+        answering_identity = context.get_artifact(ArtifactKeys.ANSWERING_MODEL_IDENTITY)
+        parsing_identity = context.get_artifact(ArtifactKeys.PARSING_MODEL_IDENTITY)
+        if answering_identity is None:
+            answering_identity = ModelIdentity.from_model_config(context.answering_model, role="answering")
+        if parsing_identity is None:
+            parsing_identity = ModelIdentity.from_model_config(context.parsing_model, role="parsing")
+        timestamp = context.get_result_field(ArtifactKeys.TIMESTAMP, "")
+        result_id = VerificationResultMetadata.compute_result_id(
+            question_id=context.question_id,
+            answering=answering_identity,
+            parsing=parsing_identity,
+            timestamp=timestamp,
+            replicate=context.replicate,
+            scenario_id=context.scenario_id,
+            scenario_node=context.scenario_node,
+            scenario_turn=context.scenario_turn,
+        )
+        folder = f"{safe_path_component(context.question_id)}__{safe_path_component(result_id)}"
+        return context.workspace_output_dir / folder
 
     def execute(self, context: VerificationContext) -> None:
         """
@@ -272,6 +313,16 @@ class GenerateAnswerStage(BaseVerificationStage):
 
         # Resolve workspace for agentic parsing (before any LLM calls)
         self._resolve_workspace(context)
+        if (
+            context.workspace_output_mode == "produced"
+            and context.workspace_output_baseline is None
+            and context.workspace_path is not None
+        ):
+            exclude_patterns = [
+                *DEFAULT_WORKSPACE_OUTPUT_EXCLUDES,
+                *context.workspace_output_exclude_patterns,
+            ]
+            context.workspace_output_baseline = snapshot_workspace(context.workspace_path, exclude_patterns)
 
         # Check if cached answer data is available
         if context.cached_answer_data is not None:

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -535,7 +535,6 @@ class GenerateAnswerStage(BaseVerificationStage):
                 if result.timeout_reached:
                     if result.raw_trace:
                         self.set_artifact_and_result(context, "response_timeout_partial", True)
-                        self.set_artifact_and_result(context, ArtifactKeys.USAGE_UNAVAILABLE, True)
                         error_msg = (
                             f"Agent timed out with partial trace ({len(result.raw_trace)} chars, {result.turns} turns)"
                         )

--- a/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/generate_answer.py
@@ -13,7 +13,7 @@ import traceback
 from typing import Any
 
 from karenina.adapters import get_agent, get_llm
-from karenina.adapters.langchain_deep_agents.runtime import workspace_path_for_prompt
+from karenina.adapters.agent_runtime import workspace_path_for_prompt
 from karenina.adapters.registry import close_adapter
 from karenina.benchmark.verification.utils.llm_invocation import _construct_few_shot_prompt
 from karenina.benchmark.verification.utils.trace_agent_metrics import extract_agent_metrics_from_messages

--- a/src/karenina/benchmark/verification/utils/schema_builder.py
+++ b/src/karenina/benchmark/verification/utils/schema_builder.py
@@ -3,10 +3,19 @@
 Two filtering operations:
 1. Remove trace fields (judge should not parse these)
 2. Strip __verification__ metadata (judge must not see ground truth)
+
+Also exposes ``build_extraction_relaxed_class`` which produces a sibling
+Pydantic model with every VerifiedField coerced to ``Optional[T] = None``.
+This relaxed class is used at agentic-extraction time so that a single
+null field from the LLM does not reject the entire record. The caller
+recombines null-valued fields into the strict template afterwards via
+``BaseAnswer.model_construct`` plus a private ``_null_fields`` set.
 """
 
 import logging
 from typing import Any
+
+from pydantic import create_model
 
 from karenina.schemas.entities.answer import BaseAnswer
 
@@ -59,3 +68,67 @@ def build_parsing_schema(answer_class: type[BaseAnswer]) -> dict[str, Any]:
                 _strip_properties(def_schema["properties"])
 
     return schema
+
+
+def build_extraction_relaxed_class(answer_class: type[BaseAnswer]) -> type[BaseAnswer]:
+    """Build a sibling Pydantic class with VerifiedFields relaxed to Optional.
+
+    Each VerifiedField on ``answer_class`` is rewritten as ``Optional[T] = None``
+    so that the agentic parser accepts ``null`` for any single field without
+    failing the whole record. The relaxed class is used only at extraction
+    time; downstream verification then reconstructs the strict template and
+    tracks which fields came back null via a private ``_null_fields`` set.
+
+    Non-VerifiedField fields (e.g. ``id``) and unverified plain fields are
+    preserved as-is; only fields that carry ``__verification__`` metadata are
+    loosened, because only those participate in scoring.
+
+    Args:
+        answer_class: The strict template class to derive from.
+
+    Returns:
+        A new Pydantic ``BaseAnswer`` subclass with relaxed field types.
+    """
+    relaxed_fields: dict[str, Any] = {}
+    for name, field_info in answer_class.model_fields.items():
+        extra = field_info.json_schema_extra
+        is_verified = isinstance(extra, dict) and "__verification__" in extra
+
+        if not is_verified:
+            # Preserve non-verified fields verbatim
+            relaxed_fields[name] = (field_info.annotation, field_info)
+            continue
+
+        # Coerce the annotation to Optional[T] with default None.
+        annotation = field_info.annotation or Any
+        relaxed_annotation = annotation | None
+        relaxed_fields[name] = (relaxed_annotation, None)
+
+    relaxed_cls = create_model(
+        f"{answer_class.__name__}__Relaxed",
+        __base__=BaseAnswer,
+        **relaxed_fields,
+    )
+    return relaxed_cls
+
+
+def rebuild_strict_answer_with_null_fields(
+    answer_class: type[BaseAnswer],
+    relaxed_instance: Any,
+) -> BaseAnswer:
+    """Rebuild a strict Answer while preserving null verified fields.
+
+    Parser adapters receive the relaxed class from
+    ``build_extraction_relaxed_class``. This helper converts the parsed relaxed
+    instance back to the original strict answer class, omitting null field
+    values and storing the names of verified null fields on ``_null_fields``.
+    ``BaseAnswer._compute_field_results`` consumes that marker and reports
+    those fields as ``None`` instead of conflating them with ``False``.
+    """
+    extracted_dict = relaxed_instance.model_dump()
+    verified_names = set(answer_class._get_verified_fields().keys())
+    null_fields = {name for name, value in extracted_dict.items() if value is None and name in verified_names}
+    strict_payload = {name: value for name, value in extracted_dict.items() if value is not None}
+    strict_instance = answer_class.model_construct(**strict_payload)
+    strict_instance.__dict__["_null_fields"] = null_fields
+    return strict_instance

--- a/src/karenina/benchmark/verification/utils/task_helpers.py
+++ b/src/karenina/benchmark/verification/utils/task_helpers.py
@@ -332,6 +332,9 @@ def extract_feature_flags(config: VerificationConfig) -> dict[str, Any]:
         "agentic_parsing_persist_trace": getattr(config, "agentic_parsing_persist_trace", False),
         "workspace_copy": getattr(config, "workspace_copy", True),
         "workspace_cleanup": getattr(config, "workspace_cleanup", True),
+        "workspace_output_mode": getattr(config, "workspace_output_mode", "none"),
+        "workspace_output_dir": getattr(config, "workspace_output_dir", None),
+        "workspace_output_exclude_patterns": getattr(config, "workspace_output_exclude_patterns", []),
         # Agentic rubric evaluation configuration
         "agentic_rubric_strategy": getattr(config, "agentic_rubric_strategy", "individual"),
         "agentic_rubric_parallel": getattr(config, "agentic_rubric_parallel", False),

--- a/src/karenina/benchmark/verification/utils/trace_agent_metrics.py
+++ b/src/karenina/benchmark/verification/utils/trace_agent_metrics.py
@@ -70,7 +70,8 @@ def extract_agent_metrics_from_messages(messages: list[Message]) -> dict[str, An
         Dict with agent metrics matching the documented schema in result_components.
     """
     iterations = 0
-    tool_calls = 0
+    assistant_tool_calls = 0
+    tool_result_calls = 0
     tools_used: set[str] = set()
     tool_call_counts: dict[str, int] = defaultdict(int)
     suspect_failed_tool_calls = 0
@@ -84,6 +85,7 @@ def extract_agent_metrics_from_messages(messages: list[Message]) -> dict[str, An
         if msg.role == Role.ASSISTANT:
             iterations += 1
             for tc in msg.tool_calls:
+                assistant_tool_calls += 1
                 tools_used.add(tc.name)
                 tool_call_counts[tc.name] += 1
                 tool_id_to_name[tc.id] = tc.name
@@ -91,7 +93,7 @@ def extract_agent_metrics_from_messages(messages: list[Message]) -> dict[str, An
         elif msg.role == Role.TOOL:
             for content_block in msg.content:
                 if isinstance(content_block, ToolResultContent):
-                    tool_calls += 1
+                    tool_result_calls += 1
 
                     # Check for suspected failures
                     is_suspect = content_block.is_error
@@ -110,7 +112,7 @@ def extract_agent_metrics_from_messages(messages: list[Message]) -> dict[str, An
 
     return {
         "iterations": iterations,
-        "tool_calls": tool_calls,
+        "tool_calls": max(assistant_tool_calls, tool_result_calls),
         "tools_used": sorted(tools_used),
         "tool_call_counts": dict(tool_call_counts),
         "suspect_failed_tool_calls": suspect_failed_tool_calls,

--- a/src/karenina/benchmark/verification/workspace_capture.py
+++ b/src/karenina/benchmark/verification/workspace_capture.py
@@ -1,0 +1,363 @@
+"""Workspace capture helpers for verification runs."""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+import logging
+import os
+import shutil
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Literal
+
+from karenina.schemas.verification import VerificationResult
+from karenina.utils.file_ops import atomic_write
+
+logger = logging.getLogger(__name__)
+
+WorkspaceOutputMode = Literal["none", "full", "produced"]
+
+DEFAULT_WORKSPACE_OUTPUT_EXCLUDES = (
+    ".venv/",
+    "venv/",
+    "__pycache__/",
+    ".pytest_cache/",
+    ".ruff_cache/",
+    ".mypy_cache/",
+    ".ipynb_checkpoints/",
+    "*.pyc",
+)
+
+
+def safe_path_component(value: str | None) -> str:
+    """Return a filesystem-safe path component."""
+
+    if not value:
+        return "unknown"
+    safe = "".join(ch if ch.isalnum() or ch in ("-", "_", ".") else "_" for ch in value)
+    return safe.strip("._") or "unknown"
+
+
+def _rel_posix(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _pattern_matches(pattern: str, rel_path: str, is_dir: bool) -> bool:
+    normalized = pattern.replace(os.sep, "/")
+    rel = rel_path.rstrip("/")
+    if normalized.endswith("/"):
+        prefix = normalized.rstrip("/")
+        return is_dir and (rel == prefix or rel.startswith(f"{prefix}/")) or rel.startswith(f"{prefix}/")
+    return fnmatch.fnmatch(rel, normalized) or fnmatch.fnmatch(Path(rel).name, normalized)
+
+
+def is_excluded(rel_path: str, *, is_dir: bool, patterns: list[str] | tuple[str, ...]) -> bool:
+    """Return True when a relative path should be excluded."""
+
+    return any(_pattern_matches(pattern, rel_path, is_dir) for pattern in patterns)
+
+
+def _iter_files(root: Path, patterns: list[str] | tuple[str, ...]) -> list[Path]:
+    files: list[Path] = []
+    if not root.exists():
+        return files
+
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        current = Path(dirpath)
+        kept_dirnames = []
+        for dirname in dirnames:
+            child = current / dirname
+            rel = _rel_posix(child, root)
+            if is_excluded(rel, is_dir=True, patterns=patterns):
+                continue
+            kept_dirnames.append(dirname)
+        dirnames[:] = kept_dirnames
+
+        for filename in filenames:
+            path = current / filename
+            rel = _rel_posix(path, root)
+            if is_excluded(rel, is_dir=path.is_dir(), patterns=patterns):
+                continue
+            files.append(path)
+    return files
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def snapshot_workspace(root: Path, patterns: list[str] | tuple[str, ...]) -> dict[str, dict[str, Any]]:
+    """Snapshot file content identities under a workspace root."""
+
+    snapshot: dict[str, dict[str, Any]] = {}
+    for path in _iter_files(root, patterns):
+        rel = _rel_posix(path, root)
+        try:
+            if path.is_symlink():
+                snapshot[rel] = {"kind": "symlink", "target": os.readlink(path)}
+            elif path.is_file():
+                stat = path.stat()
+                snapshot[rel] = {"kind": "file", "size": stat.st_size, "sha256": _hash_file(path)}
+        except OSError as exc:
+            logger.warning("Failed to snapshot workspace file %s: %s", path, exc)
+    return snapshot
+
+
+def changed_workspace_files(
+    root: Path,
+    baseline: dict[str, dict[str, Any]],
+    patterns: list[str] | tuple[str, ...],
+) -> tuple[list[Path], list[dict[str, str]]]:
+    """Return files that are new or content-modified relative to baseline."""
+
+    changed: list[Path] = []
+    errors: list[dict[str, str]] = []
+    for path in _iter_files(root, patterns):
+        rel = _rel_posix(path, root)
+        try:
+            previous = baseline.get(rel)
+            current: dict[str, Any]
+            if path.is_symlink():
+                current = {"kind": "symlink", "target": os.readlink(path)}
+            elif path.is_file():
+                stat = path.stat()
+                current = {"kind": "file", "size": stat.st_size, "sha256": _hash_file(path)}
+            else:
+                continue
+            if current != previous:
+                changed.append(path)
+        except OSError as exc:
+            errors.append({"path": rel, "error": str(exc)})
+    return changed, errors
+
+
+def _copy_file_preserving_link(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if source.is_symlink():
+        if destination.exists() or destination.is_symlink():
+            destination.unlink()
+        destination.symlink_to(os.readlink(source))
+    else:
+        shutil.copy2(source, destination, follow_symlinks=False)
+
+
+def _copy_full_workspace(
+    source: Path,
+    destination: Path,
+    patterns: list[str] | tuple[str, ...],
+) -> tuple[int, list[dict[str, str]]]:
+    copied = 0
+    errors: list[dict[str, str]] = []
+    for dirpath, dirnames, filenames in os.walk(source, followlinks=False):
+        current = Path(dirpath)
+        kept_dirnames = []
+        for dirname in dirnames:
+            child = current / dirname
+            rel = _rel_posix(child, source)
+            if is_excluded(rel, is_dir=True, patterns=patterns):
+                continue
+            try:
+                if child.is_symlink():
+                    _copy_file_preserving_link(child, destination / rel)
+                    copied += 1
+                    continue
+                (destination / rel).mkdir(parents=True, exist_ok=True)
+                kept_dirnames.append(dirname)
+            except OSError as exc:
+                errors.append({"path": rel, "error": str(exc)})
+        dirnames[:] = kept_dirnames
+
+        for filename in filenames:
+            path = current / filename
+            rel = _rel_posix(path, source)
+            if is_excluded(rel, is_dir=False, patterns=patterns):
+                continue
+            try:
+                _copy_file_preserving_link(path, destination / rel)
+                copied += 1
+            except OSError as exc:
+                errors.append({"path": rel, "error": str(exc)})
+    return copied, errors
+
+
+def _copy_full_workspace_count(
+    source: Path,
+    patterns: list[str] | tuple[str, ...],
+) -> tuple[int, list[dict[str, str]]]:
+    copied = 0
+    errors: list[dict[str, str]] = []
+    for dirpath, dirnames, filenames in os.walk(source, followlinks=False):
+        current = Path(dirpath)
+        kept_dirnames = []
+        for dirname in dirnames:
+            child = current / dirname
+            rel = _rel_posix(child, source)
+            if is_excluded(rel, is_dir=True, patterns=patterns):
+                continue
+            if child.is_symlink():
+                copied += 1
+                continue
+            kept_dirnames.append(dirname)
+        dirnames[:] = kept_dirnames
+
+        for filename in filenames:
+            path = current / filename
+            rel = _rel_posix(path, source)
+            if is_excluded(rel, is_dir=False, patterns=patterns):
+                continue
+            try:
+                if path.is_symlink() or path.is_file():
+                    copied += 1
+            except OSError as exc:
+                errors.append({"path": rel, "error": str(exc)})
+    return copied, errors
+
+
+def _replace_dir(source: Path, destination: Path) -> None:
+    if destination.exists() or destination.is_symlink():
+        if destination.is_dir() and not destination.is_symlink():
+            shutil.rmtree(destination)
+        else:
+            destination.unlink()
+    source.replace(destination)
+
+
+def _manifest_paths(output_dir: Path) -> tuple[Path, Path]:
+    return output_dir / "manifest.jsonl", output_dir / "manifest.json"
+
+
+def append_manifest_row(output_dir: Path, row: dict[str, Any]) -> None:
+    """Append one JSONL workspace manifest row."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    jsonl_path, _ = _manifest_paths(output_dir)
+    with open(jsonl_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(row, default=str, sort_keys=True) + "\n")
+
+
+def compact_manifest(output_dir: Path) -> Path | None:
+    """Compact manifest JSONL into manifest.json."""
+
+    jsonl_path, json_path = _manifest_paths(output_dir)
+    if not jsonl_path.exists():
+        return None
+    rows = []
+    with open(jsonl_path, encoding="utf-8") as f:
+        for line in f:
+            stripped = line.strip()
+            if stripped:
+                rows.append(json.loads(stripped))
+    payload = {
+        "format_version": "1.0",
+        "generated_at": time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime()),
+        "entries": rows,
+    }
+    atomic_write(json_path, json.dumps(payload, indent=2, default=str) + "\n")
+    return json_path
+
+
+def capture_workspace(
+    *,
+    mode: WorkspaceOutputMode,
+    output_dir: Path | None,
+    workspace_path: Path | None,
+    baseline: dict[str, dict[str, Any]] | None,
+    result: VerificationResult,
+    exclude_patterns: list[str] | tuple[str, ...],
+) -> None:
+    """Capture a result workspace sidecar and append a manifest row."""
+
+    if mode == "none":
+        return
+
+    if output_dir is None:
+        logger.warning("Workspace capture requested but workspace_output_dir is not set")
+        return
+
+    result_id = result.metadata.result_id
+    question_id = result.metadata.question_id
+    folder_name = f"{safe_path_component(question_id)}__{safe_path_component(result_id)}"
+    destination = output_dir / folder_name
+    row: dict[str, Any] = {
+        "question_id": question_id,
+        "result_id": result_id,
+        "run_name": result.metadata.run_name,
+        "replicate": result.metadata.replicate,
+        "scenario_id": result.metadata.scenario_id,
+        "scenario_node": result.metadata.scenario_node,
+        "scenario_turn": result.metadata.scenario_turn,
+        "answering": result.metadata.answering.model_dump(mode="json"),
+        "parsing": result.metadata.parsing.model_dump(mode="json"),
+        "capture_mode": mode,
+        "source_workspace_path": str(workspace_path) if workspace_path else None,
+        "destination": str(destination),
+        "status": "captured",
+        "copied_file_count": 0,
+        "copy_errors": [],
+    }
+
+    if workspace_path is None or not workspace_path.exists():
+        row["status"] = "skipped"
+        row["skip_reason"] = "workspace_not_available"
+        append_manifest_row(output_dir, row)
+        logger.warning("Workspace capture skipped for %s: no live workspace", question_id)
+        return
+
+    try:
+        if mode == "full" and workspace_path.resolve() == destination.resolve():
+            copied_count, errors = _copy_full_workspace_count(workspace_path, exclude_patterns)
+            row["copied_file_count"] = copied_count
+            row["copy_errors"] = errors
+            if errors:
+                row["status"] = "captured_with_errors"
+            append_manifest_row(output_dir, row)
+            return
+    except OSError as exc:
+        row["status"] = "skipped"
+        row["skip_reason"] = f"{type(exc).__name__}: {exc}"
+        append_manifest_row(output_dir, row)
+        logger.warning("Workspace capture failed for %s: %s", question_id, exc, exc_info=True)
+        return
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tmp_parent = output_dir
+    tmp_path = Path(tempfile.mkdtemp(prefix=f".{folder_name}.tmp-", dir=tmp_parent))
+    try:
+        if mode == "full":
+            copied_count, errors = _copy_full_workspace(workspace_path, tmp_path, exclude_patterns)
+        elif mode == "produced":
+            changed, detected_errors = changed_workspace_files(workspace_path, baseline or {}, exclude_patterns)
+            copied_count = 0
+            errors = list(detected_errors)
+            for path in changed:
+                rel = _rel_posix(path, workspace_path)
+                try:
+                    _copy_file_preserving_link(path, tmp_path / rel)
+                    copied_count += 1
+                except OSError as exc:
+                    errors.append({"path": rel, "error": str(exc)})
+        else:
+            raise ValueError(f"Unsupported workspace capture mode: {mode}")
+
+        _replace_dir(tmp_path, destination)
+        row["copied_file_count"] = copied_count
+        row["copy_errors"] = errors
+        if errors:
+            row["status"] = "captured_with_errors"
+            logger.warning("Workspace capture for %s completed with %d copy error(s)", question_id, len(errors))
+        append_manifest_row(output_dir, row)
+    except Exception as exc:  # noqa: BLE001
+        row["status"] = "skipped"
+        row["skip_reason"] = f"{type(exc).__name__}: {exc}"
+        append_manifest_row(output_dir, row)
+        logger.warning("Workspace capture failed for %s: %s", question_id, exc, exc_info=True)
+    finally:
+        if tmp_path.exists():
+            shutil.rmtree(tmp_path, ignore_errors=True)

--- a/src/karenina/cli/verify.py
+++ b/src/karenina/cli/verify.py
@@ -248,6 +248,21 @@ def verify(
     async_workers: Annotated[
         int | None, typer.Option(help="Number of async workers (default: 2 or KARENINA_ASYNC_MAX_WORKERS)")
     ] = None,
+    workspace_output_mode: Annotated[
+        str,
+        typer.Option(help="Workspace sidecar capture mode (none/full/produced)"),
+    ] = "none",
+    workspace_output_dir: Annotated[
+        Path | None,
+        typer.Option(help="Directory for captured workspace sidecars. Defaults to OUTPUT.parent/workspaces for JSON."),
+    ] = None,
+    workspace_output_exclude: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--workspace-output-exclude",
+            help="Additional fnmatch-style pattern to exclude from workspace capture. Repeatable.",
+        ),
+    ] = None,
     # Manual trace support
     manual_traces: Annotated[
         Path | None,
@@ -396,6 +411,9 @@ def verify(
                 embedding_model=embedding_model,
                 async_execution=async_execution,
                 async_workers=async_workers,
+                workspace_output_mode=workspace_output_mode,
+                workspace_output_dir=workspace_output_dir,
+                workspace_output_exclude_patterns=workspace_output_exclude,
                 manual_traces=manual_traces,
                 benchmark=benchmark,
                 progressive_save=progressive_save,
@@ -413,6 +431,11 @@ def verify(
 
             console.print(f"[dim]Loading replay store from {replay}[/dim]")
             config = config.model_copy(update={"replay_store": ReplayStore.load(replay)})
+
+        if config.workspace_output_mode != "none" and config.workspace_output_dir is None:
+            if output is None or output_format != "json":
+                cli_error("--workspace-output-dir is required when workspace capture is enabled without JSON output")
+            config = config.model_copy(update={"workspace_output_dir": output.parent / "workspaces"})
 
         # Step 5: Get and filter templates
         ids_filter = None

--- a/src/karenina/cli/verify_config.py
+++ b/src/karenina/cli/verify_config.py
@@ -48,6 +48,9 @@ def build_config_from_cli_args(
     embedding_model: str | None,
     async_execution: bool,
     async_workers: int | None,
+    workspace_output_mode: str | None = None,
+    workspace_output_dir: Path | None = None,
+    workspace_output_exclude_patterns: list[str] | None = None,
     preset_config: VerificationConfig | None = None,
     manual_traces_obj: object | None = None,
 ) -> VerificationConfig:
@@ -86,6 +89,9 @@ def build_config_from_cli_args(
         embedding_model: Model to use for embedding similarity.
         async_execution: Whether to run verification asynchronously.
         async_workers: Number of async workers.
+        workspace_output_mode: Workspace sidecar capture mode.
+        workspace_output_dir: Directory for workspace sidecars.
+        workspace_output_exclude_patterns: Additional workspace sidecar excludes.
         preset_config: Optional preset configuration to use as base.
         manual_traces_obj: Optional pre-loaded manual traces object.
 
@@ -149,6 +155,9 @@ def build_config_from_cli_args(
         deep_judgment_rubric_search=deep_judgment_rubric_search,
         deep_judgment_rubric_search_tool=deep_judgment_rubric_search_tool,
         deep_judgment_rubric_config=rubric_config_obj,
+        workspace_output_mode=workspace_output_mode,  # type: ignore[arg-type]
+        workspace_output_dir=workspace_output_dir,
+        workspace_output_exclude_patterns=workspace_output_exclude_patterns,
     )
 
 
@@ -303,6 +312,9 @@ def build_config_non_interactive(
     embedding_model: str | None,
     async_execution: bool,
     async_workers: int | None,
+    workspace_output_mode: str | None,
+    workspace_output_dir: Path | None,
+    workspace_output_exclude_patterns: list[str] | None,
     manual_traces: Path | None,
     benchmark: Benchmark,
     progressive_save: bool,
@@ -375,6 +387,9 @@ def build_config_non_interactive(
             embedding_model=embedding_model,
             async_execution=async_execution,
             async_workers=async_workers,
+            workspace_output_mode=workspace_output_mode,
+            workspace_output_dir=workspace_output_dir,
+            workspace_output_exclude_patterns=workspace_output_exclude_patterns,
             preset_config=preset_config,
             manual_traces_obj=manual_traces_obj,
         )
@@ -398,6 +413,9 @@ def build_config_non_interactive(
                     embedding_model,
                     async_execution,
                     async_workers,
+                    workspace_output_mode,
+                    workspace_output_dir,
+                    workspace_output_exclude_patterns,
                 ]
             )
             if has_cli_overrides:

--- a/src/karenina/ports/capabilities.py
+++ b/src/karenina/ports/capabilities.py
@@ -17,8 +17,14 @@ class PortCapabilities:
             If False, system text is prepended to user text.
         supports_structured_output: Whether the adapter supports structured output
             (e.g., JSON schema enforcement).
+        supports_file_tools: Whether an agent adapter can inspect workspace files.
+        supports_code_execution: Whether an agent adapter can execute shell commands.
+        uses_sandboxed_execution: Whether command execution is isolated from the host.
     """
 
     supports_system_prompt: bool = True
     supports_structured_output: bool = False
     supports_streaming: bool = False
+    supports_file_tools: bool = False
+    supports_code_execution: bool = False
+    uses_sandboxed_execution: bool = False

--- a/src/karenina/ports/messages.py
+++ b/src/karenina/ports/messages.py
@@ -129,6 +129,11 @@ class Message:
     Attributes:
         role: The role of the message sender (system, user, assistant, tool).
         content: List of content blocks that make up the message.
+        usage_metadata: Optional per-call usage accounting (input_tokens,
+            output_tokens, and optional cache_read_input_tokens /
+            cache_creation_input_tokens). Populated by adapters from the
+            provider's per-message usage payload so per-turn token / cache
+            accounting survives into ``template.trace_messages``.
 
     Example:
         >>> msg = Message.user("Hello, world!")
@@ -143,6 +148,7 @@ class Message:
 
     role: Role
     content: list[Content]
+    usage_metadata: dict[str, Any] | None = None
 
     @property
     def text(self) -> str:
@@ -282,6 +288,11 @@ class Message:
                     thinking["signature"] = block.signature
                 result["thinking"] = thinking
                 break
+
+        # Add per-call usage metadata when present so per-turn token /
+        # cache accounting is preserved in template.trace_messages[*].
+        if self.usage_metadata is not None:
+            result["usage_metadata"] = self.usage_metadata
 
         return result
 

--- a/src/karenina/ports/messages.py
+++ b/src/karenina/ports/messages.py
@@ -346,4 +346,8 @@ class Message:
                 )
             )
 
-        return cls(role=role, content=content_blocks)
+        return cls(
+            role=role,
+            content=content_blocks,
+            usage_metadata=data.get("usage_metadata"),
+        )

--- a/src/karenina/scenario/manager.py
+++ b/src/karenina/scenario/manager.py
@@ -580,6 +580,9 @@ class ScenarioManager:
             workspace_is_copy=turn_workspace_path is not None,
             workspace_copy=config.workspace_copy,
             workspace_cleanup=config.workspace_cleanup,
+            workspace_output_mode=config.workspace_output_mode,
+            workspace_output_dir=config.workspace_output_dir,
+            workspace_output_exclude_patterns=config.workspace_output_exclude_patterns,
             question_workspace_path=getattr(node.question, "workspace_path", None),
             # Replay fields: copied from config onto the per-turn context.
             # scenario_node_visit_index is read from the current ScenarioState

--- a/src/karenina/schemas/config/models.py
+++ b/src/karenina/schemas/config/models.py
@@ -569,6 +569,13 @@ class ModelConfig(BaseModel):
     # Extra keyword arguments to pass to the underlying model interface
     # Useful for passing vendor-specific API keys, custom parameters, etc.
     extra_kwargs: dict[str, Any] | None = None
+    # DeepAgents runtime configuration. Only used by the langchain_deep_agents
+    # adapter; ignored by other interfaces.
+    deepagents_backend: Literal["filesystem", "docker", "local_shell"] = "filesystem"
+    deepagents_docker_image: str | None = None
+    deepagents_docker_network: Literal["bridge", "none"] = "bridge"
+    deepagents_execute_timeout: int = Field(default=120, ge=1)
+    deepagents_execute_max_output_bytes: int = Field(default=100_000, ge=1)
     # Manual interface configuration
     manual_traces: Any = Field(default=None, exclude=True)  # Excluded from serialization; type: ManualTraces | None
     # Agent middleware configuration (only used when mcp_urls_dict is provided)

--- a/src/karenina/schemas/config/models.py
+++ b/src/karenina/schemas/config/models.py
@@ -566,16 +566,10 @@ class ModelConfig(BaseModel):
     # Anthropic-specific configuration (for claude_tool and claude_agent_sdk interfaces)
     anthropic_base_url: str | None = None  # Custom Anthropic API endpoint (for proxies, self-hosted)
     anthropic_api_key: SecretStr | None = None  # Override ANTHROPIC_API_KEY env var
-    # Extra keyword arguments to pass to the underlying model interface
+    # Extra keyword arguments to pass to the underlying model interface.
+    # Adapter runtime settings can live under extra_kwargs["agent_runtime"].
     # Useful for passing vendor-specific API keys, custom parameters, etc.
     extra_kwargs: dict[str, Any] | None = None
-    # DeepAgents runtime configuration. Only used by the langchain_deep_agents
-    # adapter; ignored by other interfaces.
-    deepagents_backend: Literal["filesystem", "docker", "local_shell"] = "filesystem"
-    deepagents_docker_image: str | None = None
-    deepagents_docker_network: Literal["bridge", "none"] = "bridge"
-    deepagents_execute_timeout: int = Field(default=120, ge=1)
-    deepagents_execute_max_output_bytes: int = Field(default=100_000, ge=1)
     # Manual interface configuration
     manual_traces: Any = Field(default=None, exclude=True)  # Excluded from serialization; type: ManualTraces | None
     # Agent middleware configuration (only used when mcp_urls_dict is provided)

--- a/src/karenina/schemas/entities/answer.py
+++ b/src/karenina/schemas/entities/answer.py
@@ -249,7 +249,7 @@ class BaseAnswer(BaseModel):
         self.__dict__.pop("_field_results", None)
         self.__dict__.pop("_resolved_ground_truths", None)
 
-    def _compute_field_results(self) -> dict[str, bool]:
+    def _compute_field_results(self) -> dict[str, bool | None]:
         """Evaluate all VerifiedField checks and cache in _field_results.
 
         Results are cached in self.__dict__["_field_results"] after the first
@@ -265,22 +265,31 @@ class BaseAnswer(BaseModel):
         check_trace() result against bool(meta.ground_truth). For parsed
         fields, calls primitive.check(extracted, ground_truth).
 
+        Tri-valued results:
+            - True: field extracted and matches ground truth.
+            - False: field extracted and does NOT match ground truth.
+            - None: field returned null by the extractor (i.e., the field
+              name is present in ``self._null_fields``). This is kept
+              distinct from False so a null extraction cannot silently match
+              a False ground truth. Populated by the agentic-parse stage.
+
         Returns:
-            Mapping of field name to pass/fail boolean.
+            Mapping of field name to True / False / None.
 
         Raises:
             ValueError: If a trace field is used but _raw_trace is not set.
         """
         cached = self.__dict__.get("_field_results")
         if cached is not None:
-            return cast(dict[str, bool], cached)
+            return cast(dict[str, bool | None], cached)
 
         from karenina.schemas.entities.conditional import _resolve_conditional
         from karenina.schemas.primitives import TracePrimitive
         from karenina.schemas.primitives.registry import _reconstruct_primitive
 
         verified = self.__class__._get_verified_fields()
-        results: dict[str, bool] = {}
+        null_fields: set[str] = self.__dict__.get("_null_fields") or set()
+        results: dict[str, bool | None] = {}
         resolved_gts: dict[str, Any] = {}
 
         for name, meta in verified.items():
@@ -297,6 +306,12 @@ class BaseAnswer(BaseModel):
 
             resolved_gts[name] = ground_truth
 
+            # If the extractor returned null for this field, surface None so
+            # downstream scoring can distinguish "not answered" from "False".
+            if name in null_fields:
+                results[name] = None
+                continue
+
             if isinstance(primitive, TracePrimitive):
                 raw_trace = getattr(self, "_raw_trace", None)
                 if raw_trace is None:
@@ -304,7 +319,7 @@ class BaseAnswer(BaseModel):
                 trace_result = primitive.check_trace(raw_trace)
                 results[name] = trace_result == bool(ground_truth)
             else:
-                extracted = getattr(self, name)
+                extracted = getattr(self, name, None)
                 results[name] = primitive.check(extracted, ground_truth)
 
         self.__dict__["_field_results"] = results
@@ -356,7 +371,10 @@ class BaseAnswer(BaseModel):
             if strategy is not None:
                 return evaluate_strategy(strategy, field_results)
 
-        return all(field_results.values())
+        # Tri-valued results: only True counts as pass. None (null extraction)
+        # is treated as not-satisfied here, but remains distinguishable from
+        # False in the cached field_results dict.
+        return all(v is True for v in field_results.values())
 
     def _auto_verify_granular(self) -> float:
         """Auto-generated verify_granular() for VerifiedField templates.
@@ -389,12 +407,16 @@ class BaseAnswer(BaseModel):
         if strategy is not None:
             return self._composition_aware_granular(strategy, field_results, verified)
 
-        # Default AllOf behavior: flat weighted average
+        # Default AllOf behavior: flat weighted average.
+        # None (null extraction) is treated as not-satisfied here: it does NOT
+        # contribute to weighted_sum but still counts toward total_weight, so
+        # the score is n_true / n_total, distinguishing nulls from False only
+        # in field_results, not in the granular score.
         total_weight = 0.0
         weighted_sum = 0.0
         for name, meta in verified.items():
             total_weight += meta.weight
-            if field_results.get(name, False):
+            if field_results.get(name) is True:
                 weighted_sum += meta.weight
 
         if total_weight == 0.0:
@@ -404,14 +426,16 @@ class BaseAnswer(BaseModel):
     @staticmethod
     def _composition_aware_granular(
         strategy: Any,
-        field_results: dict[str, bool],
+        field_results: dict[str, bool | None],
         verified: dict[str, Any],
     ) -> float:
         """Compute granular score honoring composition strategy.
 
         Args:
             strategy: Composition strategy node (AllOf, AnyOf, AtLeastN).
-            field_results: Per-field pass/fail booleans.
+            field_results: Per-field tri-valued result (True / False / None).
+                None denotes a null extraction; treated as not-satisfied
+                here but distinguishable from False in field_results.
             verified: Per-field VerificationMeta (for weights).
 
         Returns:
@@ -424,7 +448,7 @@ class BaseAnswer(BaseModel):
             return 0.0
 
         passing_weights: list[float] = sorted(
-            [verified[name].weight for name, passed in field_results.items() if passed],
+            [verified[name].weight for name, passed in field_results.items() if passed is True],
             reverse=True,
         )
 

--- a/src/karenina/schemas/entities/composition.py
+++ b/src/karenina/schemas/entities/composition.py
@@ -77,15 +77,24 @@ AnyOf.model_rebuild()
 AtLeastN.model_rebuild()
 
 
-def evaluate_strategy(node: StrategyNode, field_results: dict[str, bool]) -> bool:
+def evaluate_strategy(node: StrategyNode, field_results: dict[str, bool | None]) -> bool:
     """Evaluate a composition strategy tree against field results.
 
     Thin wrapper around ``evaluate_composition()`` that supplies the
     FieldCheck leaf evaluator for the template domain.
 
+    The leaf evaluator returns True only when ``field_results[leaf.field]``
+    is exactly ``True``. ``None`` (null extraction) is treated as
+    not-satisfied at composition time, equivalent to soft-False, so
+    AllOf / AnyOf / AtLeastN behave conservatively when a sub-field is
+    unanswered. Distinguishing None from False is preserved in
+    ``field_results`` for downstream consumers (granular scoring,
+    serialized result rows).
+
     Args:
         node: The root node of the strategy tree.
-        field_results: Mapping of field names to their pass/fail results.
+        field_results: Mapping of field names to their tri-valued result
+            (True / False / None).
 
     Returns:
         True if the strategy passes.
@@ -95,6 +104,6 @@ def evaluate_strategy(node: StrategyNode, field_results: dict[str, bool]) -> boo
     """
 
     def _field_check_evaluator(leaf: FieldCheck) -> bool:
-        return field_results[leaf.field]
+        return field_results[leaf.field] is True
 
     return evaluate_composition(node, _field_check_evaluator)

--- a/src/karenina/schemas/verification/config.py
+++ b/src/karenina/schemas/verification/config.py
@@ -289,6 +289,23 @@ class VerificationConfig(BaseModel):
             "directories."
         ),
     )
+    workspace_output_mode: Literal["none", "full", "produced"] = Field(
+        default="none",
+        description=(
+            "Whether to capture runtime workspaces as sidecar artifacts. "
+            "'none' preserves existing behavior. 'full' copies the complete "
+            "final workspace. 'produced' copies new or content-modified files "
+            "relative to the prepared workspace baseline."
+        ),
+    )
+    workspace_output_dir: Path | None = Field(
+        default=None,
+        description="Directory where captured workspaces are written when workspace_output_mode is not 'none'.",
+    )
+    workspace_output_exclude_patterns: list[str] = Field(
+        default_factory=list,
+        description="Additional fnmatch-style exclude patterns for workspace capture.",
+    )
 
     # Database storage settings
     db_config: Any | None = None  # DBConfig instance for automatic result persistence
@@ -808,6 +825,9 @@ class VerificationConfig(BaseModel):
         deep_judgment_rubric_search: bool | None = None,
         deep_judgment_rubric_search_tool: str | None = None,
         deep_judgment_rubric_config: DeepJudgmentRubricCustomConfig | dict[str, Any] | None = None,
+        workspace_output_mode: Literal["none", "full", "produced"] | None = None,
+        workspace_output_dir: Path | None = None,
+        workspace_output_exclude_patterns: list[str] | None = None,
     ) -> "VerificationConfig":
         """
         Create a VerificationConfig by applying overrides to an optional base config.
@@ -851,6 +871,9 @@ class VerificationConfig(BaseModel):
             deep_judgment_rubric_search: Override for rubric search flag.
             deep_judgment_rubric_search_tool: Override for rubric search tool.
             deep_judgment_rubric_config: Override for rubric config dict.
+            workspace_output_mode: Override for workspace sidecar capture mode.
+            workspace_output_dir: Override for workspace sidecar output directory.
+            workspace_output_exclude_patterns: Additional workspace sidecar exclude patterns.
 
         Returns:
             A new VerificationConfig with overrides applied.
@@ -913,6 +936,14 @@ class VerificationConfig(BaseModel):
             config_dict["deep_judgment_rubric_search_tool"] = deep_judgment_rubric_search_tool
         if deep_judgment_rubric_config is not None:
             config_dict["deep_judgment_rubric_config"] = deep_judgment_rubric_config
+
+        # Workspace output capture
+        if workspace_output_mode is not None:
+            config_dict["workspace_output_mode"] = workspace_output_mode
+        if workspace_output_dir is not None:
+            config_dict["workspace_output_dir"] = workspace_output_dir
+        if workspace_output_exclude_patterns is not None:
+            config_dict["workspace_output_exclude_patterns"] = workspace_output_exclude_patterns
 
         # --- Model configuration ---
         # Determine the unified interface (answering and parsing may differ)

--- a/src/karenina/schemas/verification/config_presets.py
+++ b/src/karenina/schemas/verification/config_presets.py
@@ -172,19 +172,6 @@ def sanitize_model_config(model: dict[str, Any]) -> dict[str, Any]:
     if "extra_kwargs" in model and model["extra_kwargs"]:
         sanitized["extra_kwargs"] = model["extra_kwargs"]
 
-    # Include DeepAgents backend settings when they differ from defaults or
-    # are required for the selected backend.
-    if "deepagents_backend" in model and model["deepagents_backend"] != "filesystem":
-        sanitized["deepagents_backend"] = model["deepagents_backend"]
-    if "deepagents_docker_image" in model and model["deepagents_docker_image"]:
-        sanitized["deepagents_docker_image"] = model["deepagents_docker_image"]
-    if "deepagents_docker_network" in model and model["deepagents_docker_network"] != "bridge":
-        sanitized["deepagents_docker_network"] = model["deepagents_docker_network"]
-    if "deepagents_execute_timeout" in model and model["deepagents_execute_timeout"] != 120:
-        sanitized["deepagents_execute_timeout"] = model["deepagents_execute_timeout"]
-    if "deepagents_execute_max_output_bytes" in model and model["deepagents_execute_max_output_bytes"] != 100000:
-        sanitized["deepagents_execute_max_output_bytes"] = model["deepagents_execute_max_output_bytes"]
-
     # Include agent_middleware if present (for MCP-enabled agents)
     if "agent_middleware" in model and model["agent_middleware"]:
         sanitized["agent_middleware"] = model["agent_middleware"]

--- a/src/karenina/schemas/verification/config_presets.py
+++ b/src/karenina/schemas/verification/config_presets.py
@@ -172,6 +172,19 @@ def sanitize_model_config(model: dict[str, Any]) -> dict[str, Any]:
     if "extra_kwargs" in model and model["extra_kwargs"]:
         sanitized["extra_kwargs"] = model["extra_kwargs"]
 
+    # Include DeepAgents backend settings when they differ from defaults or
+    # are required for the selected backend.
+    if "deepagents_backend" in model and model["deepagents_backend"] != "filesystem":
+        sanitized["deepagents_backend"] = model["deepagents_backend"]
+    if "deepagents_docker_image" in model and model["deepagents_docker_image"]:
+        sanitized["deepagents_docker_image"] = model["deepagents_docker_image"]
+    if "deepagents_docker_network" in model and model["deepagents_docker_network"] != "bridge":
+        sanitized["deepagents_docker_network"] = model["deepagents_docker_network"]
+    if "deepagents_execute_timeout" in model and model["deepagents_execute_timeout"] != 120:
+        sanitized["deepagents_execute_timeout"] = model["deepagents_execute_timeout"]
+    if "deepagents_execute_max_output_bytes" in model and model["deepagents_execute_max_output_bytes"] != 100000:
+        sanitized["deepagents_execute_max_output_bytes"] = model["deepagents_execute_max_output_bytes"]
+
     # Include agent_middleware if present (for MCP-enabled agents)
     if "agent_middleware" in model and model["agent_middleware"]:
         sanitized["agent_middleware"] = model["agent_middleware"]

--- a/src/karenina/schemas/verification/result_components.py
+++ b/src/karenina/schemas/verification/result_components.py
@@ -144,7 +144,11 @@ class VerificationResultTemplate(BaseModel):
     )  # Template verification result (None if template verification skipped)
     verify_granular_result: Any | None = None
     field_verification_error: str | None = None  # Error from verify() exception (issue 146)
-    field_results: dict[str, bool] | None = None  # Per-field primitive verification results (issue 150)
+    # Per-field primitive verification results (issue 150). Values are
+    # tri-valued: True (pass), False (fail), or None (extractor returned
+    # null for that field, kept distinct from False so a null cannot
+    # silently match a False ground truth).
+    field_results: dict[str, bool | None] | None = None
     composition_strategy: str | None = (
         None  # Composition strategy used: "all_of", "any_of", "at_least_n(N)" (issue 151)
     )

--- a/tests/benchmark/verification/test_cache_hydration.py
+++ b/tests/benchmark/verification/test_cache_hydration.py
@@ -309,6 +309,28 @@ class TestCacheHydration:
         status, _data = cache.get_or_reserve(key)
         assert status == "MISS"
 
+    def test_hydration_keeps_parser_stage_unexpected_failures(self, tmp_path: Path) -> None:
+        """Parser-stage unexpected errors still carry reusable answer traces."""
+        parser_failure = _make_result(
+            question_id="q_parser_unexpected",
+            failure=Failure(
+                category=FailureCategory.UNEXPECTED_ERROR,
+                stage="AgenticParseTemplate",
+                reason="structured extraction crashed",
+            ),
+            raw_llm_response="--- AI Message ---\nanswer already generated",
+        )
+        sink = _persist_and_resume(tmp_path, [parser_failure])
+        cache = AnswerTraceCache()
+
+        VerificationExecutor._hydrate_cache_from_results(cache, sink.iter_results())
+
+        key = _expected_cache_key(parser_failure)
+        status, data = cache.get_or_reserve(key)
+        assert status == "HIT"
+        assert data is not None
+        assert data["raw_llm_response"] == "--- AI Message ---\nanswer already generated"
+
     def test_hydration_keys_per_replicate(self, tmp_path: Path) -> None:
         """Replicate=1 and replicate=2 hydrate to independent cache entries.
 

--- a/tests/unit/adapters/claude_agent_sdk/test_agent_workspace.py
+++ b/tests/unit/adapters/claude_agent_sdk/test_agent_workspace.py
@@ -1,13 +1,15 @@
 """Tests for workspace_path to cwd wiring in ClaudeSDKAgentAdapter."""
 
+import asyncio
 import sys
 import types
 from pathlib import Path
 
 import pytest
 
-from karenina.adapters.claude_agent_sdk.agent import ClaudeSDKAgentAdapter
-from karenina.ports import AgentConfig
+from karenina.adapters.claude_agent_sdk.agent import CLAUDE_SDK_DOCKER_WRAPPER, ClaudeSDKAgentAdapter
+from karenina.adapters.claude_agent_sdk.docker_cli_wrapper import build_docker_command
+from karenina.ports import AdapterUnavailableError, AgentConfig, Message
 from karenina.schemas.config.models import ModelConfig
 
 
@@ -108,6 +110,122 @@ class TestWorkspacePath:
         assert getattr(options, "sandbox", None) is None
         assert adapter.capabilities.uses_sandboxed_execution is False
 
+    def test_native_mode_sets_workspace_local_uv_env(self, tmp_path):
+        adapter = self._make_adapter()
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        options = adapter._build_options(
+            system_prompt="test",
+            mcp_servers=None,
+            config=AgentConfig(workspace_path=workspace),
+        )
+
+        assert options.env["UV_CACHE_DIR"] == str(workspace / ".uv-cache")
+        assert options.env["XDG_CACHE_HOME"] == str(workspace / ".cache")
+        assert options.env["UV_PROJECT_ENVIRONMENT"] == str(workspace / ".venv")
+
+    def test_docker_backend_uses_wrapper_and_disables_native_sandbox(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        config = ModelConfig(
+            id="test",
+            model_name="claude-sonnet-4-20250514",
+            interface="claude_agent_sdk",
+            extra_kwargs={
+                "agent_runtime": {
+                    "backend": "docker",
+                    "docker_image": "karenina-bixbench-claude:latest",
+                    "docker_network": "none",
+                    "docker_add_hosts": ["hl-codon-gpu-020:10.0.0.20"],
+                }
+            },
+        )
+        adapter = ClaudeSDKAgentAdapter(config)
+
+        options = adapter._build_options(
+            system_prompt="test",
+            mcp_servers=None,
+            config=AgentConfig(workspace_path=workspace),
+        )
+
+        assert options.cli_path == str(CLAUDE_SDK_DOCKER_WRAPPER)
+        assert getattr(options, "sandbox", None) is None
+        assert options.cwd == str(workspace)
+        assert options.env["KARENINA_CLAUDE_DOCKER_WORKSPACE"] == str(workspace.resolve())
+        assert options.env["KARENINA_CLAUDE_DOCKER_IMAGE"] == "karenina-bixbench-claude:latest"
+        assert options.env["KARENINA_CLAUDE_DOCKER_NETWORK"] == "none"
+        assert options.env["KARENINA_CLAUDE_DOCKER_ADD_HOSTS"] == "hl-codon-gpu-020:10.0.0.20"
+        assert options.env["CLAUDE_CONFIG_DIR"] == "/tmp/claude-config"
+        assert options.permission_mode == "bypassPermissions"
+        assert adapter.capabilities.uses_sandboxed_execution is True
+
+    def test_docker_read_only_keeps_safe_permission_mode(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        config = ModelConfig(
+            id="test",
+            model_name="claude-sonnet-4-20250514",
+            interface="claude_agent_sdk",
+            extra_kwargs={
+                "agent_runtime": {
+                    "backend": "docker",
+                    "access_mode": "read_only",
+                    "docker_image": "karenina-bixbench-claude:latest",
+                }
+            },
+        )
+        adapter = ClaudeSDKAgentAdapter(config)
+
+        options = adapter._build_options(
+            system_prompt="test",
+            mcp_servers=None,
+            config=AgentConfig(workspace_path=workspace),
+        )
+
+        assert options.permission_mode == "acceptEdits"
+        assert options.allowed_tools == ["Read", "Grep", "Glob", "LS"]
+
+    def test_docker_backend_requires_workspace(self):
+        config = ModelConfig(
+            id="test",
+            model_name="claude-sonnet-4-20250514",
+            interface="claude_agent_sdk",
+            extra_kwargs={
+                "agent_runtime": {
+                    "backend": "docker",
+                    "docker_image": "karenina-bixbench-claude:latest",
+                }
+            },
+        )
+        adapter = ClaudeSDKAgentAdapter(config)
+
+        with pytest.raises(AdapterUnavailableError, match="requires an AgentConfig.workspace_path"):
+            adapter._build_options(
+                system_prompt="test",
+                mcp_servers=None,
+                config=AgentConfig(),
+            )
+
+    def test_read_only_access_mode_allows_only_read_tools(self):
+        config = ModelConfig(
+            id="test",
+            model_name="claude-sonnet-4-20250514",
+            interface="claude_agent_sdk",
+            extra_kwargs={"agent_runtime": {"access_mode": "read_only"}},
+        )
+        adapter = ClaudeSDKAgentAdapter(config)
+
+        options = adapter._build_options(
+            system_prompt="test",
+            mcp_servers=None,
+            config=AgentConfig(),
+        )
+
+        assert options.tools == ["Read", "Grep", "Glob", "LS"]
+        assert options.allowed_tools == ["Read", "Grep", "Glob", "LS"]
+        assert adapter.capabilities.supports_code_execution is False
+
     def test_build_options_ignores_plain_permission_mode_extra(self):
         adapter = self._make_adapter()
 
@@ -134,6 +252,34 @@ class TestWorkspacePath:
         )
 
         assert options.permission_mode == "bypassPermissions"
+
+
+@pytest.mark.unit
+class TestDockerCliWrapper:
+    def test_build_docker_command_maps_workspace_and_forwards_endpoint(self, monkeypatch, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        monkeypatch.setenv("KARENINA_CLAUDE_DOCKER_WORKSPACE", str(workspace))
+        monkeypatch.setenv("KARENINA_CLAUDE_DOCKER_IMAGE", "karenina-bixbench-claude:latest")
+        monkeypatch.setenv("KARENINA_CLAUDE_DOCKER_NETWORK", "bridge")
+        monkeypatch.setenv("KARENINA_CLAUDE_DOCKER_ADD_HOSTS", "hl-codon-gpu-020:10.0.0.20")
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://hl-codon-gpu-020:8000")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "EMPTY")
+
+        command = build_docker_command(["--version", "--settings", f'{{"cwd":"{workspace}"}}'])
+
+        assert command[:4] == ["docker", "run", "--rm", "-i"]
+        assert "--network" in command
+        assert command[command.index("--network") + 1] == "bridge"
+        assert "--add-host" in command
+        assert command[command.index("--add-host") + 1] == "hl-codon-gpu-020:10.0.0.20"
+        assert f"{workspace}:/workspace:rw" in command
+        assert "ANTHROPIC_BASE_URL" in command
+        assert "ANTHROPIC_API_KEY" in command
+        assert "karenina-bixbench-claude:latest" in command
+        assert "claude" in command
+        assert str(workspace) not in command[-1]
+        assert "/workspace" in command[-1]
 
 
 @pytest.mark.unit
@@ -201,3 +347,89 @@ class TestBuildOptionsIsolation:
         # env may still exist for ANTHROPIC_* keys but should not fabricate CLAUDE_CONFIG_DIR
         env = getattr(options, "env", None) or {}
         assert env.get("CLAUDE_CONFIG_DIR") is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_arun_returns_partial_trace_when_timeout_has_messages(monkeypatch):
+    class TextBlock:
+        def __init__(self, text):
+            self.text = text
+
+    class ThinkingBlock:
+        pass
+
+    class ToolUseBlock:
+        pass
+
+    class ToolResultBlock:
+        pass
+
+    class UserMessage:
+        def __init__(self, content):
+            self.content = content
+
+    class AssistantMessage:
+        def __init__(self, content, model="qwen3.5-122b-a10b"):
+            self.content = content
+            self.model = model
+
+    class ResultMessage:
+        pass
+
+    class ClaudeAgentOptions:
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    class ClaudeSDKClient:
+        def __init__(self, _options):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def query(self, _prompt):
+            return None
+
+        async def receive_response(self):
+            yield AssistantMessage([TextBlock("partial answer")])
+            await asyncio.sleep(10)
+
+    fake_sdk = types.ModuleType("claude_agent_sdk")
+    fake_sdk.ClaudeAgentOptions = ClaudeAgentOptions
+    fake_sdk.ClaudeSDKClient = ClaudeSDKClient
+    fake_sdk.AssistantMessage = AssistantMessage
+    fake_sdk.UserMessage = UserMessage
+    fake_sdk.ResultMessage = ResultMessage
+
+    fake_types = types.ModuleType("claude_agent_sdk.types")
+    fake_types.TextBlock = TextBlock
+    fake_types.ThinkingBlock = ThinkingBlock
+    fake_types.ToolUseBlock = ToolUseBlock
+    fake_types.ToolResultBlock = ToolResultBlock
+
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", fake_sdk)
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk.types", fake_types)
+
+    config = ModelConfig(
+        id="test",
+        model_name="qwen3.5-122b-a10b",
+        interface="claude_agent_sdk",
+    )
+    adapter = ClaudeSDKAgentAdapter(config)
+
+    result = await adapter.arun(
+        [Message.user("run a long task")],
+        config=AgentConfig(timeout=0.01),
+    )
+
+    assert result.timeout_reached is True
+    assert result.limit_reached is False
+    assert "partial answer" in result.raw_trace
+    assert "[Note: Agent timed out - partial trace shown]" in result.raw_trace
+    assert result.final_response == "partial answer"
+    assert result.trace_messages

--- a/tests/unit/adapters/claude_agent_sdk/test_agent_workspace.py
+++ b/tests/unit/adapters/claude_agent_sdk/test_agent_workspace.py
@@ -38,6 +38,14 @@ def patch_claude_agent_sdk(monkeypatch):
     yield
 
 
+@pytest.fixture
+def no_docker_preflight(monkeypatch):
+    monkeypatch.setattr(
+        "karenina.adapters.claude_agent_sdk.agent.preflight_docker_runtime",
+        lambda **_kwargs: None,
+    )
+
+
 @pytest.mark.unit
 class TestWorkspacePath:
     def _make_adapter(self):
@@ -125,6 +133,7 @@ class TestWorkspacePath:
         assert options.env["XDG_CACHE_HOME"] == str(workspace / ".cache")
         assert options.env["UV_PROJECT_ENVIRONMENT"] == str(workspace / ".venv")
 
+    @pytest.mark.usefixtures("no_docker_preflight")
     def test_docker_backend_uses_wrapper_and_disables_native_sandbox(self, tmp_path):
         workspace = tmp_path / "workspace"
         workspace.mkdir()
@@ -160,6 +169,36 @@ class TestWorkspacePath:
         assert options.permission_mode == "bypassPermissions"
         assert adapter.capabilities.uses_sandboxed_execution is True
 
+    def test_docker_backend_runs_preflight(self, tmp_path, monkeypatch):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        captured: dict[str, str | None] = {}
+        monkeypatch.setattr(
+            "karenina.adapters.claude_agent_sdk.agent.preflight_docker_runtime",
+            lambda *, image, **_kwargs: captured.update({"image": image}),
+        )
+        config = ModelConfig(
+            id="test",
+            model_name="claude-sonnet-4-20250514",
+            interface="claude_agent_sdk",
+            extra_kwargs={
+                "agent_runtime": {
+                    "backend": "docker",
+                    "docker_image": "karenina-bixbench-claude:latest",
+                }
+            },
+        )
+        adapter = ClaudeSDKAgentAdapter(config)
+
+        adapter._build_options(
+            system_prompt="test",
+            mcp_servers=None,
+            config=AgentConfig(workspace_path=workspace),
+        )
+
+        assert captured == {"image": "karenina-bixbench-claude:latest"}
+
+    @pytest.mark.usefixtures("no_docker_preflight")
     def test_zai_anthropic_endpoint_sets_auth_token_and_glm_mapping(self, tmp_path):
         workspace = tmp_path / "workspace"
         workspace.mkdir()
@@ -190,6 +229,7 @@ class TestWorkspacePath:
         assert options.env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "glm-5.1"
         assert options.env["API_TIMEOUT_MS"] == "3000000"
 
+    @pytest.mark.usefixtures("no_docker_preflight")
     def test_docker_read_only_keeps_safe_permission_mode(self, tmp_path):
         workspace = tmp_path / "workspace"
         workspace.mkdir()

--- a/tests/unit/adapters/claude_agent_sdk/test_agent_workspace.py
+++ b/tests/unit/adapters/claude_agent_sdk/test_agent_workspace.py
@@ -160,6 +160,36 @@ class TestWorkspacePath:
         assert options.permission_mode == "bypassPermissions"
         assert adapter.capabilities.uses_sandboxed_execution is True
 
+    def test_zai_anthropic_endpoint_sets_auth_token_and_glm_mapping(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        config = ModelConfig(
+            id="test",
+            model_name="glm-5.1",
+            interface="claude_agent_sdk",
+            anthropic_base_url="https://api.z.ai/api/anthropic",
+            anthropic_api_key="zai-key",
+            extra_kwargs={
+                "agent_runtime": {
+                    "backend": "docker",
+                    "docker_image": "karenina-bixbench-claude:latest",
+                }
+            },
+        )
+        adapter = ClaudeSDKAgentAdapter(config)
+
+        options = adapter._build_options(
+            system_prompt="test",
+            mcp_servers=None,
+            config=AgentConfig(workspace_path=workspace),
+        )
+
+        assert options.model == "claude-sonnet-4-5"
+        assert options.env["ANTHROPIC_AUTH_TOKEN"] == "zai-key"
+        assert options.env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "glm-5.1"
+        assert options.env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "glm-5.1"
+        assert options.env["API_TIMEOUT_MS"] == "3000000"
+
     def test_docker_read_only_keeps_safe_permission_mode(self, tmp_path):
         workspace = tmp_path / "workspace"
         workspace.mkdir()
@@ -265,6 +295,9 @@ class TestDockerCliWrapper:
         monkeypatch.setenv("KARENINA_CLAUDE_DOCKER_ADD_HOSTS", "hl-codon-gpu-020:10.0.0.20")
         monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://hl-codon-gpu-020:8000")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "EMPTY")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "zai-key")
+        monkeypatch.setenv("ANTHROPIC_DEFAULT_SONNET_MODEL", "glm-5.1")
+        monkeypatch.setenv("ANTHROPIC_DEFAULT_OPUS_MODEL", "glm-5.1")
 
         command = build_docker_command(["--version", "--settings", f'{{"cwd":"{workspace}"}}'])
 
@@ -276,6 +309,9 @@ class TestDockerCliWrapper:
         assert f"{workspace}:/workspace:rw" in command
         assert "ANTHROPIC_BASE_URL" in command
         assert "ANTHROPIC_API_KEY" in command
+        assert "ANTHROPIC_AUTH_TOKEN" in command
+        assert "ANTHROPIC_DEFAULT_SONNET_MODEL" in command
+        assert "ANTHROPIC_DEFAULT_OPUS_MODEL" in command
         assert "karenina-bixbench-claude:latest" in command
         assert "claude" in command
         assert str(workspace) not in command[-1]

--- a/tests/unit/adapters/claude_agent_sdk/test_agent_workspace.py
+++ b/tests/unit/adapters/claude_agent_sdk/test_agent_workspace.py
@@ -41,8 +41,8 @@ def patch_claude_agent_sdk(monkeypatch):
 @pytest.fixture
 def no_docker_preflight(monkeypatch):
     monkeypatch.setattr(
-        "karenina.adapters.claude_agent_sdk.agent.preflight_docker_runtime",
-        lambda **_kwargs: None,
+        "karenina.adapters.claude_agent_sdk.agent.preflight_container_runtime",
+        lambda *_args, **_kwargs: None,
     )
 
 
@@ -174,8 +174,8 @@ class TestWorkspacePath:
         workspace.mkdir()
         captured: dict[str, str | None] = {}
         monkeypatch.setattr(
-            "karenina.adapters.claude_agent_sdk.agent.preflight_docker_runtime",
-            lambda *, image, **_kwargs: captured.update({"image": image}),
+            "karenina.adapters.claude_agent_sdk.agent.preflight_container_runtime",
+            lambda config, **_kwargs: captured.update({"image": config.image, "runtime": config.runtime}),
         )
         config = ModelConfig(
             id="test",
@@ -196,7 +196,7 @@ class TestWorkspacePath:
             config=AgentConfig(workspace_path=workspace),
         )
 
-        assert captured == {"image": "karenina-bixbench-claude:latest"}
+        assert captured == {"image": "karenina-bixbench-claude:latest", "runtime": "docker"}
 
     @pytest.mark.usefixtures("no_docker_preflight")
     def test_zai_anthropic_endpoint_sets_auth_token_and_glm_mapping(self, tmp_path):
@@ -353,6 +353,28 @@ class TestDockerCliWrapper:
         assert "ANTHROPIC_DEFAULT_SONNET_MODEL" in command
         assert "ANTHROPIC_DEFAULT_OPUS_MODEL" in command
         assert "karenina-bixbench-claude:latest" in command
+        assert "claude" in command
+        assert str(workspace) not in command[-1]
+        assert "/workspace" in command[-1]
+
+    def test_build_singularity_command_maps_workspace(self, monkeypatch, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        image = tmp_path / "karenina.sif"
+        image.write_text("")
+        monkeypatch.setenv("KARENINA_CLAUDE_CONTAINER_WORKSPACE", str(workspace))
+        monkeypatch.setenv("KARENINA_CLAUDE_CONTAINER_RUNTIME", "singularity")
+        monkeypatch.setenv("KARENINA_CLAUDE_CONTAINER_IMAGE", str(image))
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://hl-codon-gpu-020:8000")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "EMPTY")
+
+        command = build_docker_command(["--settings", f'{{"cwd":"{workspace}"}}'])
+
+        assert command[:2] == ["singularity", "exec"]
+        assert f"{workspace.resolve()}:/workspace:rw" in command
+        assert "--pwd" in command
+        assert command[command.index("--pwd") + 1] == "/workspace"
+        assert str(image) in command
         assert "claude" in command
         assert str(workspace) not in command[-1]
         assert "/workspace" in command[-1]

--- a/tests/unit/adapters/claude_agent_sdk/test_agent_workspace.py
+++ b/tests/unit/adapters/claude_agent_sdk/test_agent_workspace.py
@@ -56,7 +56,8 @@ class TestWorkspacePath:
         )
         assert str(options.cwd) == "/tmp/test_workspace"
 
-    def test_build_options_no_cwd_when_workspace_path_is_none(self):
+    def test_build_options_uses_process_cwd_when_workspace_path_is_none(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
         adapter = self._make_adapter()
         config = AgentConfig()
         options = adapter._build_options(
@@ -64,7 +65,75 @@ class TestWorkspacePath:
             mcp_servers=None,
             config=config,
         )
-        assert options.cwd is None
+        assert str(options.cwd) == str(tmp_path)
+
+    def test_build_options_enables_native_sandbox_by_default(self):
+        adapter = self._make_adapter()
+        options = adapter._build_options(
+            system_prompt="test",
+            mcp_servers=None,
+            config=AgentConfig(),
+        )
+
+        assert options.permission_mode == "acceptEdits"
+        assert options.sandbox == {
+            "enabled": True,
+            "failIfUnavailable": True,
+            "autoAllowBashIfSandboxed": True,
+            "allowUnsandboxedCommands": False,
+        }
+
+    def test_capabilities_report_sandboxed_execution_by_default(self):
+        adapter = self._make_adapter()
+
+        assert adapter.capabilities.supports_file_tools is True
+        assert adapter.capabilities.supports_code_execution is True
+        assert adapter.capabilities.uses_sandboxed_execution is True
+
+    def test_build_options_can_disable_sandbox(self):
+        config = ModelConfig(
+            id="test",
+            model_name="claude-sonnet-4-20250514",
+            interface="claude_agent_sdk",
+            extra_kwargs={"agent_runtime": {"sandbox_enabled": False}},
+        )
+        adapter = ClaudeSDKAgentAdapter(config)
+
+        options = adapter._build_options(
+            system_prompt="test",
+            mcp_servers=None,
+            config=AgentConfig(),
+        )
+
+        assert getattr(options, "sandbox", None) is None
+        assert adapter.capabilities.uses_sandboxed_execution is False
+
+    def test_build_options_ignores_plain_permission_mode_extra(self):
+        adapter = self._make_adapter()
+
+        options = adapter._build_options(
+            system_prompt="test",
+            mcp_servers=None,
+            config=AgentConfig(extra={"permission_mode": "bypassPermissions"}),
+        )
+
+        assert options.permission_mode == "acceptEdits"
+
+    def test_build_options_allows_named_unsafe_permission_override(self):
+        adapter = self._make_adapter()
+
+        options = adapter._build_options(
+            system_prompt="test",
+            mcp_servers=None,
+            config=AgentConfig(
+                extra={
+                    "permission_mode": "bypassPermissions",
+                    "allow_unsafe_permission_mode_override": True,
+                }
+            ),
+        )
+
+        assert options.permission_mode == "bypassPermissions"
 
 
 @pytest.mark.unit

--- a/tests/unit/adapters/claude_agent_sdk/test_auth.py
+++ b/tests/unit/adapters/claude_agent_sdk/test_auth.py
@@ -1,0 +1,37 @@
+"""Tests for the Claude Agent SDK subscription auth helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.adapters.claude_agent_sdk.auth import (
+    SUBSCRIPTION_AUTH_ENV_VARS,
+    subscription_auth_env,
+)
+
+
+@pytest.mark.unit
+class TestSubscriptionAuthEnv:
+    def test_returns_empty_when_no_token_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for name in SUBSCRIPTION_AUTH_ENV_VARS:
+            monkeypatch.delenv(name, raising=False)
+
+        assert subscription_auth_env() == {}
+
+    def test_forwards_oauth_token_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for name in SUBSCRIPTION_AUTH_ENV_VARS:
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-claude-oauth-test")
+
+        env = subscription_auth_env()
+
+        assert env == {"CLAUDE_CODE_OAUTH_TOKEN": "sk-claude-oauth-test"}
+
+    def test_forwards_multiple_subscription_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-value")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "auth-value")
+
+        env = subscription_auth_env()
+
+        assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "oauth-value"
+        assert env["ANTHROPIC_AUTH_TOKEN"] == "auth-value"

--- a/tests/unit/adapters/claude_agent_sdk/test_sdk_retry_from_policy.py
+++ b/tests/unit/adapters/claude_agent_sdk/test_sdk_retry_from_policy.py
@@ -19,6 +19,7 @@ def _make_config(
     *,
     retry_policy: RetryPolicy | None = None,
     anthropic_base_url: str | None = None,
+    extra_kwargs: dict | None = None,
 ) -> ModelConfig:
     """Create a ModelConfig for claude_agent_sdk parser tests."""
     return ModelConfig(
@@ -29,6 +30,7 @@ def _make_config(
         max_tokens=1024,
         retry_policy=retry_policy,
         anthropic_base_url=anthropic_base_url,
+        extra_kwargs=extra_kwargs,
     )
 
 
@@ -136,3 +138,20 @@ class TestClaudeSDKParserOpenAIRetry:
 
             _, kwargs = mock_cls.call_args
             assert kwargs["max_retries"] == 0
+
+    def test_openai_client_uses_explicit_parser_base_url_override(self) -> None:
+        """Z.ai-style endpoint layouts can override the OpenAI parser base URL."""
+        config = _make_config(
+            anthropic_base_url="https://api.z.ai/api/anthropic",
+            extra_kwargs={
+                "claude_sdk_parser_openai_base_url": "https://api.z.ai/api/coding/paas/v4",
+            },
+        )
+        parser = ClaudeSDKParserAdapter(config)
+
+        with patch("openai.AsyncOpenAI") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            parser._get_openai_client()
+
+            _, kwargs = mock_cls.call_args
+            assert kwargs["base_url"] == "https://api.z.ai/api/coding/paas/v4"

--- a/tests/unit/adapters/claude_sdk/test_message_converter_usage.py
+++ b/tests/unit/adapters/claude_sdk/test_message_converter_usage.py
@@ -1,0 +1,152 @@
+"""Tests that ClaudeSDKMessageConverter.from_provider populates usage_metadata.
+
+Fix E (extension): the production trace path in claude_agent_sdk/agent.py
+builds ``trace_messages`` via ``self._converter.from_provider(...)`` rather
+than the direct-to-dict ``sdk_messages_to_trace_messages`` helper. This test
+asserts that the converter attaches per-call ``usage_metadata`` to the
+returned ``Message`` so that ``Message.to_dict()`` emits it into
+``template.trace_messages[*]``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.adapters.claude_agent_sdk import ClaudeSDKMessageConverter
+from karenina.ports import Role
+
+
+@pytest.mark.unit
+class TestClaudeSDKConverterUsageMetadata:
+    def test_assistant_message_carries_usage_metadata(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        sdk_messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="The answer is 42.")],
+                usage={"input_tokens": 123, "output_tokens": 45},
+            ),
+        ]
+
+        converter = ClaudeSDKMessageConverter()
+        result = converter.from_provider(sdk_messages)
+
+        assert len(result) == 1
+        msg = result[0]
+        assert msg.role == Role.ASSISTANT
+        assert msg.usage_metadata == {"input_tokens": 123, "output_tokens": 45}
+
+    def test_to_dict_emits_usage_metadata_after_conversion(self) -> None:
+        """End-to-end: converter populates field, to_dict emits it."""
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        sdk_messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="hi")],
+                usage={"input_tokens": 7, "output_tokens": 3},
+            ),
+        ]
+
+        converter = ClaudeSDKMessageConverter()
+        [msg] = converter.from_provider(sdk_messages)
+        out = msg.to_dict()
+
+        assert out["role"] == "assistant"
+        assert out["usage_metadata"] == {"input_tokens": 7, "output_tokens": 3}
+
+    def test_cache_fields_propagate_when_reported(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        sdk_messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="cached")],
+                usage={
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_read_input_tokens": 800,
+                    "cache_creation_input_tokens": 50,
+                },
+            ),
+        ]
+
+        converter = ClaudeSDKMessageConverter()
+        [msg] = converter.from_provider(sdk_messages)
+
+        assert msg.usage_metadata == {
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_read_input_tokens": 800,
+            "cache_creation_input_tokens": 50,
+        }
+
+    def test_partial_cache_fields_only_include_reported(self) -> None:
+        """A reported zero must be preserved; missing fields must stay absent."""
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        sdk_messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="partial")],
+                usage={
+                    "input_tokens": 60,
+                    "output_tokens": 10,
+                    "cache_read_input_tokens": 0,
+                },
+            ),
+        ]
+
+        converter = ClaudeSDKMessageConverter()
+        [msg] = converter.from_provider(sdk_messages)
+
+        assert msg.usage_metadata is not None
+        assert msg.usage_metadata["cache_read_input_tokens"] == 0
+        assert "cache_creation_input_tokens" not in msg.usage_metadata
+
+    def test_no_usage_yields_none_usage_metadata(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        sdk_messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="no usage")],
+            ),
+        ]
+
+        converter = ClaudeSDKMessageConverter()
+        [msg] = converter.from_provider(sdk_messages)
+
+        assert msg.usage_metadata is None
+        # to_dict must omit the key entirely
+        assert "usage_metadata" not in msg.to_dict()
+
+    def test_empty_usage_dict_yields_none(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        sdk_messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="empty usage")],
+                usage={},
+            ),
+        ]
+
+        converter = ClaudeSDKMessageConverter()
+        [msg] = converter.from_provider(sdk_messages)
+
+        assert msg.usage_metadata is None
+        assert "usage_metadata" not in msg.to_dict()

--- a/tests/unit/adapters/claude_sdk/test_trace_includes_usage.py
+++ b/tests/unit/adapters/claude_sdk/test_trace_includes_usage.py
@@ -1,0 +1,134 @@
+"""Tests that sdk_messages_to_trace_messages preserves per-call usage_metadata.
+
+Fix E (karenina infrastructure plan): trace converters must propagate the
+per-message ``usage`` payload that the Claude Agent SDK attaches to each
+``AssistantMessage`` so that ``template.trace_messages[*].usage_metadata``
+contains per-turn token / cache accounting (and not just the aggregate).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _to_trace(messages):
+    from karenina.adapters.claude_agent_sdk.trace import sdk_messages_to_trace_messages
+
+    return sdk_messages_to_trace_messages(messages)
+
+
+@pytest.mark.unit
+class TestTraceUsageMetadataCSDK:
+    def test_assistant_message_with_usage_propagates_input_output_tokens(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="The answer is 42.")],
+                usage={"input_tokens": 123, "output_tokens": 45},
+            ),
+        ]
+
+        trace = _to_trace(messages)
+        assert len(trace) == 1
+        assert trace[0]["role"] == "assistant"
+        assert "usage_metadata" in trace[0]
+        assert trace[0]["usage_metadata"] == {
+            "input_tokens": 123,
+            "output_tokens": 45,
+        }
+
+    def test_cache_fields_present_propagate_when_reported(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="cached answer")],
+                usage={
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_read_input_tokens": 800,
+                    "cache_creation_input_tokens": 50,
+                },
+            ),
+        ]
+
+        trace = _to_trace(messages)
+        assert trace[0]["usage_metadata"] == {
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_read_input_tokens": 800,
+            "cache_creation_input_tokens": 50,
+        }
+
+    def test_partial_cache_fields_only_include_reported_ones(self) -> None:
+        """When only one cache field is reported, the other must not be added.
+
+        This distinguishes 'not reported' from a real zero — crucial for
+        provenance during post-hoc audits.
+        """
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="partial cache info")],
+                usage={
+                    "input_tokens": 60,
+                    "output_tokens": 10,
+                    "cache_read_input_tokens": 0,
+                },
+            ),
+        ]
+
+        trace = _to_trace(messages)
+        usage_metadata = trace[0]["usage_metadata"]
+        assert usage_metadata["input_tokens"] == 60
+        assert usage_metadata["output_tokens"] == 10
+        # cache_read_input_tokens was explicitly reported as 0 → keep it.
+        assert usage_metadata["cache_read_input_tokens"] == 0
+        # cache_creation_input_tokens was NOT reported → must be absent.
+        assert "cache_creation_input_tokens" not in usage_metadata
+
+    def test_assistant_message_without_usage_omits_usage_metadata(self) -> None:
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        # usage defaults to None on AssistantMessage construction
+        messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="no usage payload")],
+            ),
+        ]
+
+        trace = _to_trace(messages)
+        assert len(trace) == 1
+        assert trace[0]["role"] == "assistant"
+        assert "usage_metadata" not in trace[0]
+
+    def test_assistant_message_with_empty_usage_dict_omits_usage_metadata(self) -> None:
+        """An empty usage dict is falsy -> treated as 'not reported'."""
+        pytest.importorskip("claude_agent_sdk.types")
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        messages = [
+            AssistantMessage(
+                model="claude-haiku-4-5",
+                content=[TextBlock(text="empty usage")],
+                usage={},
+            ),
+        ]
+
+        trace = _to_trace(messages)
+        assert "usage_metadata" not in trace[0]

--- a/tests/unit/adapters/claude_sdk/test_usage_partial_recovery.py
+++ b/tests/unit/adapters/claude_sdk/test_usage_partial_recovery.py
@@ -162,39 +162,55 @@ def _stream_event(event: dict) -> MagicMock:
 
 
 class TestCollapsePartialAssistantMessages:
-    """SDK emits one AssistantMessage per content_block_stop, all sharing a
-    message_id. Keep only the last (most complete) one per turn so iterations
-    and per-message input_tokens reflect real LLM calls."""
+    """The CLI subprocess emits one AssistantMessage per content_block_stop,
+    each carrying only the single block that just finished, all sharing a
+    message_id. Merge the content lists into one AssistantMessage per turn
+    so the trace keeps thinking + text + tool_use, and iterations / input
+    tokens reflect real LLM calls instead of per-block emissions."""
 
-    def test_drops_earlier_duplicates_keeping_last_per_message_id(self) -> None:
+    def test_merges_content_blocks_across_partials(self) -> None:
+        """Each partial carries ONE block; merge them all onto the last
+        emission, preserving source order (thinking, text, tool_use)."""
         partial_1 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 0})
-        partial_1.content = ["thinking_only"]
+        partial_1.content = ["thinking_block"]
         partial_2 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 0})
-        partial_2.content = ["thinking", "text", "tool_use"]
-        result = collapse_partial_assistant_messages([partial_1, partial_2])
+        partial_2.content = ["text_block"]
+        partial_3 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 0})
+        partial_3.content = ["tool_use_block"]
+        result = collapse_partial_assistant_messages([partial_1, partial_2, partial_3])
         assert len(result) == 1
-        assert result[0] is partial_2  # the more complete one wins
+        assert result[0] is partial_3  # the last emission is the survivor
+        assert result[0].content == ["thinking_block", "text_block", "tool_use_block"]
 
     def test_preserves_distinct_message_ids(self) -> None:
         a1 = _assistant_message_with_id("msg_a", {"input_tokens": 50, "output_tokens": 0})
+        a1.content = ["a_thinking"]
         a2 = _assistant_message_with_id("msg_a", {"input_tokens": 50, "output_tokens": 0})
+        a2.content = ["a_tool_use"]
         b1 = _assistant_message_with_id("msg_b", {"input_tokens": 60, "output_tokens": 0})
+        b1.content = ["b_thinking"]
         b2 = _assistant_message_with_id("msg_b", {"input_tokens": 60, "output_tokens": 0})
+        b2.content = ["b_tool_use"]
         result = collapse_partial_assistant_messages([a1, a2, b1, b2])
         assert len(result) == 2
         assert result[0] is a2
+        assert result[0].content == ["a_thinking", "a_tool_use"]
         assert result[1] is b2
+        assert result[1].content == ["b_thinking", "b_tool_use"]
 
     def test_passes_through_non_assistant_messages(self) -> None:
         from claude_agent_sdk import StreamEvent
 
         a1 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 0})
+        a1.content = ["block_1"]
         a2 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 0})
+        a2.content = ["block_2"]
         se = MagicMock(spec=StreamEvent)
         user = _non_assistant_message()
         result = collapse_partial_assistant_messages([se, a1, user, a2])
-        # se and user stay; a1 dropped; a2 stays at its position
+        # se and user stay; a1 dropped; a2 stays at its position with merged content
         assert result == [se, user, a2]
+        assert a2.content == ["block_1", "block_2"]
 
     def test_keeps_messages_without_message_id(self) -> None:
         """Defensive: if the SDK ever returns AssistantMessages without an id,
@@ -213,11 +229,25 @@ class TestCollapsePartialAssistantMessages:
         """End-to-end: without collapse, two partials with same input_tokens=100
         would sum to 200. After collapse, sum is 100."""
         a1 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 0})
+        a1.content = ["text_block"]
         a2 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 7})
+        a2.content = ["tool_use_block"]
         collapsed = collapse_partial_assistant_messages([a1, a2])
         usage = extract_sdk_usage_from_messages(collapsed)
         assert usage.input_tokens == 100
         assert usage.output_tokens == 7
+
+    def test_handles_empty_content_lists(self) -> None:
+        """A partial may carry an empty content list (e.g. for the initial
+        emission before any content_block_stop). It must still be merged
+        without raising and the merged content stays empty."""
+        a1 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 0})
+        a1.content = []
+        a2 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 0})
+        a2.content = []
+        result = collapse_partial_assistant_messages([a1, a2])
+        assert len(result) == 1
+        assert result[0].content == []
 
 
 class TestBackfillAssistantOutputTokens:

--- a/tests/unit/adapters/claude_sdk/test_usage_partial_recovery.py
+++ b/tests/unit/adapters/claude_sdk/test_usage_partial_recovery.py
@@ -16,6 +16,10 @@ import pytest
 from karenina.adapters.claude_agent_sdk import (
     extract_sdk_usage_from_messages,
 )
+from karenina.adapters.claude_agent_sdk.usage import (
+    backfill_assistant_output_tokens,
+    collapse_partial_assistant_messages,
+)
 from karenina.ports import UsageMetadata
 
 
@@ -138,6 +142,178 @@ class TestExtractSdkUsageFromMessages:
         usage = extract_sdk_usage_from_messages(messages)
         assert usage.input_tokens == 75
         assert usage.output_tokens == 15
+
+
+def _assistant_message_with_id(
+    message_id: str | None,
+    usage: dict | None,
+) -> MagicMock:
+    msg = _assistant_message(usage)
+    msg.message_id = message_id
+    return msg
+
+
+def _stream_event(event: dict) -> MagicMock:
+    from claude_agent_sdk import StreamEvent
+
+    se = MagicMock(spec=StreamEvent)
+    se.event = event
+    return se
+
+
+class TestCollapsePartialAssistantMessages:
+    """SDK emits one AssistantMessage per content_block_stop, all sharing a
+    message_id. Keep only the last (most complete) one per turn so iterations
+    and per-message input_tokens reflect real LLM calls."""
+
+    def test_drops_earlier_duplicates_keeping_last_per_message_id(self) -> None:
+        partial_1 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 0})
+        partial_1.content = ["thinking_only"]
+        partial_2 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 0})
+        partial_2.content = ["thinking", "text", "tool_use"]
+        result = collapse_partial_assistant_messages([partial_1, partial_2])
+        assert len(result) == 1
+        assert result[0] is partial_2  # the more complete one wins
+
+    def test_preserves_distinct_message_ids(self) -> None:
+        a1 = _assistant_message_with_id("msg_a", {"input_tokens": 50, "output_tokens": 0})
+        a2 = _assistant_message_with_id("msg_a", {"input_tokens": 50, "output_tokens": 0})
+        b1 = _assistant_message_with_id("msg_b", {"input_tokens": 60, "output_tokens": 0})
+        b2 = _assistant_message_with_id("msg_b", {"input_tokens": 60, "output_tokens": 0})
+        result = collapse_partial_assistant_messages([a1, a2, b1, b2])
+        assert len(result) == 2
+        assert result[0] is a2
+        assert result[1] is b2
+
+    def test_passes_through_non_assistant_messages(self) -> None:
+        from claude_agent_sdk import StreamEvent
+
+        a1 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 0})
+        a2 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 0})
+        se = MagicMock(spec=StreamEvent)
+        user = _non_assistant_message()
+        result = collapse_partial_assistant_messages([se, a1, user, a2])
+        # se and user stay; a1 dropped; a2 stays at its position
+        assert result == [se, user, a2]
+
+    def test_keeps_messages_without_message_id(self) -> None:
+        """Defensive: if the SDK ever returns AssistantMessages without an id,
+        we must not silently drop them by treating them all as one bucket."""
+        a1 = _assistant_message_with_id(None, {"input_tokens": 100, "output_tokens": 5})
+        a2 = _assistant_message_with_id(None, {"input_tokens": 200, "output_tokens": 7})
+        result = collapse_partial_assistant_messages([a1, a2])
+        assert len(result) == 2
+        assert result[0] is a1
+        assert result[1] is a2
+
+    def test_returns_empty_for_empty_input(self) -> None:
+        assert collapse_partial_assistant_messages([]) == []
+
+    def test_collapse_then_aggregate_avoids_double_count(self) -> None:
+        """End-to-end: without collapse, two partials with same input_tokens=100
+        would sum to 200. After collapse, sum is 100."""
+        a1 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 0})
+        a2 = _assistant_message_with_id("msg_a", {"input_tokens": 100, "output_tokens": 7})
+        collapsed = collapse_partial_assistant_messages([a1, a2])
+        usage = extract_sdk_usage_from_messages(collapsed)
+        assert usage.input_tokens == 100
+        assert usage.output_tokens == 7
+
+
+class TestBackfillAssistantOutputTokens:
+    """vLLM and other non-canonical Anthropic endpoints defer output_tokens to
+    the streaming message_delta event. With include_partial_messages=True the
+    SDK surfaces those as StreamEvent objects, which this helper folds back
+    into AssistantMessage.usage so downstream aggregation sees real counts."""
+
+    def test_backfills_output_tokens_from_message_delta(self) -> None:
+        msg = _assistant_message_with_id("msg_abc", {"input_tokens": 100, "output_tokens": 0})
+        events = [
+            _stream_event({"type": "message_start", "message": {"id": "msg_abc", "usage": {"input_tokens": 100, "output_tokens": 0}}}),
+            _stream_event({"type": "content_block_delta", "delta": {}}),
+            _stream_event({"type": "message_delta", "usage": {"input_tokens": 100, "output_tokens": 42}}),
+            _stream_event({"type": "message_stop"}),
+        ]
+        backfill_assistant_output_tokens([*events, msg])
+        assert msg.usage == {"input_tokens": 100, "output_tokens": 42}
+
+    def test_correlates_multiple_messages_by_message_id(self) -> None:
+        msg_a = _assistant_message_with_id("msg_a", {"input_tokens": 50, "output_tokens": 0})
+        msg_b = _assistant_message_with_id("msg_b", {"input_tokens": 70, "output_tokens": 0})
+        events = [
+            _stream_event({"type": "message_start", "message": {"id": "msg_a"}}),
+            _stream_event({"type": "message_delta", "usage": {"output_tokens": 11}}),
+            _stream_event({"type": "message_start", "message": {"id": "msg_b"}}),
+            _stream_event({"type": "message_delta", "usage": {"output_tokens": 22}}),
+        ]
+        backfill_assistant_output_tokens([*events, msg_a, msg_b])
+        assert msg_a.usage["output_tokens"] == 11
+        assert msg_b.usage["output_tokens"] == 22
+
+    def test_does_not_clobber_non_zero_output_tokens(self) -> None:
+        """Canonical Anthropic puts real output_tokens on AssistantMessage.usage
+        directly; the delta value would be redundant but must not overwrite a
+        non-zero existing count."""
+        msg = _assistant_message_with_id("msg_x", {"input_tokens": 100, "output_tokens": 99})
+        events = [
+            _stream_event({"type": "message_start", "message": {"id": "msg_x"}}),
+            _stream_event({"type": "message_delta", "usage": {"output_tokens": 42}}),
+        ]
+        backfill_assistant_output_tokens([*events, msg])
+        assert msg.usage["output_tokens"] == 99
+
+    def test_noop_when_no_stream_events_present(self) -> None:
+        """Without include_partial_messages=True there are no StreamEvent
+        records; the helper must leave AssistantMessages untouched."""
+        msg = _assistant_message_with_id("msg_y", {"input_tokens": 100, "output_tokens": 0})
+        backfill_assistant_output_tokens([msg])
+        assert msg.usage["output_tokens"] == 0
+
+    def test_noop_when_message_id_unknown_to_delta_map(self) -> None:
+        msg = _assistant_message_with_id("msg_unmatched", {"input_tokens": 100, "output_tokens": 0})
+        events = [
+            _stream_event({"type": "message_start", "message": {"id": "msg_other"}}),
+            _stream_event({"type": "message_delta", "usage": {"output_tokens": 42}}),
+        ]
+        backfill_assistant_output_tokens([*events, msg])
+        assert msg.usage["output_tokens"] == 0
+
+    def test_preserves_input_tokens_and_cache_fields(self) -> None:
+        msg = _assistant_message_with_id(
+            "msg_full",
+            {
+                "input_tokens": 100,
+                "output_tokens": 0,
+                "cache_read_input_tokens": 50,
+                "cache_creation_input_tokens": 20,
+            },
+        )
+        events = [
+            _stream_event({"type": "message_start", "message": {"id": "msg_full"}}),
+            _stream_event({"type": "message_delta", "usage": {"output_tokens": 30}}),
+        ]
+        backfill_assistant_output_tokens([*events, msg])
+        assert msg.usage["input_tokens"] == 100
+        assert msg.usage["output_tokens"] == 30
+        assert msg.usage["cache_read_input_tokens"] == 50
+        assert msg.usage["cache_creation_input_tokens"] == 20
+
+    def test_aggregate_picks_up_backfilled_output_tokens(self) -> None:
+        """End-to-end: after backfill, extract_sdk_usage_from_messages sums correctly."""
+        msg_a = _assistant_message_with_id("msg_a", {"input_tokens": 50, "output_tokens": 0})
+        msg_b = _assistant_message_with_id("msg_b", {"input_tokens": 70, "output_tokens": 0})
+        all_messages = [
+            _stream_event({"type": "message_start", "message": {"id": "msg_a"}}),
+            _stream_event({"type": "message_delta", "usage": {"output_tokens": 11}}),
+            msg_a,
+            _stream_event({"type": "message_start", "message": {"id": "msg_b"}}),
+            _stream_event({"type": "message_delta", "usage": {"output_tokens": 22}}),
+            msg_b,
+        ]
+        backfill_assistant_output_tokens(all_messages)
+        usage = extract_sdk_usage_from_messages(all_messages)
+        assert usage.input_tokens == 120
+        assert usage.output_tokens == 33
 
 
 class TestBuildAgentResultUsesFallbackOnPartialTrace:

--- a/tests/unit/adapters/claude_sdk/test_usage_partial_recovery.py
+++ b/tests/unit/adapters/claude_sdk/test_usage_partial_recovery.py
@@ -1,0 +1,202 @@
+"""Tests for partial-usage recovery from SDK AssistantMessage lists.
+
+These exercise the fallback path used when a ClaudeSDKClient run is
+cancelled mid-stream (e.g. by asyncio.wait_for) and no aggregate
+ResultMessage is ever emitted. The collected AssistantMessage objects
+still carry per-call usage dicts, so we aggregate them ourselves rather
+than reporting zero tokens.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from karenina.adapters.claude_agent_sdk import (
+    extract_sdk_usage_from_messages,
+)
+from karenina.ports import UsageMetadata
+
+
+def _assistant_message(usage: dict | None) -> MagicMock:
+    """Build a mock that ``isinstance(msg, AssistantMessage)`` accepts.
+
+    Populates the attributes that downstream trace/usage helpers touch so the
+    mock can flow through ``_build_agent_result`` without AttributeError.
+    """
+    from claude_agent_sdk import AssistantMessage
+
+    msg = MagicMock(spec=AssistantMessage)
+    msg.usage = usage
+    msg.content = []  # raw_trace builder iterates content blocks
+    msg.model = None
+    msg.parent_tool_use_id = None
+    return msg
+
+
+def _non_assistant_message() -> MagicMock:
+    """A non-AssistantMessage to verify we filter it out."""
+    msg = MagicMock()
+    msg.usage = {"input_tokens": 9999, "output_tokens": 9999}
+    return msg
+
+
+class TestExtractSdkUsageFromMessages:
+    def test_returns_zero_for_empty_list(self) -> None:
+        usage = extract_sdk_usage_from_messages([])
+        assert isinstance(usage, UsageMetadata)
+        assert usage.input_tokens == 0
+        assert usage.output_tokens == 0
+        assert usage.total_tokens == 0
+        assert usage.cache_read_tokens is None
+        assert usage.cache_creation_tokens is None
+
+    def test_sums_input_and_output_tokens(self) -> None:
+        messages = [
+            _assistant_message({"input_tokens": 100, "output_tokens": 20}),
+            _assistant_message({"input_tokens": 150, "output_tokens": 30}),
+            _assistant_message({"input_tokens": 200, "output_tokens": 40}),
+        ]
+        usage = extract_sdk_usage_from_messages(messages)
+        assert usage.input_tokens == 450
+        assert usage.output_tokens == 90
+        assert usage.total_tokens == 540
+
+    def test_propagates_model_parameter(self) -> None:
+        usage = extract_sdk_usage_from_messages([], model="qwen-122b")
+        assert usage.model == "qwen-122b"
+
+    def test_aggregates_cache_tokens_when_reported(self) -> None:
+        messages = [
+            _assistant_message(
+                {
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_read_input_tokens": 50,
+                    "cache_creation_input_tokens": 5,
+                }
+            ),
+            _assistant_message(
+                {
+                    "input_tokens": 80,
+                    "output_tokens": 15,
+                    "cache_read_input_tokens": 30,
+                }
+            ),
+        ]
+        usage = extract_sdk_usage_from_messages(messages)
+        assert usage.input_tokens == 180
+        assert usage.output_tokens == 35
+        assert usage.cache_read_tokens == 80
+        assert usage.cache_creation_tokens == 5
+
+    def test_cache_fields_stay_none_when_never_reported(self) -> None:
+        """If no message carries cache tokens, the field stays None (not 0).
+
+        Distinguishes "endpoint did not report cache info" from "endpoint
+        reported zero cache hits".
+        """
+        messages = [
+            _assistant_message({"input_tokens": 50, "output_tokens": 10}),
+            _assistant_message({"input_tokens": 60, "output_tokens": 12}),
+        ]
+        usage = extract_sdk_usage_from_messages(messages)
+        assert usage.cache_read_tokens is None
+        assert usage.cache_creation_tokens is None
+
+    def test_skips_non_assistant_messages(self) -> None:
+        """UserMessage, ResultMessage, tool results etc. must not be summed."""
+        messages = [
+            _assistant_message({"input_tokens": 100, "output_tokens": 20}),
+            _non_assistant_message(),  # has usage dict but isn't AssistantMessage
+            _assistant_message({"input_tokens": 50, "output_tokens": 10}),
+        ]
+        usage = extract_sdk_usage_from_messages(messages)
+        assert usage.input_tokens == 150
+        assert usage.output_tokens == 30
+
+    def test_tolerates_missing_usage_on_some_messages(self) -> None:
+        messages = [
+            _assistant_message({"input_tokens": 100, "output_tokens": 20}),
+            _assistant_message(None),
+            _assistant_message({}),
+            _assistant_message({"input_tokens": 50, "output_tokens": 10}),
+        ]
+        usage = extract_sdk_usage_from_messages(messages)
+        assert usage.input_tokens == 150
+        assert usage.output_tokens == 30
+
+    def test_handles_none_values_in_usage_dict(self) -> None:
+        """Some SDK versions populate fields with explicit None on missing data."""
+        messages = [
+            _assistant_message(
+                {"input_tokens": None, "output_tokens": None}
+            ),
+            _assistant_message({"input_tokens": 75, "output_tokens": 15}),
+        ]
+        usage = extract_sdk_usage_from_messages(messages)
+        assert usage.input_tokens == 75
+        assert usage.output_tokens == 15
+
+
+class TestBuildAgentResultUsesFallbackOnPartialTrace:
+    """When ResultMessage is absent, _build_agent_result must use the per-message fallback.
+
+    This is the regression scenario from the qwen122 / glm51 BixBench runs:
+    csdk's wall-clock timeouts produced 0-token AgentResults despite tens of
+    iterations because the SDK never emits ResultMessage on cancellation.
+    """
+
+    @pytest.fixture
+    def adapter(self):
+        from karenina.adapters.claude_agent_sdk.agent import (
+            ClaudeSDKAgentAdapter,
+        )
+        from karenina.schemas.config.models import ModelConfig
+
+        config = ModelConfig(
+            id="answering",
+            model_name="qwen3.5-122b-a10b",
+            interface="claude_agent_sdk",
+        )
+        return ClaudeSDKAgentAdapter(config)
+
+    def test_fallback_aggregates_when_result_message_is_none(self, adapter) -> None:
+        messages = [
+            _assistant_message({"input_tokens": 1000, "output_tokens": 50}),
+            _assistant_message({"input_tokens": 1200, "output_tokens": 60}),
+            _assistant_message({"input_tokens": 900, "output_tokens": 40}),
+        ]
+        result = adapter._build_agent_result(
+            messages,
+            result_message=None,
+            limit_reached=False,
+            timeout_reached=True,
+        )
+        assert result.usage.input_tokens == 3100
+        assert result.usage.output_tokens == 150
+        assert result.usage.total_tokens == 3250
+        assert result.timeout_reached is True
+
+    def test_uses_result_message_when_present(self, adapter) -> None:
+        """The fallback must NOT override a real ResultMessage."""
+        messages = [
+            _assistant_message({"input_tokens": 1000, "output_tokens": 50}),
+        ]
+        result_message = MagicMock()
+        result_message.usage = {"input_tokens": 9999, "output_tokens": 9999}
+        result_message.total_cost_usd = 0.123
+        result_message.num_turns = 5
+        result_message.session_id = "sess-x"
+        result_message.subtype = ""
+
+        result = adapter._build_agent_result(
+            messages,
+            result_message=result_message,
+            limit_reached=False,
+            timeout_reached=False,
+        )
+        assert result.usage.input_tokens == 9999
+        assert result.usage.output_tokens == 9999
+        assert result.usage.cost_usd == 0.123

--- a/tests/unit/adapters/conformance/test_trace_format.py
+++ b/tests/unit/adapters/conformance/test_trace_format.py
@@ -27,7 +27,9 @@ class TestTraceFormatConformance:
         assert "--- AI Message ---" in trace
 
     def test_tool_call_uses_standard_delimiter(self):
-        """raw_trace must use '--- Tool Call ---' for tool invocations."""
+        """raw_trace must place tool calls inline inside ``--- AI Message ---``
+        with a ``Tool Calls:`` block, matching the canonical format used by
+        the langchain, claude_agent_sdk, and manual adapters."""
         from langchain_core.messages import AIMessage
 
         messages = [
@@ -37,15 +39,20 @@ class TestTraceFormatConformance:
             ),
         ]
         trace = deep_agents_messages_to_raw_trace(messages)
-        assert "--- Tool Call ---" in trace
+        assert "--- AI Message ---" in trace
+        assert "Tool Calls:" in trace
+        # No standalone --- Tool Call --- section; everything stays in the AI Message
+        assert "--- Tool Call ---" not in trace
 
     def test_tool_result_uses_standard_delimiter(self):
-        """raw_trace must use '--- Tool Result ---' for tool outputs."""
+        """raw_trace must use ``--- Tool Message (call_id: <id>) ---`` for
+        tool outputs, matching the canonical format used by the other adapters."""
         from langchain_core.messages import ToolMessage
 
         messages = [ToolMessage(content="result data", tool_call_id="c1")]
         trace = deep_agents_messages_to_raw_trace(messages)
-        assert "--- Tool Result ---" in trace
+        assert "--- Tool Message (call_id: c1) ---" in trace
+        assert "--- Tool Result ---" not in trace
 
     def test_empty_messages_produce_empty_trace(self):
         """Empty message list must produce empty string, not an error."""

--- a/tests/unit/adapters/langchain_deep_agents/test_agent.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_agent.py
@@ -167,8 +167,9 @@ class TestDeepAgentsBackendConfiguration:
         captured_preflight: dict[str, str | None] = {}
         captured_kwargs: dict = {}
 
-        def capture_preflight(*, image, **_kwargs):
-            captured_preflight["image"] = image
+        def capture_preflight(config, **_kwargs):
+            captured_preflight["image"] = config.image
+            captured_preflight["runtime"] = config.runtime
 
         def capture_create(**kwargs):
             captured_kwargs.update(kwargs)
@@ -180,7 +181,7 @@ class TestDeepAgentsBackendConfiguration:
             )
 
         monkeypatch.setattr(
-            "karenina.adapters.langchain_deep_agents.docker_backend.preflight_docker_runtime",
+            "karenina.adapters.langchain_deep_agents.docker_backend.preflight_container_runtime",
             capture_preflight,
         )
         monkeypatch.setattr(
@@ -211,7 +212,7 @@ class TestDeepAgentsBackendConfiguration:
             config=AgentConfig(max_turns=2, workspace_path=workspace),
         )
 
-        assert captured_preflight == {"image": "karenina-bixbench:latest"}
+        assert captured_preflight == {"image": "karenina-bixbench:latest", "runtime": "docker"}
         assert captured_kwargs["backend"].id.startswith("docker-")
 
     @pytest.mark.asyncio

--- a/tests/unit/adapters/langchain_deep_agents/test_agent.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_agent.py
@@ -350,8 +350,11 @@ class TestDeepAgentsAgentAdapter:
         )
 
         assert "answer is X" in result.final_response
-        assert "--- Tool Call ---" in result.raw_trace
-        assert "--- Tool Result ---" in result.raw_trace
+        # DA now emits the canonical inline-tool-calls + "Tool Message" format
+        # shared with langchain / csdk / manual.
+        assert "--- AI Message ---" in result.raw_trace
+        assert "Tool Calls:" in result.raw_trace
+        assert "--- Tool Message (call_id:" in result.raw_trace
         assert result.turns == 2  # Two AIMessages
 
     @pytest.mark.asyncio

--- a/tests/unit/adapters/langchain_deep_agents/test_agent.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_agent.py
@@ -2,12 +2,22 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
 from karenina.adapters.langchain_deep_agents.agent import DeepAgentsAgentAdapter
 from karenina.ports import AgentConfig, AgentResult, Message
+
+
+def _mock_deep_agent(result):
+    """Return a minimal DeepAgents-like object that streams one state."""
+
+    class MockDeepAgent:
+        async def astream(self, *_args, **_kwargs):
+            yield result
+
+    return MockDeepAgent()
 
 
 @pytest.mark.unit
@@ -30,14 +40,12 @@ class TestDeepAgentsBackendConfiguration:
 
         def capture_create(**kwargs):
             captured_kwargs.update(kwargs)
-            mock_agent = MagicMock()
-            mock_agent.ainvoke = AsyncMock(
-                return_value={
+            return _mock_deep_agent(
+                {
                     "messages": [AIMessage(content="ok")],
                     "is_last_step": False,
                 }
             )
-            return mock_agent
 
         monkeypatch.setattr(
             "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
@@ -68,14 +76,12 @@ class TestDeepAgentsBackendConfiguration:
 
         def capture_create(**kwargs):
             captured_kwargs.update(kwargs)
-            mock_agent = MagicMock()
-            mock_agent.ainvoke = AsyncMock(
-                return_value={
+            return _mock_deep_agent(
+                {
                     "messages": [AIMessage(content="ok")],
                     "is_last_step": False,
                 }
             )
-            return mock_agent
 
         monkeypatch.setattr(
             "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
@@ -111,14 +117,12 @@ class TestDeepAgentsBackendConfiguration:
 
         def capture_create(**kwargs):
             captured_kwargs.update(kwargs)
-            mock_agent = MagicMock()
-            mock_agent.ainvoke = AsyncMock(
-                return_value={
+            return _mock_deep_agent(
+                {
                     "messages": [AIMessage(content="ok")],
                     "is_last_step": False,
                 }
             )
-            return mock_agent
 
         monkeypatch.setattr(
             "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
@@ -155,12 +159,9 @@ class TestDeepAgentsAgentAdapter:
             "is_last_step": False,
         }
 
-        mock_agent = MagicMock()
-        mock_agent.ainvoke = AsyncMock(return_value=mock_result)
-
         monkeypatch.setattr(
             "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
-            lambda **_kwargs: mock_agent,
+            lambda **_kwargs: _mock_deep_agent(mock_result),
         )
         monkeypatch.setattr(
             "karenina.adapters.langchain_deep_agents.agent.create_chat_model",
@@ -191,12 +192,9 @@ class TestDeepAgentsAgentAdapter:
             "is_last_step": True,
         }
 
-        mock_agent = MagicMock()
-        mock_agent.ainvoke = AsyncMock(return_value=mock_result)
-
         monkeypatch.setattr(
             "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
-            lambda **_kwargs: mock_agent,
+            lambda **_kwargs: _mock_deep_agent(mock_result),
         )
         monkeypatch.setattr(
             "karenina.adapters.langchain_deep_agents.agent.create_chat_model",
@@ -228,12 +226,9 @@ class TestDeepAgentsAgentAdapter:
             "is_last_step": False,
         }
 
-        mock_agent = MagicMock()
-        mock_agent.ainvoke = AsyncMock(return_value=mock_result)
-
         monkeypatch.setattr(
             "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
-            lambda **_kwargs: mock_agent,
+            lambda **_kwargs: _mock_deep_agent(mock_result),
         )
         monkeypatch.setattr(
             "karenina.adapters.langchain_deep_agents.agent.create_chat_model",
@@ -277,6 +272,8 @@ class TestDeepAgentsMCPToolsWiring:
     @pytest.mark.asyncio
     async def test_explicit_tools_passed_to_agent(self, deep_agents_model_config, monkeypatch):
         """Explicit tools should be forwarded to create_deep_agent."""
+        from langchain_core.messages import AIMessage
+
         from karenina.ports import AgentConfig, Message, Tool
         from karenina.ports.usage import UsageMetadata
 
@@ -284,14 +281,12 @@ class TestDeepAgentsMCPToolsWiring:
 
         def mock_create_deep_agent(**kwargs):
             captured_kwargs.update(kwargs)
-            mock_agent = AsyncMock()
-            mock_agent.ainvoke = AsyncMock(
-                return_value={
-                    "messages": [MagicMock(content="Done", type="ai")],
+            return _mock_deep_agent(
+                {
+                    "messages": [AIMessage(content="Done")],
                     "is_last_step": False,
                 }
             )
-            return mock_agent
 
         monkeypatch.setattr(
             "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
@@ -325,6 +320,8 @@ class TestDeepAgentsMCPToolsWiring:
     @pytest.mark.asyncio
     async def test_mcp_tools_loaded_and_combined(self, deep_agents_model_config, monkeypatch):
         """MCP servers should be converted to tools and combined with explicit tools."""
+        from langchain_core.messages import AIMessage
+
         from karenina.ports import AgentConfig, Message, Tool
         from karenina.ports.usage import UsageMetadata
 
@@ -334,14 +331,12 @@ class TestDeepAgentsMCPToolsWiring:
 
         def mock_create_deep_agent(**kwargs):
             captured_kwargs.update(kwargs)
-            mock_agent = AsyncMock()
-            mock_agent.ainvoke = AsyncMock(
-                return_value={
-                    "messages": [MagicMock(content="Done", type="ai")],
+            return _mock_deep_agent(
+                {
+                    "messages": [AIMessage(content="Done")],
                     "is_last_step": False,
                 }
             )
-            return mock_agent
 
         async def mock_convert_mcp(servers, exit_stack):
             return [fake_mcp_tool]
@@ -384,6 +379,8 @@ class TestDeepAgentsMCPToolsWiring:
     @pytest.mark.asyncio
     async def test_no_tools_kwarg_when_none_provided(self, deep_agents_model_config, monkeypatch):
         """When neither tools nor mcp_servers are given, tools kwarg should be absent."""
+        from langchain_core.messages import AIMessage
+
         from karenina.ports import AgentConfig, Message
         from karenina.ports.usage import UsageMetadata
 
@@ -391,14 +388,12 @@ class TestDeepAgentsMCPToolsWiring:
 
         def mock_create_deep_agent(**kwargs):
             captured_kwargs.update(kwargs)
-            mock_agent = AsyncMock()
-            mock_agent.ainvoke = AsyncMock(
-                return_value={
-                    "messages": [MagicMock(content="Done", type="ai")],
+            return _mock_deep_agent(
+                {
+                    "messages": [AIMessage(content="Done")],
                     "is_last_step": False,
                 }
             )
-            return mock_agent
 
         monkeypatch.setattr(
             "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",

--- a/tests/unit/adapters/langchain_deep_agents/test_agent.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_agent.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from karenina.adapters.langchain_deep_agents.agent import DeepAgentsAgentAdapter
+from karenina.benchmark.verification.executor import set_async_portal
 from karenina.ports import AgentConfig, AgentResult, Message
 
 
@@ -251,6 +252,74 @@ class TestDeepAgentsAgentAdapter:
         """aclose() should not raise."""
         adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
         await adapter.aclose()
+
+    def test_run_uses_fresh_loop_even_when_portal_is_active(self, deep_agents_model_config, monkeypatch):
+        """The sync agent-loop path must not run DeepAgents on the shared batch portal."""
+        from langchain_core.messages import AIMessage
+
+        class FailingPortal:
+            def call(self, *_args, **_kwargs):
+                raise AssertionError("DeepAgentsAgentAdapter.run() should not use the shared portal")
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+            lambda **_kwargs: _mock_deep_agent(
+                {
+                    "messages": [AIMessage(content="ok")],
+                    "is_last_step": False,
+                }
+            ),
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.create_chat_model",
+            lambda _config, **_kw: MagicMock(),
+        )
+
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        set_async_portal(FailingPortal())
+        try:
+            result = adapter.run(
+                messages=[Message.user("test")],
+                config=AgentConfig(max_turns=2),
+            )
+        finally:
+            set_async_portal(None)
+
+        assert result.final_response == "ok"
+
+    @pytest.mark.asyncio
+    async def test_arun_enables_model_call_retries(self, deep_agents_model_config, monkeypatch):
+        """Agent loops should pass retry budget to LangChain model calls."""
+        from langchain_core.messages import AIMessage
+
+        captured_model_kwargs: dict = {}
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+            lambda **_kwargs: _mock_deep_agent(
+                {
+                    "messages": [AIMessage(content="ok")],
+                    "is_last_step": False,
+                }
+            ),
+        )
+
+        def capture_chat_model(_config, **kwargs):
+            captured_model_kwargs.update(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.create_chat_model",
+            capture_chat_model,
+        )
+
+        adapter = DeepAgentsAgentAdapter(deep_agents_model_config)
+        await adapter.arun(
+            messages=[Message.user("test")],
+            config=AgentConfig(max_turns=2),
+        )
+
+        assert captured_model_kwargs["max_retries"] >= 1
 
 
 @pytest.mark.unit

--- a/tests/unit/adapters/langchain_deep_agents/test_agent.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_agent.py
@@ -160,6 +160,61 @@ class TestDeepAgentsBackendConfiguration:
         assert not hasattr(backend, "execute")
 
     @pytest.mark.asyncio
+    async def test_docker_backend_runs_preflight_before_agent(self, deep_agents_model_config, tmp_path, monkeypatch):
+        """Docker-backed command execution should fail fast when host Docker is unavailable."""
+        from langchain_core.messages import AIMessage
+
+        captured_preflight: dict[str, str | None] = {}
+        captured_kwargs: dict = {}
+
+        def capture_preflight(*, image, **_kwargs):
+            captured_preflight["image"] = image
+
+        def capture_create(**kwargs):
+            captured_kwargs.update(kwargs)
+            return _mock_deep_agent(
+                {
+                    "messages": [AIMessage(content="ok")],
+                    "is_last_step": False,
+                }
+            )
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.docker_backend.preflight_docker_runtime",
+            capture_preflight,
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+            capture_create,
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.create_chat_model",
+            lambda _config, **_kw: MagicMock(),
+        )
+
+        workspace = tmp_path / "my_workspace"
+        workspace.mkdir()
+        docker_config = deep_agents_model_config.model_copy(
+            update={
+                "extra_kwargs": {
+                    "agent_runtime": {
+                        "backend": "docker",
+                        "docker_image": "karenina-bixbench:latest",
+                    }
+                }
+            }
+        )
+
+        adapter = DeepAgentsAgentAdapter(docker_config)
+        await adapter.arun(
+            messages=[Message.user("analyze data")],
+            config=AgentConfig(max_turns=2, workspace_path=workspace),
+        )
+
+        assert captured_preflight == {"image": "karenina-bixbench:latest"}
+        assert captured_kwargs["backend"].id.startswith("docker-")
+
+    @pytest.mark.asyncio
     async def test_backend_is_never_state_backend(self, deep_agents_model_config, monkeypatch):
         """StateBackend must never be used; it makes the agent blind to real files."""
         from deepagents.backends import StateBackend

--- a/tests/unit/adapters/langchain_deep_agents/test_agent.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_agent.py
@@ -109,6 +109,57 @@ class TestDeepAgentsBackendConfiguration:
         assert backend.cwd == workspace
 
     @pytest.mark.asyncio
+    async def test_read_only_access_mode_wraps_backend(self, deep_agents_model_config, tmp_path, monkeypatch):
+        """Read-only access mode should keep reads but block writes and execution."""
+        from deepagents.backends import FilesystemBackend
+        from langchain_core.messages import AIMessage
+
+        from karenina.adapters.langchain_deep_agents.read_only_backend import ReadOnlyBackend
+
+        captured_kwargs: dict = {}
+
+        def capture_create(**kwargs):
+            captured_kwargs.update(kwargs)
+            return _mock_deep_agent(
+                {
+                    "messages": [AIMessage(content="ok")],
+                    "is_last_step": False,
+                }
+            )
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent._create_deep_agent",
+            capture_create,
+        )
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.agent.create_chat_model",
+            lambda _config, **_kw: MagicMock(),
+        )
+
+        workspace = tmp_path / "my_workspace"
+        workspace.mkdir()
+        (workspace / "results.txt").write_text("answer: 42")
+        read_only_config = deep_agents_model_config.model_copy(
+            update={"extra_kwargs": {"agent_runtime": {"access_mode": "read_only"}}}
+        )
+
+        adapter = DeepAgentsAgentAdapter(read_only_config)
+        await adapter.arun(
+            messages=[Message.user("inspect results")],
+            config=AgentConfig(max_turns=2, workspace_path=workspace),
+        )
+
+        backend = captured_kwargs["backend"]
+        assert isinstance(backend, ReadOnlyBackend)
+        assert isinstance(backend.delegate, FilesystemBackend)
+        assert backend.read("/results.txt") == "     1\tanswer: 42"
+        assert backend.write("/new.txt", "content").error is not None
+        assert backend.edit("/results.txt", "42", "43").error is not None
+        assert (await backend.awrite("/async-new.txt", "content")).error is not None
+        assert (await backend.aedit("/results.txt", "42", "43")).error is not None
+        assert not hasattr(backend, "execute")
+
+    @pytest.mark.asyncio
     async def test_backend_is_never_state_backend(self, deep_agents_model_config, monkeypatch):
         """StateBackend must never be used; it makes the agent blind to real files."""
         from deepagents.backends import StateBackend

--- a/tests/unit/adapters/langchain_deep_agents/test_llm.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_llm.py
@@ -8,6 +8,7 @@ import pytest
 
 from karenina.adapters.langchain_deep_agents.llm import DeepAgentsLLMAdapter
 from karenina.ports import LLMResponse, Message
+from karenina.schemas.config import ModelConfig
 
 
 @pytest.mark.unit
@@ -118,3 +119,61 @@ class TestDeepAgentsSDKRetrySuppression:
         create_chat_model(deep_agents_model_config, max_retries=3)
 
         assert captured_kwargs.get("max_retries") == 3
+
+
+@pytest.mark.unit
+class TestDeepAgentsEndpointBaseUrlMode:
+    def test_create_chat_model_normalizes_endpoint_to_v1_by_default(self, monkeypatch):
+        captured_kwargs: dict = {}
+
+        def _capture_init(*, model, model_provider, **kwargs):
+            captured_kwargs.update(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.initialization.init_chat_model",
+            _capture_init,
+        )
+
+        from karenina.adapters.langchain_deep_agents.initialization import create_chat_model
+
+        create_chat_model(
+            ModelConfig(
+                id="qwen",
+                model_name="qwen",
+                model_provider="openai",
+                interface="langchain_deep_agents",
+                endpoint_base_url="http://localhost:8000",
+                endpoint_api_key="EMPTY",
+            )
+        )
+
+        assert captured_kwargs["base_url"] == "http://localhost:8000/v1"
+
+    def test_create_chat_model_can_use_raw_endpoint_base_url(self, monkeypatch):
+        captured_kwargs: dict = {}
+
+        def _capture_init(*, model, model_provider, **kwargs):
+            captured_kwargs.update(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.initialization.init_chat_model",
+            _capture_init,
+        )
+
+        from karenina.adapters.langchain_deep_agents.initialization import create_chat_model
+
+        create_chat_model(
+            ModelConfig(
+                id="glm-5.1",
+                model_name="glm-5.1",
+                model_provider="openai",
+                interface="langchain_deep_agents",
+                endpoint_base_url="https://api.z.ai/api/coding/paas/v4",
+                endpoint_api_key="EMPTY",
+                extra_kwargs={"endpoint_base_url_mode": "raw"},
+            )
+        )
+
+        assert captured_kwargs["base_url"] == "https://api.z.ai/api/coding/paas/v4"

--- a/tests/unit/adapters/langchain_deep_agents/test_llm.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_llm.py
@@ -99,3 +99,22 @@ class TestDeepAgentsSDKRetrySuppression:
         create_chat_model(deep_agents_model_config)
 
         assert captured_kwargs.get("max_retries") == 0
+
+    def test_create_chat_model_allows_explicit_max_retries_override(self, deep_agents_model_config, monkeypatch):
+        """Agent loops can opt into SDK model-call retries without changing LLM/parser defaults."""
+        captured_kwargs: dict = {}
+
+        def _capture_init(*, model, model_provider, **kwargs):
+            captured_kwargs.update(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.initialization.init_chat_model",
+            _capture_init,
+        )
+
+        from karenina.adapters.langchain_deep_agents.initialization import create_chat_model
+
+        create_chat_model(deep_agents_model_config, max_retries=3)
+
+        assert captured_kwargs.get("max_retries") == 3

--- a/tests/unit/adapters/langchain_deep_agents/test_message_converter_usage.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_message_converter_usage.py
@@ -1,0 +1,127 @@
+"""Tests that DeepAgentsMessageConverter.from_provider populates usage_metadata.
+
+Fix E (extension): the production trace path in
+langchain_deep_agents/agent.py builds ``trace_messages`` via
+``self._converter.from_provider(lc_messages)`` rather than the direct
+``deep_agents_messages_to_trace_messages`` helper. The converter must
+attach per-call usage to each assistant ``Message`` so that
+``Message.to_dict()`` emits it into ``template.trace_messages[*]``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.adapters.langchain_deep_agents.messages import DeepAgentsMessageConverter
+from karenina.ports import Role
+
+
+@pytest.mark.unit
+class TestDeepAgentsConverterUsageMetadata:
+    def test_modern_usage_metadata_propagates(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="Hello world",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            },
+        )
+
+        converter = DeepAgentsMessageConverter()
+        [out] = converter.from_provider([msg])
+
+        assert out.role == Role.ASSISTANT
+        assert out.usage_metadata == {"input_tokens": 100, "output_tokens": 50}
+
+    def test_to_dict_emits_usage_metadata_after_conversion(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="Hello",
+            usage_metadata={"input_tokens": 7, "output_tokens": 3, "total_tokens": 10},
+        )
+
+        converter = DeepAgentsMessageConverter()
+        [out] = converter.from_provider([msg])
+
+        assert out.to_dict()["usage_metadata"] == {
+            "input_tokens": 7,
+            "output_tokens": 3,
+        }
+
+    def test_cache_fields_propagate_when_reported(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="cached",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+                "cache_read_input_tokens": 800,
+                "cache_creation_input_tokens": 50,
+            },
+        )
+
+        converter = DeepAgentsMessageConverter()
+        [out] = converter.from_provider([msg])
+
+        assert out.usage_metadata == {
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_read_input_tokens": 800,
+            "cache_creation_input_tokens": 50,
+        }
+
+    def test_response_metadata_token_usage_fallback(self) -> None:
+        """Older LangChain adapters use response_metadata.token_usage with
+        prompt_tokens / completion_tokens — converter must rename keys.
+        """
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="Legacy adapter response",
+            response_metadata={
+                "token_usage": {
+                    "prompt_tokens": 200,
+                    "completion_tokens": 75,
+                    "total_tokens": 275,
+                }
+            },
+        )
+
+        converter = DeepAgentsMessageConverter()
+        [out] = converter.from_provider([msg])
+
+        assert out.usage_metadata == {"input_tokens": 200, "output_tokens": 75}
+
+    def test_no_usage_yields_none(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(content="no usage")
+
+        converter = DeepAgentsMessageConverter()
+        [out] = converter.from_provider([msg])
+
+        assert out.usage_metadata is None
+        assert "usage_metadata" not in out.to_dict()
+
+    def test_modern_usage_metadata_wins_over_response_metadata(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="both",
+            usage_metadata={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+            response_metadata={
+                "token_usage": {"prompt_tokens": 999, "completion_tokens": 888}
+            },
+        )
+
+        converter = DeepAgentsMessageConverter()
+        [out] = converter.from_provider([msg])
+
+        # The modern usage_metadata path is preferred per _extract_ai_usage_metadata.
+        assert out.usage_metadata == {"input_tokens": 10, "output_tokens": 5}

--- a/tests/unit/adapters/langchain_deep_agents/test_messages.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_messages.py
@@ -72,3 +72,66 @@ class TestDeepAgentsMessageConverter:
         result = self.converter.from_provider(lc_messages)
         assert len(result) == 1
         assert result[0].role.value == "assistant"
+
+    def test_from_provider_ai_with_reasoning_content_emits_thinking_block(self):
+        """Parity with CSDK: reasoning surfaces as a ``ThinkingContent`` block
+        in the unified Message content list, not just in the raw_trace string."""
+        from langchain_core.messages import AIMessage
+
+        from karenina.ports import TextContent, ThinkingContent, ToolUseContent
+
+        lc_messages = [
+            AIMessage(
+                content="The answer is 42.",
+                additional_kwargs={"reasoning_content": "Computed via 2+40."},
+                tool_calls=[{"name": "submit", "args": {"a": 1}, "id": "call_x"}],
+            )
+        ]
+        result = self.converter.from_provider(lc_messages)
+        assert len(result) == 1
+        msg = result[0]
+        # Block order matches CSDK: thinking, text, tool_use.
+        kinds = [type(b).__name__ for b in msg.content]
+        assert kinds == ["ThinkingContent", "TextContent", "ToolUseContent"]
+        assert isinstance(msg.content[0], ThinkingContent)
+        assert msg.content[0].thinking == "Computed via 2+40."
+        assert isinstance(msg.content[1], TextContent)
+        assert isinstance(msg.content[2], ToolUseContent)
+
+    def test_from_provider_ai_anthropic_style_thinking_block(self):
+        """Content-list ``type='thinking'`` should also produce a ThinkingContent."""
+        from langchain_core.messages import AIMessage
+
+        from karenina.ports import ThinkingContent
+
+        lc_messages = [
+            AIMessage(
+                content=[
+                    {"type": "thinking", "thinking": "Reasoning step.", "signature": "sig"},
+                    {"type": "text", "text": "Answer."},
+                ],
+            )
+        ]
+        result = self.converter.from_provider(lc_messages)
+        assert len(result) == 1
+        msg = result[0]
+        assert isinstance(msg.content[0], ThinkingContent)
+        assert msg.content[0].thinking == "Reasoning step."
+        assert msg.content[0].signature == "sig"
+
+    def test_from_provider_ai_blank_reasoning_is_ignored(self):
+        """Whitespace-only reasoning must NOT produce an empty ThinkingContent."""
+        from langchain_core.messages import AIMessage
+
+        from karenina.ports import ThinkingContent
+
+        lc_messages = [
+            AIMessage(
+                content="Answer.",
+                additional_kwargs={"reasoning_content": "   "},
+            )
+        ]
+        result = self.converter.from_provider(lc_messages)
+        assert len(result) == 1
+        kinds = [type(b).__name__ for b in result[0].content]
+        assert "ThinkingContent" not in kinds

--- a/tests/unit/adapters/langchain_deep_agents/test_trace.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_trace.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import pytest
 
-from karenina.adapters.langchain_deep_agents.trace import deep_agents_messages_to_raw_trace
+from karenina.adapters.langchain_deep_agents.trace import (
+    deep_agents_messages_to_raw_trace,
+    deep_agents_messages_to_trace_messages,
+)
 
 
 @pytest.mark.unit
@@ -43,3 +46,104 @@ class TestDeepAgentsTraceExtraction:
         messages = [AIMessage(content="First"), AIMessage(content="Second")]
         trace = deep_agents_messages_to_raw_trace(messages)
         assert trace.count("--- AI Message ---") == 2
+
+
+@pytest.mark.unit
+class TestDeepAgentsThinkingExtraction:
+    """Parity with CSDK: thinking / reasoning content must surface in the
+    trace when the underlying provider attaches it. vLLM's OpenAI-compatible
+    endpoint emits delta.reasoning_content for thinking models (qwen3,
+    deepseek-r1, etc.), which recent langchain_openai surfaces under
+    ``AIMessage.additional_kwargs["reasoning_content"]``."""
+
+    def test_reasoning_content_renders_thinking_section(self):
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="The answer is 42.",
+            additional_kwargs={"reasoning_content": "Let me think... 2+40=42."},
+        )
+        trace = deep_agents_messages_to_raw_trace([msg])
+        assert "--- Thinking ---" in trace
+        assert "Let me think... 2+40=42." in trace
+        # Thinking appears before the AI Message text.
+        assert trace.index("--- Thinking ---") < trace.index("--- AI Message ---")
+
+    def test_alternate_reasoning_key_supported(self):
+        """Some providers/LangChain wrappers use the bare key ``reasoning``."""
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="Done.",
+            additional_kwargs={"reasoning": "Chain of thought goes here."},
+        )
+        trace = deep_agents_messages_to_raw_trace([msg])
+        assert "--- Thinking ---" in trace
+        assert "Chain of thought goes here." in trace
+
+    def test_anthropic_style_thinking_block_in_content_list(self):
+        """When the model is invoked through an Anthropic wrapper, thinking
+        arrives as a content block with ``type == 'thinking'``."""
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content=[
+                {"type": "thinking", "thinking": "Reasoning step one."},
+                {"type": "text", "text": "Final answer."},
+            ],
+        )
+        trace = deep_agents_messages_to_raw_trace([msg])
+        assert "--- Thinking ---" in trace
+        assert "Reasoning step one." in trace
+        assert "Final answer." in trace
+
+    def test_thinking_only_message_still_renders(self):
+        """A turn with only reasoning (no text, no tool calls) — e.g. a
+        deliberative turn before a tool call comes in a separate message —
+        must still produce a Thinking section in the trace."""
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="",
+            additional_kwargs={"reasoning_content": "Pondering options."},
+        )
+        trace = deep_agents_messages_to_raw_trace([msg])
+        assert "--- Thinking ---" in trace
+        assert "Pondering options." in trace
+
+    def test_no_reasoning_means_no_thinking_section(self):
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(content="Just an answer.")
+        trace = deep_agents_messages_to_raw_trace([msg])
+        assert "--- Thinking ---" not in trace
+
+    def test_blank_reasoning_string_is_ignored(self):
+        """Whitespace-only reasoning_content (some endpoints emit empty
+        strings on non-thinking turns) must NOT produce an empty section."""
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="Reply.",
+            additional_kwargs={"reasoning_content": "   "},
+        )
+        trace = deep_agents_messages_to_raw_trace([msg])
+        assert "--- Thinking ---" not in trace
+
+    def test_structured_trace_messages_attach_thinking_metadata(self):
+        """Parity with CSDK structured trace: thinking surfaces under the
+        ``thinking`` key on the assistant entry, alongside content/tool_calls."""
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="The answer is 42.",
+            additional_kwargs={"reasoning_content": "Computed via 2+40."},
+            tool_calls=[{"name": "submit", "args": {"a": 1}, "id": "call_x"}],
+        )
+        trace_msgs = deep_agents_messages_to_trace_messages([msg])
+        assert len(trace_msgs) == 1
+        entry = trace_msgs[0]
+        assert entry["role"] == "assistant"
+        assert entry["content"] == "The answer is 42."
+        assert entry["thinking"] == {"thinking": "Computed via 2+40."}
+        assert entry["tool_calls"][0]["name"] == "submit"

--- a/tests/unit/adapters/langchain_deep_agents/test_trace.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_trace.py
@@ -20,7 +20,10 @@ class TestDeepAgentsTraceExtraction:
         assert "--- AI Message ---" in trace
         assert "Hello world" in trace
 
-    def test_tool_call_produces_tool_delimiter(self):
+    def test_tool_call_renders_inline_in_ai_message(self):
+        """DA now uses the canonical format shared with langchain / csdk /
+        manual: tool calls live inside the same ``--- AI Message ---`` as
+        the assistant text, and tool results use ``--- Tool Message (call_id: <id>) ---``."""
         from langchain_core.messages import AIMessage, ToolMessage
 
         messages = [
@@ -32,9 +35,14 @@ class TestDeepAgentsTraceExtraction:
         ]
         trace = deep_agents_messages_to_raw_trace(messages)
         assert "--- AI Message ---" in trace
-        assert "--- Tool Call ---" in trace
-        assert "--- Tool Result ---" in trace
-        assert "search" in trace
+        assert "Tool Calls:" in trace
+        assert "search (call_call_1)" in trace
+        assert "Call ID: call_1" in trace
+        assert "--- Tool Message (call_id: call_1) ---" in trace
+        assert "search result" in trace
+        # Old DA-only delimiters must NOT appear.
+        assert "--- Tool Call ---" not in trace
+        assert "--- Tool Result ---" not in trace
 
     def test_empty_messages_returns_empty_string(self):
         trace = deep_agents_messages_to_raw_trace([])

--- a/tests/unit/adapters/langchain_deep_agents/test_trace_includes_usage.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_trace_includes_usage.py
@@ -1,0 +1,170 @@
+"""Tests that deep_agents_messages_to_trace_messages preserves per-call usage.
+
+Fix E (karenina infrastructure plan): the DA structured trace converter must
+propagate the per-message ``usage_metadata`` that LangChain AIMessages carry
+(or fall back to ``response_metadata.token_usage`` for adapters that haven't
+adopted the modern usage_metadata standard) so that per-turn token /
+cache accounting survives into ``template.trace_messages``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _to_trace(messages):
+    from karenina.adapters.langchain_deep_agents.trace import (
+        deep_agents_messages_to_trace_messages,
+    )
+
+    return deep_agents_messages_to_trace_messages(messages)
+
+
+@pytest.mark.unit
+class TestTraceUsageMetadataDA:
+    def test_ai_message_with_modern_usage_metadata_propagates(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="Hello world",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            },
+        )
+
+        trace = _to_trace([msg])
+        assert len(trace) == 1
+        assert trace[0]["role"] == "assistant"
+        assert trace[0]["content"] == "Hello world"
+        assert trace[0]["usage_metadata"] == {
+            "input_tokens": 100,
+            "output_tokens": 50,
+        }
+
+    def test_ai_message_with_response_metadata_token_usage_is_renamed(self) -> None:
+        """Older LangChain adapters expose token counts via
+        ``response_metadata.token_usage`` using OpenAI-style keys
+        (prompt_tokens / completion_tokens). The converter must rename
+        those keys to input_tokens / output_tokens so downstream consumers
+        see a uniform shape.
+        """
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="From an older provider",
+            response_metadata={
+                "token_usage": {
+                    "prompt_tokens": 80,
+                    "completion_tokens": 20,
+                }
+            },
+        )
+
+        trace = _to_trace([msg])
+        assert trace[0]["usage_metadata"] == {
+            "input_tokens": 80,
+            "output_tokens": 20,
+        }
+
+    def test_ai_message_usage_metadata_preferred_over_response_metadata(self) -> None:
+        """When both are present, usage_metadata wins (it's the modern source)."""
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="x",
+            usage_metadata={
+                "input_tokens": 5,
+                "output_tokens": 7,
+                "total_tokens": 12,
+            },
+            response_metadata={
+                "token_usage": {"prompt_tokens": 999, "completion_tokens": 999}
+            },
+        )
+
+        trace = _to_trace([msg])
+        assert trace[0]["usage_metadata"] == {
+            "input_tokens": 5,
+            "output_tokens": 7,
+        }
+
+    def test_ai_message_without_any_usage_omits_usage_metadata(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(content="no usage info")
+        trace = _to_trace([msg])
+
+        assert len(trace) == 1
+        assert "usage_metadata" not in trace[0]
+
+    def test_cache_fields_in_usage_metadata_propagate(self) -> None:
+        """If the prompt-cache middleware exposes Anthropic-shaped cache
+        fields via AIMessage.usage_metadata, they survive into the trace.
+        """
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="cached",
+            usage_metadata={
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "total_tokens": 15,
+                "cache_read_input_tokens": 200,
+                "cache_creation_input_tokens": 25,
+            },
+        )
+
+        trace = _to_trace([msg])
+        assert trace[0]["usage_metadata"] == {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cache_read_input_tokens": 200,
+            "cache_creation_input_tokens": 25,
+        }
+
+    def test_tool_call_message_emits_assistant_with_tool_calls_and_usage(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(
+            content="Searching",
+            tool_calls=[{"id": "call_1", "name": "search", "args": {"q": "BCL2"}}],
+            usage_metadata={
+                "input_tokens": 30,
+                "output_tokens": 6,
+                "total_tokens": 36,
+            },
+        )
+
+        trace = _to_trace([msg])
+        assert trace[0]["role"] == "assistant"
+        assert trace[0]["tool_calls"] == [
+            {"id": "call_1", "name": "search", "input": {"q": "BCL2"}}
+        ]
+        assert trace[0]["usage_metadata"] == {"input_tokens": 30, "output_tokens": 6}
+
+    def test_tool_message_does_not_get_usage_metadata(self) -> None:
+        from langchain_core.messages import AIMessage, ToolMessage
+
+        messages = [
+            AIMessage(
+                content="step",
+                tool_calls=[{"id": "c1", "name": "s", "args": {}}],
+                usage_metadata={
+                    "input_tokens": 1,
+                    "output_tokens": 1,
+                    "total_tokens": 2,
+                },
+            ),
+            ToolMessage(content="result", tool_call_id="c1"),
+        ]
+
+        trace = _to_trace(messages)
+        # Find tool entry
+        tool_entries = [t for t in trace if t["role"] == "tool"]
+        assert len(tool_entries) == 1
+        assert "usage_metadata" not in tool_entries[0]
+
+    def test_empty_messages_returns_empty_list(self) -> None:
+        assert _to_trace([]) == []

--- a/tests/unit/adapters/test_agent_runtime.py
+++ b/tests/unit/adapters/test_agent_runtime.py
@@ -1,0 +1,64 @@
+"""Tests for shared agent runtime helpers."""
+
+from __future__ import annotations
+
+from karenina.adapters.agent_runtime import (
+    AgentRuntimeProfile,
+    map_path_for_prompt,
+    register_agent_runtime_profile,
+    workspace_path_for_prompt,
+)
+from karenina.ports.capabilities import PortCapabilities
+from karenina.schemas.config import ModelConfig
+
+
+def test_deepagents_docker_workspace_maps_to_container_path(tmp_path):
+    config = ModelConfig(
+        id="deep",
+        model_name="claude-sonnet-4-20250514",
+        interface="langchain_deep_agents",
+        extra_kwargs={"agent_runtime": {"backend": "docker"}},
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    trace_path = workspace / "traces" / "trace.md"
+
+    assert workspace_path_for_prompt(config, workspace) == "/workspace"
+    assert map_path_for_prompt(config, trace_path, workspace) == "/workspace/traces/trace.md"
+
+
+def test_claude_sdk_workspace_uses_host_path(tmp_path):
+    config = ModelConfig(
+        id="claude",
+        model_name="claude-sonnet-4-20250514",
+        interface="claude_agent_sdk",
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    trace_path = workspace / "traces" / "trace.md"
+
+    assert workspace_path_for_prompt(config, workspace) == str(workspace)
+    assert map_path_for_prompt(config, trace_path, workspace) == str(trace_path)
+
+
+def test_runtime_profile_registry_allows_extension_adapters():
+    profile = AgentRuntimeProfile(
+        capabilities=lambda _config: PortCapabilities(
+            supports_system_prompt=True,
+            supports_file_tools=True,
+            supports_code_execution=False,
+        ),
+        workspace_path_for_prompt=lambda _config, _workspace: "custom://workspace",
+        map_path_for_prompt=lambda _config, _path, _workspace: "custom://trace",
+    )
+    register_agent_runtime_profile("test_runtime_profile_adapter", profile, force=True)
+    config = ModelConfig.model_construct(
+        id="custom",
+        model_name="custom-model",
+        interface="test_runtime_profile_adapter",
+    )
+
+    assert workspace_path_for_prompt(config, None) == "custom://workspace"
+    assert map_path_for_prompt(config, None, None) == "custom://trace"

--- a/tests/unit/adapters/test_agent_runtime.py
+++ b/tests/unit/adapters/test_agent_runtime.py
@@ -233,6 +233,48 @@ def test_singularity_command_isolates_host_filesystem(tmp_path):
     assert command[image_idx + 1 :] == ["python", "-c", "import sys; print(sys.path)"]
 
 
+def test_singularity_sets_home_via_flag_not_env(tmp_path):
+    """Singularity refuses --env HOME=... with a noisy warning; HOME must
+    be set via --home instead. The caller's env dict can still carry HOME
+    (Docker uses it), and we must honour that value when building --home."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    image = tmp_path / "image.sif"
+    image.write_text("")
+
+    command = build_container_command(
+        config=ContainerRuntimeConfig(runtime="singularity", image=str(image)),
+        host_workspace=workspace,
+        argv=["/bin/true"],
+        env={"HOME": "/tmp", "UV_LINK_MODE": "copy"},
+    )
+
+    env_indices = [i for i, arg in enumerate(command) if arg == "--env"]
+    env_values = [command[i + 1] for i in env_indices]
+    assert not any(value.startswith("HOME=") for value in env_values), (
+        "HOME must not be passed via --env: Singularity rejects it with a warning"
+    )
+
+    assert "--home" in command, "missing --home: HOME would fall back to an unmounted host path"
+    assert command[command.index("--home") + 1] == "/tmp"
+
+
+def test_singularity_home_defaults_to_tmp_when_env_omits_it(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    image = tmp_path / "image.sif"
+    image.write_text("")
+
+    command = build_container_command(
+        config=ContainerRuntimeConfig(runtime="singularity", image=str(image)),
+        host_workspace=workspace,
+        argv=["/bin/true"],
+    )
+
+    assert "--home" in command
+    assert command[command.index("--home") + 1] == "/tmp"
+
+
 def test_apptainer_command_inherits_isolation_flags(tmp_path):
     """The same isolation flags apply when the runtime is apptainer."""
     workspace = tmp_path / "workspace"

--- a/tests/unit/adapters/test_agent_runtime.py
+++ b/tests/unit/adapters/test_agent_runtime.py
@@ -8,8 +8,13 @@ import pytest
 
 from karenina.adapters.agent_runtime import (
     AgentRuntimeProfile,
+    ContainerRuntimeConfig,
+    build_container_command,
     get_agent_runtime_capabilities,
+    get_claude_sdk_backend,
+    get_container_runtime_config,
     map_path_for_prompt,
+    preflight_container_runtime,
     preflight_docker_runtime,
     register_agent_runtime_profile,
     workspace_path_for_prompt,
@@ -109,6 +114,104 @@ def test_claude_sdk_docker_capabilities_report_sandboxed_execution():
     assert capabilities.supports_file_tools is True
     assert capabilities.supports_code_execution is True
     assert capabilities.uses_sandboxed_execution is True
+
+
+def test_legacy_docker_backend_normalizes_to_container_runtime():
+    config = ModelConfig(
+        id="claude",
+        model_name="claude-sonnet-4-20250514",
+        interface="claude_agent_sdk",
+        extra_kwargs={
+            "agent_runtime": {
+                "backend": "docker",
+                "docker_image": "karenina-bixbench-claude:latest",
+            }
+        },
+    )
+
+    assert get_claude_sdk_backend(config) == "container"
+    container_config = get_container_runtime_config(config)
+    assert container_config.runtime == "docker"
+    assert container_config.image == "karenina-bixbench-claude:latest"
+
+
+def test_singularity_container_workspace_maps_to_container_path(tmp_path):
+    config = ModelConfig(
+        id="claude",
+        model_name="claude-sonnet-4-20250514",
+        interface="claude_agent_sdk",
+        extra_kwargs={
+            "agent_runtime": {
+                "backend": "container",
+                "container_runtime": "singularity",
+                "container_image": str(tmp_path / "image.sif"),
+            }
+        },
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    trace_path = workspace / "traces" / "trace.md"
+
+    assert workspace_path_for_prompt(config, workspace) == "/workspace"
+    assert map_path_for_prompt(config, trace_path, workspace) == "/workspace/traces/trace.md"
+
+
+def test_singularity_preflight_requires_existing_sif(monkeypatch, tmp_path):
+    monkeypatch.setattr("karenina.adapters.agent_runtime.shutil.which", lambda _name: "/usr/bin/singularity")
+
+    with pytest.raises(AdapterUnavailableError) as exc_info:
+        preflight_container_runtime(
+            ContainerRuntimeConfig(
+                runtime="singularity",
+                image=str(tmp_path / "missing.sif"),
+            )
+        )
+
+    assert exc_info.value.reason == "container_image_unavailable"
+
+
+def test_singularity_command_binds_workspace_and_sets_env(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    image = tmp_path / "image.sif"
+    image.write_text("")
+
+    command = build_container_command(
+        config=ContainerRuntimeConfig(runtime="singularity", image=str(image)),
+        host_workspace=workspace,
+        argv=["/bin/sh", "-lc", "pwd"],
+        env={"UV_LINK_MODE": "copy"},
+    )
+
+    assert command[:2] == ["singularity", "exec"]
+    assert f"{workspace.resolve()}:/workspace:rw" in command
+    assert "--pwd" in command
+    assert command[command.index("--pwd") + 1] == "/workspace"
+    assert "--env" in command
+    assert "UV_LINK_MODE=copy" in command
+    assert str(image) in command
+
+
+def test_singularity_rejects_docker_only_add_hosts():
+    config = ModelConfig(
+        id="claude",
+        model_name="claude-sonnet-4-20250514",
+        interface="claude_agent_sdk",
+        extra_kwargs={
+            "agent_runtime": {
+                "backend": "container",
+                "container_runtime": "singularity",
+                "container_image": "/tmp/image.sif",
+                "container_add_hosts": ["internal:10.0.0.1"],
+            }
+        },
+    )
+
+    with pytest.raises(AdapterUnavailableError) as exc_info:
+        get_container_runtime_config(config)
+
+    assert exc_info.value.reason == "unsupported_container_add_hosts"
 
 
 def test_runtime_profile_registry_allows_extension_adapters():

--- a/tests/unit/adapters/test_agent_runtime.py
+++ b/tests/unit/adapters/test_agent_runtime.py
@@ -193,6 +193,85 @@ def test_singularity_command_binds_workspace_and_sets_env(tmp_path):
     assert str(image) in command
 
 
+def test_singularity_command_isolates_host_filesystem(tmp_path):
+    """The constructed command must close the host-home leak path.
+
+    Without --no-home + --no-mount bind-paths, Singularity's site config can
+    auto-bind /homes, /hps/software, /nfs/* into the sandbox, exposing the
+    host user's ~/.local/.../site-packages to the model. PYTHONNOUSERSITE
+    is a defense-in-depth safeguard if a future caller adds a bind that
+    still exposes a user-site directory.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    image = tmp_path / "image.sif"
+    image.write_text("")
+
+    command = build_container_command(
+        config=ContainerRuntimeConfig(runtime="singularity", image=str(image)),
+        host_workspace=workspace,
+        argv=["python", "-c", "import sys; print(sys.path)"],
+    )
+
+    assert "--no-home" in command, "missing --no-home: host $HOME would auto-mount"
+
+    no_mount_idx = command.index("--no-mount")
+    assert command[no_mount_idx + 1] == "bind-paths", (
+        "--no-mount must be followed by 'bind-paths' to drop system default binds"
+    )
+
+    env_indices = [i for i, arg in enumerate(command) if arg == "--env"]
+    env_values = {command[i + 1] for i in env_indices}
+    assert "PYTHONNOUSERSITE=1" in env_values, (
+        "missing PYTHONNOUSERSITE=1: user-site directories would still be picked up by Python"
+    )
+
+    # Image and argv still come after the isolation flags.
+    assert str(image) in command
+    image_idx = command.index(str(image))
+    assert image_idx > no_mount_idx
+    assert command[image_idx + 1 :] == ["python", "-c", "import sys; print(sys.path)"]
+
+
+def test_apptainer_command_inherits_isolation_flags(tmp_path):
+    """The same isolation flags apply when the runtime is apptainer."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    image = tmp_path / "image.sif"
+    image.write_text("")
+
+    command = build_container_command(
+        config=ContainerRuntimeConfig(runtime="apptainer", image=str(image)),
+        host_workspace=workspace,
+        argv=["/bin/true"],
+    )
+
+    assert command[0] == "apptainer"
+    assert "--no-home" in command
+    assert "--no-mount" in command
+    assert command[command.index("--no-mount") + 1] == "bind-paths"
+    env_values = {command[i + 1] for i, arg in enumerate(command) if arg == "--env"}
+    assert "PYTHONNOUSERSITE=1" in env_values
+
+
+def test_docker_command_does_not_carry_singularity_isolation_flags(tmp_path):
+    """Docker does not auto-mount $HOME, so the singularity-specific flags
+    must not appear in the docker command (they would be invalid flags)."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    command = build_container_command(
+        config=ContainerRuntimeConfig(runtime="docker", image="example:latest"),
+        host_workspace=workspace,
+        argv=["/bin/true"],
+    )
+
+    assert command[0] == "docker"
+    assert "--no-home" not in command
+    assert "--no-mount" not in command
+    assert "bind-paths" not in command
+
+
 def test_singularity_rejects_docker_only_add_hosts():
     config = ModelConfig(
         id="claude",

--- a/tests/unit/adapters/test_agent_runtime.py
+++ b/tests/unit/adapters/test_agent_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from karenina.adapters.agent_runtime import (
     AgentRuntimeProfile,
+    get_agent_runtime_capabilities,
     map_path_for_prompt,
     register_agent_runtime_profile,
     workspace_path_for_prompt,
@@ -41,6 +42,67 @@ def test_claude_sdk_workspace_uses_host_path(tmp_path):
 
     assert workspace_path_for_prompt(config, workspace) == str(workspace)
     assert map_path_for_prompt(config, trace_path, workspace) == str(trace_path)
+
+
+def test_claude_sdk_docker_workspace_maps_to_container_path(tmp_path):
+    config = ModelConfig(
+        id="claude",
+        model_name="claude-sonnet-4-20250514",
+        interface="claude_agent_sdk",
+        extra_kwargs={"agent_runtime": {"backend": "docker", "docker_image": "karenina-bixbench-claude:latest"}},
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    trace_path = workspace / "traces" / "trace.md"
+
+    assert workspace_path_for_prompt(config, workspace) == "/workspace"
+    assert map_path_for_prompt(config, trace_path, workspace) == "/workspace/traces/trace.md"
+
+
+def test_deepagents_read_only_access_mode_disables_code_execution_capability():
+    config = ModelConfig(
+        id="deep",
+        model_name="claude-sonnet-4-20250514",
+        interface="langchain_deep_agents",
+        extra_kwargs={"agent_runtime": {"backend": "docker", "access_mode": "read_only"}},
+    )
+
+    capabilities = get_agent_runtime_capabilities(config)
+
+    assert capabilities.supports_file_tools is True
+    assert capabilities.supports_code_execution is False
+    assert capabilities.uses_sandboxed_execution is True
+
+
+def test_claude_sdk_read_only_access_mode_disables_code_execution_capability():
+    config = ModelConfig(
+        id="claude",
+        model_name="claude-sonnet-4-20250514",
+        interface="claude_agent_sdk",
+        extra_kwargs={"agent_runtime": {"access_mode": "read_only"}},
+    )
+
+    capabilities = get_agent_runtime_capabilities(config)
+
+    assert capabilities.supports_file_tools is True
+    assert capabilities.supports_code_execution is False
+    assert capabilities.uses_sandboxed_execution is True
+
+
+def test_claude_sdk_docker_capabilities_report_sandboxed_execution():
+    config = ModelConfig(
+        id="claude",
+        model_name="claude-sonnet-4-20250514",
+        interface="claude_agent_sdk",
+        extra_kwargs={"agent_runtime": {"backend": "docker", "docker_image": "karenina-bixbench-claude:latest"}},
+    )
+
+    capabilities = get_agent_runtime_capabilities(config)
+
+    assert capabilities.supports_file_tools is True
+    assert capabilities.supports_code_execution is True
+    assert capabilities.uses_sandboxed_execution is True
 
 
 def test_runtime_profile_registry_allows_extension_adapters():

--- a/tests/unit/adapters/test_agent_runtime.py
+++ b/tests/unit/adapters/test_agent_runtime.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import subprocess
+
+import pytest
+
 from karenina.adapters.agent_runtime import (
     AgentRuntimeProfile,
     get_agent_runtime_capabilities,
     map_path_for_prompt,
+    preflight_docker_runtime,
     register_agent_runtime_profile,
     workspace_path_for_prompt,
 )
+from karenina.ports import AdapterUnavailableError
 from karenina.ports.capabilities import PortCapabilities
 from karenina.schemas.config import ModelConfig
 
@@ -124,3 +130,69 @@ def test_runtime_profile_registry_allows_extension_adapters():
 
     assert workspace_path_for_prompt(config, None) == "custom://workspace"
     assert map_path_for_prompt(config, None, None) == "custom://trace"
+
+
+def test_docker_preflight_requires_docker_cli(monkeypatch):
+    monkeypatch.setattr("karenina.adapters.agent_runtime.shutil.which", lambda _name: None)
+
+    with pytest.raises(AdapterUnavailableError) as exc_info:
+        preflight_docker_runtime(image="karenina-bixbench:latest")
+
+    assert exc_info.value.reason == "docker_unavailable"
+
+
+def test_docker_preflight_reports_daemon_unavailable(monkeypatch):
+    monkeypatch.setattr("karenina.adapters.agent_runtime.shutil.which", lambda _name: "/usr/bin/docker")
+
+    def fake_run(command, **_kwargs):
+        assert command == ["docker", "info"]
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="Cannot connect to Docker daemon")
+
+    monkeypatch.setattr("karenina.adapters.agent_runtime.subprocess.run", fake_run)
+
+    with pytest.raises(AdapterUnavailableError) as exc_info:
+        preflight_docker_runtime(image="karenina-bixbench:latest")
+
+    assert exc_info.value.reason == "docker_daemon_unavailable"
+    assert "Cannot connect to Docker daemon" in str(exc_info.value)
+
+
+def test_docker_preflight_reports_missing_image(monkeypatch):
+    monkeypatch.setattr("karenina.adapters.agent_runtime.shutil.which", lambda _name: "/usr/bin/docker")
+    calls: list[list[str]] = []
+
+    def fake_run(command, **_kwargs):
+        calls.append(command)
+        if command == ["docker", "info"]:
+            return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="No such image")
+
+    monkeypatch.setattr("karenina.adapters.agent_runtime.subprocess.run", fake_run)
+
+    with pytest.raises(AdapterUnavailableError) as exc_info:
+        preflight_docker_runtime(image="karenina-bixbench:latest")
+
+    assert calls == [
+        ["docker", "info"],
+        ["docker", "image", "inspect", "karenina-bixbench:latest"],
+    ]
+    assert exc_info.value.reason == "docker_image_unavailable"
+    assert "No such image" in str(exc_info.value)
+
+
+def test_docker_preflight_accepts_ready_runtime(monkeypatch):
+    monkeypatch.setattr("karenina.adapters.agent_runtime.shutil.which", lambda _name: "/usr/bin/docker")
+    calls: list[list[str]] = []
+
+    def fake_run(command, **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("karenina.adapters.agent_runtime.subprocess.run", fake_run)
+
+    preflight_docker_runtime(image="karenina-bixbench:latest")
+
+    assert calls == [
+        ["docker", "info"],
+        ["docker", "image", "inspect", "karenina-bixbench:latest"],
+    ]

--- a/tests/unit/adapters/test_registry.py
+++ b/tests/unit/adapters/test_registry.py
@@ -226,6 +226,30 @@ class TestRegistrationBehavior:
         assert result is not None
         assert result.description == "Second adapter"
 
+    def test_registration_installs_runtime_profile(self) -> None:
+        """AdapterSpec runtime profiles should integrate extension adapters."""
+        from karenina.adapters.agent_runtime import AgentRuntimeProfile, get_agent_runtime_capabilities
+        from karenina.adapters.registry import AdapterRegistry, AdapterSpec
+        from karenina.ports.capabilities import PortCapabilities
+        from karenina.schemas.config import ModelConfig
+
+        profile = AgentRuntimeProfile(
+            capabilities=lambda _config: PortCapabilities(
+                supports_system_prompt=True,
+                supports_file_tools=True,
+            )
+        )
+        AdapterRegistry.register(
+            AdapterSpec(
+                interface="test_unique_interface_runtime_profile",
+                description="Runtime profile test adapter",
+                runtime_profile=profile,
+            )
+        )
+        config = ModelConfig.model_construct(interface="test_unique_interface_runtime_profile")
+
+        assert get_agent_runtime_capabilities(config).supports_file_tools is True
+
 
 class TestManualAdapterSpec:
     """Tests specifically for manual adapter registration."""

--- a/tests/unit/benchmark/verification/prompts/rubric/test_deep_judgment_prompts.py
+++ b/tests/unit/benchmark/verification/prompts/rubric/test_deep_judgment_prompts.py
@@ -343,9 +343,33 @@ class TestScoreExtractionPrompts:
         assert "## Anti-patterns" in prompt
         assert "## Output handoff" in prompt
 
-    def test_boolean_system_prompt_warns_against_default_true(self) -> None:
-        prompt = DeepJudgmentPromptBuilder().build_score_extraction_system_prompt_boolean()
-        assert "default to false" in prompt.lower()
+    def test_boolean_score_prompts_route_hedged_reasoning_by_conclusion(self, boolean_trait: LLMRubricTrait) -> None:
+        """Regression: hedged reasoning with a negative conclusion must not default true.
+
+        The score-extraction stage only sees the reasoning text plus these
+        prompts. A realistic failure is a reasoning stage that acknowledges
+        partial support but concludes the criteria are not met; boolean judges
+        tend to over-reward the hedge unless the system prompt tells them to
+        mirror the Conclusion line and avoid directional defaults.
+        """
+        builder = DeepJudgmentPromptBuilder()
+        system_prompt = builder.build_score_extraction_system_prompt_boolean()
+        user_prompt = builder.build_score_extraction_user_prompt(
+            trait=boolean_trait,
+            reasoning=(
+                "Evidence: The answer cites one source but leaves the main claim unsupported.\n"
+                "Interpretation: The evidence is mixed and the response sounds confident.\n"
+                "Conclusion: the criteria are not met."
+            ),
+        )
+
+        anti_patterns = system_prompt.split("## Anti-patterns", 1)[1].split("## Output handoff", 1)[0]
+        assert "The verdict must follow logically from the reasoning's Conclusion." in system_prompt
+        assert "Biasing toward true or false when the reasoning is hedged or balanced" in anti_patterns
+        assert "verdict should mirror the Conclusion line" in anti_patterns
+        assert "directional default" in anti_patterns
+        assert "Conclusion: the criteria are not met." in user_prompt
+        assert "otherwise false" in user_prompt
 
     def test_numeric_system_prompt_has_four_sections(self) -> None:
         prompt = DeepJudgmentPromptBuilder().build_score_extraction_system_prompt_numeric()

--- a/tests/unit/benchmark/verification/stages/test_agentic_parse_template.py
+++ b/tests/unit/benchmark/verification/stages/test_agentic_parse_template.py
@@ -138,8 +138,12 @@ class TestAgenticParseTemplateStage:
         # Parser was called
         mock_parser.parse_to_pydantic.assert_called_once()
 
-        # Results stored
-        assert ctx.get_artifact(ArtifactKeys.PARSED_ANSWER) is parsed_answer
+        # Results stored. After Fix C the stage rebuilds the strict answer
+        # via model_construct, so identity is no longer preserved; match
+        # by class + field values instead.
+        stored = ctx.get_artifact(ArtifactKeys.PARSED_ANSWER)
+        assert isinstance(stored, MockAnswer)
+        assert stored.test_field is True
         assert ctx.get_artifact(ArtifactKeys.AGENTIC_PARSING_PERFORMED) is True
         assert ctx.get_artifact(ArtifactKeys.INVESTIGATION_TRACE) == "investigation trace"
 

--- a/tests/unit/benchmark/verification/stages/test_agentic_parse_template.py
+++ b/tests/unit/benchmark/verification/stages/test_agentic_parse_template.py
@@ -128,8 +128,12 @@ class TestAgenticParseTemplateStage:
         # Agent was called with workspace_path
         mock_agent.run.assert_called_once()
         call_kwargs = mock_agent.run.call_args
+        messages = call_kwargs.kwargs.get("messages") or call_kwargs[1].get("messages")
         agent_config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
+        system_prompt = messages[0].text
         assert agent_config.workspace_path == Path("/tmp/test_workspace")
+        assert "Look only for artifacts that appear to contain final reported results" in system_prompt
+        assert "Do not run scripts, notebooks, or commands" in system_prompt
 
         # Parser was called
         mock_parser.parse_to_pydantic.assert_called_once()
@@ -138,6 +142,48 @@ class TestAgenticParseTemplateStage:
         assert ctx.get_artifact(ArtifactKeys.PARSED_ANSWER) is parsed_answer
         assert ctx.get_artifact(ArtifactKeys.AGENTIC_PARSING_PERFORMED) is True
         assert ctx.get_artifact(ArtifactKeys.INVESTIGATION_TRACE) == "investigation trace"
+
+    @patch("karenina.benchmark.verification.stages.pipeline.agentic_parse_template.get_agent")
+    @patch("karenina.benchmark.verification.stages.pipeline.agentic_parse_template.get_parser")
+    def test_execute_tracks_agentic_parsing_usage_separately(self, mock_get_parser, mock_get_agent):
+        from karenina.benchmark.verification.stages.pipeline.agentic_parse_template import (
+            AgenticParseTemplateStage,
+        )
+        from karenina.ports import AgentResult, ParsePortResult, UsageMetadata
+
+        mock_agent = MagicMock()
+        mock_agent.run.return_value = AgentResult(
+            final_response='{"test_field": true}',
+            raw_trace="investigation trace",
+            trace_messages=[],
+            usage=UsageMetadata(input_tokens=100, output_tokens=20, total_tokens=120),
+            turns=3,
+            limit_reached=False,
+        )
+        mock_get_agent.return_value = mock_agent
+
+        mock_parser = MagicMock()
+        parsed_answer = MockAnswer(test_field=True)
+        mock_parser.parse_to_pydantic.return_value = ParsePortResult(
+            parsed=parsed_answer,
+            usage=UsageMetadata(input_tokens=30, output_tokens=10, total_tokens=40),
+        )
+        mock_get_parser.return_value = mock_parser
+
+        stage = AgenticParseTemplateStage()
+        ctx = _make_context()
+        stage.execute(ctx)
+
+        usage_tracker = ctx.get_artifact(ArtifactKeys.USAGE_TRACKER)
+        usage_metadata = usage_tracker.get_total_summary()
+
+        assert usage_metadata["agentic_parsing_investigation"]["input_tokens"] == 100
+        assert usage_metadata["agentic_parsing_investigation"]["output_tokens"] == 20
+        assert usage_metadata["agentic_parsing_extraction"]["input_tokens"] == 30
+        assert usage_metadata["agentic_parsing_extraction"]["output_tokens"] == 10
+        assert usage_metadata["total"]["input_tokens"] == 130
+        assert usage_metadata["total"]["output_tokens"] == 30
+        assert usage_metadata["total"]["total_tokens"] == 160
 
     @patch("karenina.benchmark.verification.stages.pipeline.agentic_parse_template.get_agent")
     def test_execute_marks_error_on_agent_failure(self, mock_get_agent):

--- a/tests/unit/benchmark/verification/stages/test_agentic_parse_template_optional_fields.py
+++ b/tests/unit/benchmark/verification/stages/test_agentic_parse_template_optional_fields.py
@@ -1,0 +1,200 @@
+"""Fix C: agentic-parse-template tolerates null sub-question extractions.
+
+The agentic parser passes a relaxed sibling schema (every VerifiedField
+becomes Optional[T] = None) to the LLM-side parser. Fields the LLM
+returns as ``null`` are stored on the strict template via
+``_null_fields``, so ``_compute_field_results`` reports them as ``None``
+rather than False, preserving partial credit on the other fields.
+
+Two regressions guarded here:
+
+1. With a 3-field template and ``q2`` returned as null, q1 and q3 are
+   scored normally and field_results["q2"] is exactly ``None``.
+
+2. **Critical**: when ground truth for a boolean is ``False`` and the
+   model returned ``None``, field_results["q2"] MUST stay ``None``
+   (not become ``False``). Scoring it as False would silently look
+   correct against the False ground truth. The bug Fix C exists to
+   prevent.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import (
+    ArtifactKeys,
+    VerificationContext,
+)
+from karenina.schemas.config.models import ModelConfig
+from karenina.schemas.entities.answer import BaseAnswer
+from karenina.schemas.entities.verified_field import VerifiedField
+from karenina.schemas.primitives import BooleanMatch, NumericTolerance
+
+
+class ThreeFieldAnswer(BaseAnswer):
+    """Three-field template; one bool, two floats. Mirrors BixBench shape."""
+
+    q1: float = VerifiedField(
+        description="First sub-answer.",
+        ground_truth=1.5,
+        verify_with=NumericTolerance(tolerance=0.1),
+    )
+    q2: bool = VerifiedField(
+        description="Second sub-answer.",
+        ground_truth=True,
+        verify_with=BooleanMatch(),
+    )
+    q3: float = VerifiedField(
+        description="Third sub-answer.",
+        ground_truth=2.0,
+        verify_with=NumericTolerance(tolerance=0.1),
+    )
+
+
+class FalseGTAnswer(BaseAnswer):
+    """Boolean with ground truth = False. Used for the critical regression."""
+
+    q2: bool = VerifiedField(
+        description="Did X happen?",
+        ground_truth=False,
+        verify_with=BooleanMatch(),
+    )
+
+
+def _make_context(answer_cls: type[BaseAnswer]) -> VerificationContext:
+    """Minimal VerificationContext for agentic-parse stage tests."""
+    ctx = VerificationContext(
+        question_id="q1",
+        template_id="t1",
+        question_text="Compute stuff.",
+        template_code=f"class {answer_cls.__name__}(BaseAnswer): ...",
+        answering_model=ModelConfig(id="test", model_name="test-model", interface="claude_agent_sdk"),
+        parsing_model=ModelConfig(id="test", model_name="test-model", interface="claude_agent_sdk"),
+        agentic_parsing=True,
+        agentic_judge_context="workspace_only",
+        workspace_path=Path("/tmp/test_workspace"),
+    )
+    ctx.set_artifact(ArtifactKeys.RAW_ANSWER, answer_cls)
+    ctx.set_artifact(ArtifactKeys.ANSWER, answer_cls)
+    ctx.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "raw trace")
+    return ctx
+
+
+@pytest.mark.unit
+class TestAgenticParseOptionalFields:
+    """Null extractions surface as None in field_results, not False."""
+
+    @patch("karenina.benchmark.verification.stages.pipeline.agentic_parse_template.get_agent")
+    @patch("karenina.benchmark.verification.stages.pipeline.agentic_parse_template.get_parser")
+    def test_null_field_does_not_fail_whole_record(self, mock_get_parser, mock_get_agent):
+        """q1 + q3 score normally; q2 (null in extraction) is None."""
+        from karenina.benchmark.verification.stages.pipeline.agentic_parse_template import (
+            AgenticParseTemplateStage,
+        )
+        from karenina.benchmark.verification.utils.schema_builder import (
+            build_extraction_relaxed_class,
+        )
+        from karenina.ports import AgentResult, ParsePortResult, UsageMetadata
+
+        mock_agent = MagicMock()
+        mock_agent.run.return_value = AgentResult(
+            final_response="ok",
+            raw_trace="investigation trace",
+            trace_messages=[],
+            usage=UsageMetadata(),
+            turns=2,
+            limit_reached=False,
+        )
+        mock_get_agent.return_value = mock_agent
+
+        # Parser returns a *relaxed* instance with q2=None; the production
+        # code path calls build_extraction_relaxed_class(answer_class) and
+        # passes that to parse_to_pydantic, so we build the same class here.
+        relaxed_cls = build_extraction_relaxed_class(ThreeFieldAnswer)
+        relaxed_instance = relaxed_cls(q1=1.5, q2=None, q3=2.0)
+
+        mock_parser = MagicMock()
+        mock_parser.parse_to_pydantic.return_value = ParsePortResult(
+            parsed=relaxed_instance,
+            usage=UsageMetadata(),
+        )
+        mock_get_parser.return_value = mock_parser
+
+        ctx = _make_context(ThreeFieldAnswer)
+        AgenticParseTemplateStage().execute(ctx)
+
+        assert ctx.error is None, ctx.error
+        stored = ctx.get_artifact(ArtifactKeys.PARSED_ANSWER)
+        assert isinstance(stored, ThreeFieldAnswer)
+        # q2 was nulled, so it is present in _null_fields.
+        assert stored.__dict__.get("_null_fields") == {"q2"}
+
+        # Tri-valued field_results: q1 True, q2 None, q3 True
+        field_results = stored._compute_field_results()
+        assert field_results["q1"] is True
+        assert field_results["q2"] is None
+        assert field_results["q3"] is True
+
+        # AllOf default: any non-True (including None) makes verify() False.
+        assert stored.verify() is False
+        # Granular: n_true / n_total = 2 / 3
+        assert stored.verify_granular() == pytest.approx(2 / 3)
+
+    @patch("karenina.benchmark.verification.stages.pipeline.agentic_parse_template.get_agent")
+    @patch("karenina.benchmark.verification.stages.pipeline.agentic_parse_template.get_parser")
+    def test_null_extraction_with_false_ground_truth_stays_none(self, mock_get_parser, mock_get_agent):
+        """CRITICAL: GT=False + extracted=None MUST yield None, not False.
+
+        Without Fix C, a null extraction could be silently scored as False
+        and "accidentally match" a False ground truth. The user called this
+        out explicitly. It is the load-bearing regression test for the
+        whole tri-valued design.
+        """
+        from karenina.benchmark.verification.stages.pipeline.agentic_parse_template import (
+            AgenticParseTemplateStage,
+        )
+        from karenina.benchmark.verification.utils.schema_builder import (
+            build_extraction_relaxed_class,
+        )
+        from karenina.ports import AgentResult, ParsePortResult, UsageMetadata
+
+        mock_agent = MagicMock()
+        mock_agent.run.return_value = AgentResult(
+            final_response="ok",
+            raw_trace="investigation trace",
+            trace_messages=[],
+            usage=UsageMetadata(),
+            turns=2,
+            limit_reached=False,
+        )
+        mock_get_agent.return_value = mock_agent
+
+        relaxed_cls = build_extraction_relaxed_class(FalseGTAnswer)
+        relaxed_instance = relaxed_cls(q2=None)
+
+        mock_parser = MagicMock()
+        mock_parser.parse_to_pydantic.return_value = ParsePortResult(
+            parsed=relaxed_instance,
+            usage=UsageMetadata(),
+        )
+        mock_get_parser.return_value = mock_parser
+
+        ctx = _make_context(FalseGTAnswer)
+        AgenticParseTemplateStage().execute(ctx)
+
+        assert ctx.error is None, ctx.error
+        stored = ctx.get_artifact(ArtifactKeys.PARSED_ANSWER)
+        field_results = stored._compute_field_results()
+
+        # The bug Fix C prevents: BooleanMatch(None, False) might return True
+        # (silently treating a null extraction as a False match). The
+        # tri-valued contract says field_results[q2] is None, not False/True.
+        assert field_results["q2"] is None, f"q2 with null extraction must be None, got {field_results['q2']!r}"
+        # Strict identity to rule out tricky truthiness bugs
+        assert field_results["q2"] is not False
+        assert field_results["q2"] is not True
+
+        # verify() rejects None at the leaf (soft-False)
+        assert stored.verify() is False

--- a/tests/unit/benchmark/verification/stages/test_generate_answer_routing.py
+++ b/tests/unit/benchmark/verification/stages/test_generate_answer_routing.py
@@ -1,183 +1,180 @@
 """Tests for GenerateAnswerStage routing logic.
 
-Verifies that the generate_answer stage correctly routes to AgentPort
-or LLMPort based on the model configuration, particularly for manual
-interface models.
+Verifies that the generate_answer stage routes to AgentPort or LLMPort
+based on the model configuration. Routing is driven by the real
+``use_agent`` decision in ``GenerateAnswerStage.execute``:
+
+    use_agent = bool(mcp_urls) or spec.agent_tier == "deep_agent" or interface == "manual"
+
+These tests exercise that decision against the real ``VerificationContext``
+by patching ``get_agent`` / ``get_llm`` at the module where the stage looks
+them up, then asserting which factory was called. The manual path is
+especially load-bearing: ``ManualLLMAdapter`` raises
+``ManualInterfaceError``, so a routing regression would silently send
+manual runs to the wrong adapter.
 """
 
-import contextlib
-import inspect
-from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
 import karenina.benchmark.verification.stages.pipeline.generate_answer as gen_mod
 from karenina.adapters.registry import AdapterRegistry, AdapterSpec
+from karenina.benchmark.verification.stages.core.base import VerificationContext
+from karenina.benchmark.verification.stages.pipeline.generate_answer import GenerateAnswerStage
+from karenina.schemas.config import ModelConfig
 
 
-def _make_context(interface, model_provider=None, model_name="test"):
-    """Build a minimal VerificationContext stand-in via SimpleNamespace."""
-    model = SimpleNamespace(
-        id=model_name,
+def _make_context(
+    *,
+    interface: str,
+    mcp_urls_dict: dict | None = None,
+) -> VerificationContext:
+    """Build a minimal real VerificationContext for routing tests.
+
+    Uses the real context class (not a SimpleNamespace stand-in) so that
+    earlier sections of execute() — replay lookup, workspace resolution,
+    cache check — do not short-circuit or raise before the routing branch
+    under test is reached.
+    """
+    extra: dict = {}
+    if interface == "manual":
+        # ModelConfig validates that interface="manual" carries a non-None,
+        # non-bool manual_traces. A sentinel object satisfies the validator
+        # without forcing us to build a real ManualTraces (which needs a
+        # Benchmark). The routing branch under test never inspects it.
+        extra["manual_traces"] = object()
+    model = ModelConfig(
+        id="m1",
+        model_name="test-model",
+        model_provider="openai" if interface != "manual" else None,
         interface=interface,
-        mcp_urls_dict=None,
-        system_prompt=None,
-        agent_middleware=None,
-        agent_timeout=180,
-        model_provider=model_provider,
-        model_name=model_name,
+        system_prompt="You are helpful.",
+        request_timeout=30.0,
+        mcp_urls_dict=mcp_urls_dict,
+        **extra,
     )
-    artifacts = {}
-    context = SimpleNamespace(
-        answering_model=model,
-        question_text="What is 2+2?",
-        few_shot_examples=[],
-        few_shot_enabled=False,
-        workspace_path=None,
-        agentic_parsing=False,
-        cached_answer_data=None,
+    return VerificationContext(
         question_id="q1",
-        error=None,
-        completed_without_errors=True,
+        template_id="t1",
+        question_text="What is 2+2?",
+        template_code="class Answer(BaseAnswer): value: str",
+        answering_model=model,
+        parsing_model=model,
     )
-    context.get_artifact = lambda key: artifacts.get(key)
-    context.set_artifact = lambda key, value: artifacts.__setitem__(key, value)
-    context.mark_error = lambda msg: setattr(context, "error", msg)
-    return context
+
+
+def _install_factories(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, MagicMock]:
+    """Patch get_agent/get_llm with call-tracking mocks and return them.
+
+    Both mocks return a sentinel adapter so the routing branch is observable
+    via ``call_count`` regardless of what execute() does afterwards. The
+    downstream invocation may fail; we wrap execute() in ``suppress`` so the
+    test only asserts on which factory was selected.
+    """
+    agent_factory = MagicMock(return_value=MagicMock(name="FakeAgent"))
+    llm_factory = MagicMock(return_value=MagicMock(name="FakeLLM"))
+    monkeypatch.setattr(gen_mod, "get_agent", agent_factory)
+    monkeypatch.setattr(gen_mod, "get_llm", llm_factory)
+    return agent_factory, llm_factory
+
+
+def _force_spec(monkeypatch: pytest.MonkeyPatch, spec: AdapterSpec) -> None:
+    monkeypatch.setattr(AdapterRegistry, "get_spec", staticmethod(lambda _iface: spec))
 
 
 @pytest.mark.unit
 class TestGenerateAnswerRouting:
     """Tests for the use_agent routing decision in GenerateAnswerStage."""
 
-    def test_source_routes_manual_to_agent(self):
-        """The execute() source must contain a manual interface check.
+    def test_manual_interface_routes_to_agent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Manual interface must route to AgentPort (ManualAgentAdapter).
 
-        Inspects the source of GenerateAnswerStage.execute() to verify that
-        manual interface routing is present. The routing expression must
-        include a check for interface == "manual" so that manual models use
-        AgentPort (ManualAgentAdapter) instead of LLMPort
-        (ManualLLMAdapter, which raises ManualInterfaceError).
+        ManualLLMAdapter raises ManualInterfaceError, so a regression that
+        drops the ``interface == "manual"`` clause would silently break every
+        manual run. The manual spec here uses agent_tier="tool_loop" to prove
+        it is the manual-interface clause — not the agent_tier clause — that
+        forces the agent path.
         """
-        source = inspect.getsource(gen_mod.GenerateAnswerStage.execute)
-
-        assert 'interface == "manual"' in source, (
-            "GenerateAnswerStage.execute() must contain a check for "
-            'interface == "manual" in the use_agent routing logic. '
-            "Without this, manual models are sent to ManualLLMAdapter "
-            "which raises ManualInterfaceError."
+        agent_factory, llm_factory = _install_factories(monkeypatch)
+        _force_spec(
+            monkeypatch,
+            AdapterSpec(
+                interface="manual",
+                description="Manual interface for pre-recorded traces",
+                supports_mcp=False,
+                supports_tools=False,
+                requires_provider=False,
+                agent_tier="tool_loop",
+            ),
         )
 
-    def test_manual_get_agent_called(self, monkeypatch):
-        """Verify GenerateAnswerStage calls get_agent (not get_llm) for manual.
+        stage = GenerateAnswerStage()
+        stage.execute(_make_context(interface="manual"))
 
-        Patches get_agent and get_llm at the module level and runs execute()
-        to confirm that the manual interface routes through the agent path.
+        assert agent_factory.call_count == 1
+        assert llm_factory.call_count == 0
+
+    def test_langchain_without_mcp_routes_to_llm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Standard LangChain model without MCP routes to LLMPort.
+
+        agent_tier is "tool_loop" (not "deep_agent"), no MCP URLs, and the
+        interface is not manual — so none of the use_agent clauses fire and
+        the stage must use LLMPort.
         """
-        agent_called = False
-        llm_called = False
-
-        class FakeAgent:
-            """Stub AgentPort for tracking calls."""
-
-            async def run(self, *_args, **_kwargs):
-                from karenina.ports import Message
-
-                return [Message.ai("fake")]
-
-        class FakeLLM:
-            """Stub LLMPort for tracking calls."""
-
-            async def ainvoke(self, *_args, **_kwargs):
-                from karenina.ports import Message
-
-                return Message.ai("fake")
-
-        def fake_get_agent(_model_config, auto_fallback=False):
-            nonlocal agent_called
-            agent_called = True
-            return FakeAgent()
-
-        def fake_get_llm(_model_config, auto_fallback=False):
-            nonlocal llm_called
-            llm_called = True
-            return FakeLLM()
-
-        monkeypatch.setattr(gen_mod, "get_agent", fake_get_agent)
-        monkeypatch.setattr(gen_mod, "get_llm", fake_get_llm)
-
-        manual_spec = AdapterSpec(
-            interface="manual",
-            description="Manual interface for pre-recorded traces",
-            supports_mcp=False,
-            supports_tools=False,
-            requires_provider=False,
-            agent_tier="tool_loop",
-        )
-        monkeypatch.setattr(
-            AdapterRegistry,
-            "get_spec",
-            staticmethod(lambda _iface: manual_spec),
+        agent_factory, llm_factory = _install_factories(monkeypatch)
+        _force_spec(
+            monkeypatch,
+            AdapterSpec(
+                interface="langchain",
+                description="LangChain adapter",
+                agent_tier="tool_loop",
+            ),
         )
 
-        context = _make_context("manual")
-        stage = gen_mod.GenerateAnswerStage()
+        stage = GenerateAnswerStage()
+        stage.execute(_make_context(interface="langchain"))
 
-        # execute() will call get_agent then fail at the stub invocation.
-        # We only care which factory was called.
-        with contextlib.suppress(Exception):
-            stage.execute(context)
+        assert llm_factory.call_count == 1
+        assert agent_factory.call_count == 0
 
-        assert agent_called is True, (
-            "Expected get_agent() to be called for manual interface, "
-            "but it was not called. The routing logic did not recognize "
-            "manual as requiring AgentPort."
-        )
-        assert llm_called is False, (
-            "get_llm() should not be called for manual interface. ManualLLMAdapter raises ManualInterfaceError."
-        )
+    def test_deep_agent_tier_routes_to_agent_without_mcp(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A deep-agent spec (e.g. Claude Code) uses AgentPort even with no MCP.
 
-    def test_langchain_without_mcp_routes_to_llm(self, monkeypatch):
-        """Standard LangChain model without MCP should route to LLMPort."""
-        agent_called = False
-        llm_called = False
-
-        class FakeLLM:
-            """Stub LLMPort."""
-
-            async def ainvoke(self, *_args, **_kwargs):
-                from karenina.ports import Message
-
-                return Message.ai("fake")
-
-        def fake_get_agent(_model_config, auto_fallback=False):
-            nonlocal agent_called
-            agent_called = True
-
-        def fake_get_llm(_model_config, auto_fallback=False):
-            nonlocal llm_called
-            llm_called = True
-            return FakeLLM()
-
-        monkeypatch.setattr(gen_mod, "get_agent", fake_get_agent)
-        monkeypatch.setattr(gen_mod, "get_llm", fake_get_llm)
-
-        langchain_spec = AdapterSpec(
-            interface="langchain",
-            description="LangChain adapter",
-            agent_tier="tool_loop",
-        )
-        monkeypatch.setattr(
-            AdapterRegistry,
-            "get_spec",
-            staticmethod(lambda _iface: langchain_spec),
+        Deep-agent runtimes execute tools internally; the LLMPort path would
+        lose the tool-call trace. This pins the agent_tier clause of use_agent
+        independently of the manual clause.
+        """
+        agent_factory, llm_factory = _install_factories(monkeypatch)
+        _force_spec(
+            monkeypatch,
+            AdapterSpec(
+                interface="langchain",
+                description="Deep agent runtime",
+                agent_tier="deep_agent",
+            ),
         )
 
-        context = _make_context("langchain", model_provider="anthropic", model_name="claude-sonnet-4-20250514")
-        stage = gen_mod.GenerateAnswerStage()
+        stage = GenerateAnswerStage()
+        stage.execute(_make_context(interface="langchain"))
 
-        with contextlib.suppress(Exception):
-            stage.execute(context)
+        assert agent_factory.call_count == 1
+        assert llm_factory.call_count == 0
 
-        assert llm_called is True, "Standard langchain model without MCP should route to LLMPort."
-        assert agent_called is False, "get_agent() should not be called for standard langchain model."
+    def test_mcp_urls_force_agent_regardless_of_tier(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """MCP-attached models route to AgentPort even with a tool_loop tier."""
+        agent_factory, llm_factory = _install_factories(monkeypatch)
+        _force_spec(
+            monkeypatch,
+            AdapterSpec(
+                interface="langchain",
+                description="LangChain adapter",
+                agent_tier="tool_loop",
+            ),
+        )
+
+        stage = GenerateAnswerStage()
+        stage.execute(_make_context(interface="langchain", mcp_urls_dict={"brave-search": "http://x/mcp"}))
+
+        assert agent_factory.call_count == 1
+        assert llm_factory.call_count == 0

--- a/tests/unit/benchmark/verification/stages/test_generate_answer_streaming.py
+++ b/tests/unit/benchmark/verification/stages/test_generate_answer_streaming.py
@@ -258,10 +258,10 @@ class TestAgentTimeoutPath:
         ):
             stage.execute(ctx)
 
-    def test_agent_timeout_with_trace_sets_partial_and_usage_unavailable(self) -> None:
+    def test_agent_timeout_with_trace_and_no_usage_sets_usage_unavailable(self) -> None:
         """When agent times out but has a partial trace, RESPONSE_TIMEOUT_PARTIAL
-        and USAGE_UNAVAILABLE should be set, the trace stored, and the context
-        marked as an error (transient timeout)."""
+        and USAGE_UNAVAILABLE should be set if usage is missing, the trace
+        stored, and the context marked as an error (transient timeout)."""
         ctx = _make_context()
         result = _make_agent_result(
             timeout_reached=True,
@@ -282,6 +282,39 @@ class TestAgentTimeoutPath:
         assert "Partial response from agent" in raw
 
         # Partial timeout is an error (timeout category)
+        assert ctx.completed_without_errors is False
+        assert ctx.error_category.value == "timeout"
+        assert "timed out" in ctx.error.lower()
+
+    def test_agent_timeout_with_recovered_usage_does_not_mark_unavailable(self) -> None:
+        """A partial agent timeout can still carry trustworthy recovered usage.
+
+        The Claude Agent SDK may omit the final ResultMessage on wall-clock
+        timeout while still reporting per-assistant-message input tokens. In
+        that case the run should remain marked partial, but usage should not be
+        classified as unavailable.
+        """
+        ctx = _make_context()
+        result = _make_agent_result(
+            timeout_reached=True,
+            raw_trace="--- AI Message ---\nPartial response from agent",
+            turns=3,
+        )
+        result.usage = UsageMetadata(
+            input_tokens=606_981,
+            output_tokens=0,
+            total_tokens=606_981,
+        )
+
+        self._run_agent_stage(ctx, result)
+
+        assert ctx.get_artifact(ArtifactKeys.RESPONSE_TIMEOUT_PARTIAL) is True
+        assert ctx.get_result_field("response_timeout_partial") is True
+        assert ctx.get_artifact(ArtifactKeys.USAGE_UNAVAILABLE) is None
+        assert ctx.get_result_field(ArtifactKeys.USAGE_UNAVAILABLE) is None
+
+        raw = ctx.get_artifact(ArtifactKeys.RAW_LLM_RESPONSE)
+        assert "Partial response from agent" in raw
         assert ctx.completed_without_errors is False
         assert ctx.error_category.value == "timeout"
         assert "timed out" in ctx.error.lower()

--- a/tests/unit/benchmark/verification/stages/test_parse_template_optional_fields.py
+++ b/tests/unit/benchmark/verification/stages/test_parse_template_optional_fields.py
@@ -1,0 +1,146 @@
+"""Classical template parsing tolerates null sub-question extractions."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karenina.benchmark.verification.stages.core.base import (
+    ArtifactKeys,
+    VerificationContext,
+)
+from karenina.benchmark.verification.stages.pipeline.parse_template import (
+    ParseTemplateStage,
+)
+from karenina.ports import ParsePortResult, UsageMetadata
+from karenina.ports.capabilities import PortCapabilities
+from karenina.schemas.config.models import ModelConfig
+from karenina.schemas.entities.answer import BaseAnswer
+from karenina.schemas.entities.verified_field import VerifiedField
+from karenina.schemas.primitives import BooleanMatch, NumericTolerance
+
+
+class ThreeFieldClassicalAnswer(BaseAnswer):
+    """Three-field template mirroring grouped QA sub-question scoring."""
+
+    q1: float = VerifiedField(
+        description="First sub-answer.",
+        ground_truth=1.5,
+        verify_with=NumericTolerance(tolerance=0.1),
+    )
+    q2: bool = VerifiedField(
+        description="Second sub-answer.",
+        ground_truth=True,
+        verify_with=BooleanMatch(),
+    )
+    q3: float = VerifiedField(
+        description="Third sub-answer.",
+        ground_truth=2.0,
+        verify_with=NumericTolerance(tolerance=0.1),
+    )
+
+
+class FalseGTClassicalAnswer(BaseAnswer):
+    """Boolean with ground truth False for null-vs-False regression coverage."""
+
+    q2: bool = VerifiedField(
+        description="Did X happen?",
+        ground_truth=False,
+        verify_with=BooleanMatch(),
+    )
+
+
+def _make_context(answer_cls: type[BaseAnswer]) -> VerificationContext:
+    ctx = VerificationContext(
+        question_id="q1",
+        template_id="t1",
+        question_text="Compute stuff.",
+        template_code=f"class {answer_cls.__name__}(BaseAnswer): ...",
+        answering_model=ModelConfig(
+            id="test",
+            model_provider="openai",
+            model_name="test-model",
+            interface="langchain",
+        ),
+        parsing_model=ModelConfig(
+            id="test",
+            model_provider="openai",
+            model_name="test-model",
+            interface="langchain",
+        ),
+        use_full_trace_for_template=True,
+    )
+    ctx.set_artifact(ArtifactKeys.RAW_ANSWER, answer_cls)
+    ctx.set_artifact(ArtifactKeys.ANSWER, answer_cls)
+    ctx.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "Final answer text.")
+    return ctx
+
+
+@pytest.mark.unit
+class TestClassicalParseOptionalFields:
+    """Null extractions in classical parsing surface as None in field_results."""
+
+    @patch("karenina.benchmark.verification.evaluators.template.evaluator.get_llm")
+    @patch("karenina.benchmark.verification.evaluators.template.evaluator.get_parser")
+    def test_null_field_does_not_fail_whole_record(self, mock_get_parser, mock_get_llm):
+        mock_get_llm.return_value = MagicMock()
+
+        mock_parser = MagicMock()
+        mock_parser.capabilities = PortCapabilities(supports_structured_output=True)
+
+        def parse_to_pydantic(_messages, schema):
+            return ParsePortResult(
+                parsed=schema(q1=1.5, q2=None, q3=2.0),
+                usage=UsageMetadata(),
+            )
+
+        mock_parser.parse_to_pydantic.side_effect = parse_to_pydantic
+        mock_get_parser.return_value = mock_parser
+
+        ctx = _make_context(ThreeFieldClassicalAnswer)
+        ParseTemplateStage().execute(ctx)
+
+        assert ctx.error is None, ctx.error
+        parsed = ctx.get_artifact(ArtifactKeys.PARSED_ANSWER)
+        assert isinstance(parsed, ThreeFieldClassicalAnswer)
+        assert parsed.__dict__.get("_null_fields") == {"q2"}
+
+        field_results = parsed._compute_field_results()
+        assert field_results == {"q1": True, "q2": None, "q3": True}
+        assert parsed.verify() is False
+        assert parsed.verify_granular() == pytest.approx(2 / 3)
+
+        schema_used = mock_parser.parse_to_pydantic.call_args.args[1]
+        assert schema_used.__name__ == "ThreeFieldClassicalAnswer__Relaxed"
+
+    @patch("karenina.benchmark.verification.evaluators.template.evaluator.get_llm")
+    @patch("karenina.benchmark.verification.evaluators.template.evaluator.get_parser")
+    def test_null_extraction_with_false_ground_truth_stays_none(
+        self,
+        mock_get_parser,
+        mock_get_llm,
+    ):
+        mock_get_llm.return_value = MagicMock()
+
+        mock_parser = MagicMock()
+        mock_parser.capabilities = PortCapabilities(supports_structured_output=True)
+
+        def parse_to_pydantic(_messages, schema):
+            return ParsePortResult(
+                parsed=schema(q2=None),
+                usage=UsageMetadata(),
+            )
+
+        mock_parser.parse_to_pydantic.side_effect = parse_to_pydantic
+        mock_get_parser.return_value = mock_parser
+
+        ctx = _make_context(FalseGTClassicalAnswer)
+        ParseTemplateStage().execute(ctx)
+
+        assert ctx.error is None, ctx.error
+        parsed = ctx.get_artifact(ArtifactKeys.PARSED_ANSWER)
+        field_results = parsed._compute_field_results()
+
+        assert field_results["q2"] is None
+        assert field_results["q2"] is not False
+        assert field_results["q2"] is not True
+        assert parsed.verify() is False

--- a/tests/unit/benchmark/verification/stages/test_rubric_evaluation_warnings.py
+++ b/tests/unit/benchmark/verification/stages/test_rubric_evaluation_warnings.py
@@ -106,6 +106,7 @@ class TestRubricEvaluationWarnings:
             (),
             {
                 "evaluate_rubric": lambda _self, **_kw: ({"clarity": 1.0}, {"clarity": "yes"}, []),
+                "close": lambda _self: None,
             },
         )()
         with patch(

--- a/tests/unit/benchmark/verification/test_workspace_capture.py
+++ b/tests/unit/benchmark/verification/test_workspace_capture.py
@@ -1,0 +1,184 @@
+import json
+import os
+from pathlib import Path
+
+from karenina.benchmark.verification.stages.core.base import ArtifactKeys, VerificationContext
+from karenina.benchmark.verification.stages.pipeline.generate_answer import GenerateAnswerStage
+from karenina.benchmark.verification.workspace_capture import (
+    DEFAULT_WORKSPACE_OUTPUT_EXCLUDES,
+    capture_workspace,
+    compact_manifest,
+    snapshot_workspace,
+)
+from karenina.schemas.config import ModelConfig
+from karenina.schemas.verification import (
+    ModelIdentity,
+    VerificationResult,
+    VerificationResultMetadata,
+    VerificationResultTemplate,
+)
+
+
+def _result(question_id: str = "q/1", result_id: str = "rid1") -> VerificationResult:
+    identity = ModelIdentity(
+        interface="test",
+        model_name="model",
+        config_id="answering",
+    )
+    return VerificationResult(
+        metadata=VerificationResultMetadata(
+            question_id=question_id,
+            template_id="template",
+            failure=None,
+            caveats=[],
+            question_text="question",
+            answering=identity,
+            parsing=identity.model_copy(update={"config_id": "parsing"}),
+            execution_time=0.1,
+            timestamp="2026-05-20 12:00:00",
+            result_id=result_id,
+        ),
+        template=VerificationResultTemplate(),
+    )
+
+
+def _manifest_rows(output_dir: Path) -> list[dict]:
+    return [json.loads(line) for line in (output_dir / "manifest.jsonl").read_text().splitlines() if line.strip()]
+
+
+def test_produced_capture_copies_new_and_modified_files(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "input.csv").write_text("before")
+    (workspace / "unchanged.csv").write_text("same")
+    baseline = snapshot_workspace(workspace, DEFAULT_WORKSPACE_OUTPUT_EXCLUDES)
+
+    (workspace / "input.csv").write_text("after")
+    (workspace / "result.json").write_text("{}")
+    output_dir = tmp_path / "out" / "workspaces"
+
+    capture_workspace(
+        mode="produced",
+        output_dir=output_dir,
+        workspace_path=workspace,
+        baseline=baseline,
+        result=_result(),
+        exclude_patterns=DEFAULT_WORKSPACE_OUTPUT_EXCLUDES,
+    )
+
+    captured = output_dir / "q_1__rid1"
+    assert (captured / "input.csv").read_text() == "after"
+    assert (captured / "result.json").read_text() == "{}"
+    assert not (captured / "unchanged.csv").exists()
+    assert _manifest_rows(output_dir)[0]["copied_file_count"] == 2
+
+
+def test_full_capture_honors_excludes_and_preserves_symlinks(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "result.txt").write_text("result")
+    (workspace / "empty_dir").mkdir()
+    (workspace / ".venv").mkdir()
+    (workspace / ".venv" / "installed.txt").write_text("noise")
+    target = workspace / "target.txt"
+    target.write_text("target")
+    os.symlink("target.txt", workspace / "link.txt")
+    output_dir = tmp_path / "out" / "workspaces"
+
+    capture_workspace(
+        mode="full",
+        output_dir=output_dir,
+        workspace_path=workspace,
+        baseline=None,
+        result=_result(result_id="rid2"),
+        exclude_patterns=DEFAULT_WORKSPACE_OUTPUT_EXCLUDES,
+    )
+
+    captured = output_dir / "q_1__rid2"
+    assert (captured / "result.txt").read_text() == "result"
+    assert (captured / "empty_dir").is_dir()
+    assert not (captured / ".venv").exists()
+    assert (captured / "link.txt").is_symlink()
+    assert os.readlink(captured / "link.txt") == "target.txt"
+
+
+def test_capture_replaces_existing_destination_and_compacts_manifest(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "result.txt").write_text("v1")
+    output_dir = tmp_path / "out" / "workspaces"
+    result = _result(question_id="q1", result_id="same")
+
+    capture_workspace(
+        mode="full",
+        output_dir=output_dir,
+        workspace_path=workspace,
+        baseline=None,
+        result=result,
+        exclude_patterns=DEFAULT_WORKSPACE_OUTPUT_EXCLUDES,
+    )
+    (workspace / "result.txt").write_text("v2")
+    capture_workspace(
+        mode="full",
+        output_dir=output_dir,
+        workspace_path=workspace,
+        baseline=None,
+        result=result,
+        exclude_patterns=DEFAULT_WORKSPACE_OUTPUT_EXCLUDES,
+    )
+
+    assert (output_dir / "q1__same" / "result.txt").read_text() == "v2"
+    compact_manifest(output_dir)
+    manifest = json.loads((output_dir / "manifest.json").read_text())
+    assert manifest["format_version"] == "1.0"
+    assert len(manifest["entries"]) == 2
+
+
+def test_missing_workspace_records_skip(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out" / "workspaces"
+    capture_workspace(
+        mode="full",
+        output_dir=output_dir,
+        workspace_path=tmp_path / "missing",
+        baseline=None,
+        result=_result(question_id="q1"),
+        exclude_patterns=DEFAULT_WORKSPACE_OUTPUT_EXCLUDES,
+    )
+
+    row = _manifest_rows(output_dir)[0]
+    assert row["status"] == "skipped"
+    assert row["skip_reason"] == "workspace_not_available"
+
+
+def test_full_output_mode_resolves_live_workspace_in_output_dir(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "benchmark"
+    source = workspace_root / "workspaces" / "q1"
+    source.mkdir(parents=True)
+    (source / "input.txt").write_text("input")
+    output_dir = tmp_path / "run" / "workspaces"
+    model = ModelConfig(model_name="model", model_provider="provider", interface="langchain", id="m1")
+    context = VerificationContext(
+        question_id="q1",
+        template_id="template",
+        question_text="question",
+        template_code="class Answer: pass",
+        answering_model=model,
+        parsing_model=model,
+        agentic_parsing=True,
+        workspace_root=workspace_root,
+        question_workspace_path="workspaces/q1",
+        workspace_copy=True,
+        workspace_cleanup=True,
+        workspace_output_mode="full",
+        workspace_output_dir=output_dir,
+    )
+    context.set_result_field(ArtifactKeys.TIMESTAMP, "2026-05-20 12:00:00")
+
+    GenerateAnswerStage()._resolve_workspace(context)
+
+    assert context.workspace_path is not None
+    assert context.workspace_path.parent == output_dir
+    assert context.workspace_path.name.startswith("q1__")
+    assert (context.workspace_path / "input.txt").read_text() == "input"
+    assert context.workspace_is_copy is False
+    assert not list(workspace_root.glob("*_run_*"))

--- a/tests/unit/ports/test_message_to_dict_usage.py
+++ b/tests/unit/ports/test_message_to_dict_usage.py
@@ -1,0 +1,73 @@
+"""Tests that Message.to_dict() emits the usage_metadata field when set.
+
+Fix E (extension): the unified ``Message`` carries an optional
+``usage_metadata`` dict so that per-call token / cache accounting is
+preserved end-to-end into ``template.trace_messages[*]``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.ports import Message, Role, TextContent
+
+
+@pytest.mark.unit
+class TestMessageToDictUsageMetadata:
+    def test_to_dict_emits_usage_metadata_when_set(self) -> None:
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[TextContent(text="42")],
+            usage_metadata={"input_tokens": 100, "output_tokens": 20},
+        )
+
+        out = msg.to_dict()
+
+        assert out["role"] == "assistant"
+        assert out["content"] == "42"
+        assert out["usage_metadata"] == {"input_tokens": 100, "output_tokens": 20}
+
+    def test_to_dict_omits_usage_metadata_when_none(self) -> None:
+        msg = Message(role=Role.ASSISTANT, content=[TextContent(text="hi")])
+
+        out = msg.to_dict()
+
+        assert "usage_metadata" not in out
+
+    def test_to_dict_emits_usage_metadata_with_cache_fields(self) -> None:
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[TextContent(text="cached")],
+            usage_metadata={
+                "input_tokens": 50,
+                "output_tokens": 10,
+                "cache_read_input_tokens": 800,
+                "cache_creation_input_tokens": 0,
+            },
+        )
+
+        out = msg.to_dict()
+
+        assert out["usage_metadata"] == {
+            "input_tokens": 50,
+            "output_tokens": 10,
+            "cache_read_input_tokens": 800,
+            "cache_creation_input_tokens": 0,
+        }
+
+    def test_to_dict_emits_empty_usage_metadata_dict(self) -> None:
+        """An explicit empty dict is distinct from None and should be emitted."""
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[TextContent(text="weird")],
+            usage_metadata={},
+        )
+
+        out = msg.to_dict()
+
+        # Explicit empty dict is still 'set' (not None) → emit it.
+        assert out["usage_metadata"] == {}
+
+    def test_default_usage_metadata_is_none(self) -> None:
+        msg = Message.assistant("hi")
+        assert msg.usage_metadata is None

--- a/tests/unit/ports/test_message_to_dict_usage.py
+++ b/tests/unit/ports/test_message_to_dict_usage.py
@@ -71,3 +71,24 @@ class TestMessageToDictUsageMetadata:
     def test_default_usage_metadata_is_none(self) -> None:
         msg = Message.assistant("hi")
         assert msg.usage_metadata is None
+
+    def test_from_dict_preserves_usage_metadata(self) -> None:
+        data = {
+            "role": "assistant",
+            "content": "cached answer",
+            "block_index": 0,
+            "usage_metadata": {
+                "input_tokens": 50,
+                "output_tokens": 10,
+                "cache_read_input_tokens": 800,
+            },
+        }
+
+        msg = Message.from_dict(data)
+
+        assert msg.usage_metadata == {
+            "input_tokens": 50,
+            "output_tokens": 10,
+            "cache_read_input_tokens": 800,
+        }
+        assert msg.to_dict()["usage_metadata"] == data["usage_metadata"]

--- a/tests/unit/schemas/test_composition_with_none_fields.py
+++ b/tests/unit/schemas/test_composition_with_none_fields.py
@@ -1,0 +1,188 @@
+"""Tests for composition strategy evaluation with tri-valued field results.
+
+After Fix C, ``field_results`` may contain ``None`` for fields the agentic
+parser returned as null. At composition time None behaves like a soft False
+(not-satisfied), but it must never be conflated with a real False. The
+distinction is preserved in the cached field_results dict for downstream
+consumers (granular scoring, serialized result rows, dataframe export).
+"""
+
+import pytest
+
+from karenina.schemas.entities.composition import (
+    AllOf,
+    AnyOf,
+    AtLeastN,
+    FieldCheck,
+    evaluate_strategy,
+)
+
+
+@pytest.mark.unit
+class TestFieldCheckWithNone:
+    """A leaf FieldCheck must return False when the field is None."""
+
+    def test_none_is_not_passing(self):
+        results = {"target": None}
+        assert evaluate_strategy(FieldCheck(field="target"), results) is False
+
+    def test_true_still_passes(self):
+        results = {"target": True}
+        assert evaluate_strategy(FieldCheck(field="target"), results) is True
+
+    def test_false_still_fails(self):
+        results = {"target": False}
+        assert evaluate_strategy(FieldCheck(field="target"), results) is False
+
+
+@pytest.mark.unit
+class TestAllOfWithNone:
+    """AllOf must reject when any leaf is None (soft-False)."""
+
+    def test_all_true_passes(self):
+        results = {"a": True, "b": True, "c": True}
+        strategy = AllOf(
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is True
+
+    def test_one_none_fails(self):
+        results = {"a": True, "b": None, "c": True}
+        strategy = AllOf(
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is False
+
+    def test_mix_true_false_none(self):
+        results = {"a": True, "b": False, "c": None}
+        strategy = AllOf(
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is False
+
+
+@pytest.mark.unit
+class TestAnyOfWithNone:
+    """AnyOf passes only when at least one leaf is exactly True."""
+
+    def test_one_true_among_nones_passes(self):
+        results = {"a": None, "b": True, "c": None}
+        strategy = AnyOf(
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is True
+
+    def test_all_none_fails(self):
+        results = {"a": None, "b": None, "c": None}
+        strategy = AnyOf(
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is False
+
+    def test_none_and_false_no_true_fails(self):
+        results = {"a": None, "b": False, "c": None}
+        strategy = AnyOf(
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is False
+
+
+@pytest.mark.unit
+class TestAtLeastNWithNone:
+    """AtLeastN counts only exactly-True leaves toward N."""
+
+    def test_two_trues_one_none_meets_n2(self):
+        results = {"a": True, "b": True, "c": None}
+        strategy = AtLeastN(
+            n=2,
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is True
+
+    def test_one_true_two_nones_fails_n2(self):
+        results = {"a": True, "b": None, "c": None}
+        strategy = AtLeastN(
+            n=2,
+            conditions=[
+                FieldCheck(field="a"),
+                FieldCheck(field="b"),
+                FieldCheck(field="c"),
+            ],
+        )
+        assert evaluate_strategy(strategy, results) is False
+
+    def test_n0_passes_even_with_all_none(self):
+        results = {"a": None, "b": None}
+        strategy = AtLeastN(
+            n=0,
+            conditions=[FieldCheck(field="a"), FieldCheck(field="b")],
+        )
+        assert evaluate_strategy(strategy, results) is True
+
+    def test_n_equals_passing_trues(self):
+        # 3 of 5 leaves True, the rest None and False: n=3 succeeds, n=4 fails.
+        results = {"a": True, "b": True, "c": True, "d": None, "e": False}
+        conditions = [
+            FieldCheck(field="a"),
+            FieldCheck(field="b"),
+            FieldCheck(field="c"),
+            FieldCheck(field="d"),
+            FieldCheck(field="e"),
+        ]
+        assert evaluate_strategy(AtLeastN(n=3, conditions=conditions), results) is True
+        assert evaluate_strategy(AtLeastN(n=4, conditions=conditions), results) is False
+
+
+@pytest.mark.unit
+class TestNestedCompositionWithNone:
+    """Nested compositions handle None at every level."""
+
+    def test_allof_of_anyof_with_none(self):
+        # AllOf( AnyOf(a,b), AnyOf(c,d) ) with a=True, b=None, c=None, d=True.
+        results = {"a": True, "b": None, "c": None, "d": True}
+        strategy = AllOf(
+            conditions=[
+                AnyOf(conditions=[FieldCheck(field="a"), FieldCheck(field="b")]),
+                AnyOf(conditions=[FieldCheck(field="c"), FieldCheck(field="d")]),
+            ]
+        )
+        assert evaluate_strategy(strategy, results) is True
+
+    def test_allof_of_anyof_all_none_in_branch_fails(self):
+        # AllOf( AnyOf(a,b), AnyOf(c,d) ) with first branch all None.
+        results = {"a": None, "b": None, "c": True, "d": False}
+        strategy = AllOf(
+            conditions=[
+                AnyOf(conditions=[FieldCheck(field="a"), FieldCheck(field="b")]),
+                AnyOf(conditions=[FieldCheck(field="c"), FieldCheck(field="d")]),
+            ]
+        )
+        assert evaluate_strategy(strategy, results) is False

--- a/tests/unit/schemas/test_verification_config.py
+++ b/tests/unit/schemas/test_verification_config.py
@@ -618,6 +618,30 @@ def test_sanitize_model_config_includes_max_retries() -> None:
 
 
 @pytest.mark.unit
+def test_sanitize_model_config_preserves_agent_runtime_extra_kwargs() -> None:
+    """Adapter runtime settings should remain modular under extra_kwargs."""
+    model = {
+        "id": "deep-agent",
+        "model_provider": "anthropic",
+        "model_name": "claude-sonnet-4-20250514",
+        "temperature": 0.0,
+        "interface": "langchain_deep_agents",
+        "system_prompt": "test",
+        "extra_kwargs": {
+            "agent_runtime": {
+                "backend": "docker",
+                "docker_image": "python:3.13-slim",
+                "docker_network": "none",
+            }
+        },
+    }
+
+    result = VerificationConfig.sanitize_model_config(model)
+
+    assert result["extra_kwargs"] == model["extra_kwargs"]
+
+
+@pytest.mark.unit
 def test_sanitize_model_config_openai_endpoint_includes_endpoint_fields() -> None:
     """Test sanitize_model_config includes endpoint fields for openai_endpoint."""
     model = {

--- a/tests/unit/verification/test_sinks.py
+++ b/tests/unit/verification/test_sinks.py
@@ -10,6 +10,7 @@ import pytest
 
 from karenina.benchmark.verification.sinks import (
     STATE_FORMAT_VERSION,
+    AgenticProgressiveFileSink,
     CompositeSink,
     InMemorySink,
     ProgressiveFileSink,
@@ -17,10 +18,12 @@ from karenina.benchmark.verification.sinks import (
     is_completed_result,
 )
 from karenina.schemas.config import ModelConfig
+from karenina.schemas.results.failure import Failure, FailureCategory
 from karenina.schemas.verification import (
     VerificationConfig,
     VerificationResult,
     VerificationResultMetadata,
+    VerificationResultTemplate,
 )
 from karenina.schemas.verification.model_identity import ModelIdentity
 from karenina.utils.progressive_save import TaskIdentifier
@@ -52,6 +55,9 @@ def _result(
     replicate: int | None = None,
     *,
     completed: bool = True,
+    failure: Failure | None = None,
+    raw_llm_response: str = "",
+    investigation_trace: str | None = None,
 ) -> VerificationResult:
     answering = ModelIdentity(interface="openai_endpoint", model_name=answering_name)
     parsing = ModelIdentity(interface="openai_endpoint", model_name=parsing_name)
@@ -75,6 +81,11 @@ def _result(
             replicate=replicate,
             result_id=result_id,
             run_name="test_run",
+            failure=failure,
+        ),
+        template=VerificationResultTemplate(
+            raw_llm_response=raw_llm_response,
+            investigation_trace=investigation_trace,
         ),
     )
 
@@ -313,6 +324,157 @@ class TestProgressiveFileSink:
         sink.on_start(["k1", "k2"], sink.config)
         sink.on_start(["k2"], sink.config)
         assert sink.total_tasks == 2
+
+
+@pytest.mark.unit
+class TestAgenticProgressiveFileSink:
+    def _fresh(self, tmp_path: Path, *, keep_sidecars: bool = False) -> AgenticProgressiveFileSink:
+        return AgenticProgressiveFileSink(
+            output_path=tmp_path / "results.json",
+            config=_config(),
+            benchmark_path="bench.jsonld",
+            trace_output_dir=tmp_path / "traces",
+            keep_progress_sidecars=keep_sidecars,
+        )
+
+    def test_writes_readable_trace_sidecars_on_result(self, tmp_path: Path):
+        sink = self._fresh(tmp_path)
+        result = _result(
+            "q1",
+            raw_llm_response="answer trace",
+            investigation_trace="investigation trace",
+        )
+        sink.on_start([TaskIdentifier.from_result(result).to_key()], sink.config)
+
+        sink.on_result(result)
+
+        assert (tmp_path / "traces" / "q1" / "answering_trace.txt").read_text() == "answer trace"
+        assert (tmp_path / "traces" / "q1" / "investigation_trace.txt").read_text() == "investigation trace"
+
+    def test_parser_failure_is_not_a_completed_triple_but_remains_hydratable(self, tmp_path: Path):
+        sink = self._fresh(tmp_path)
+        failure = Failure(
+            category=FailureCategory.PARSING,
+            stage="AgenticParseTemplate",
+            reason="structured extraction failed",
+        )
+        result = _result("q1", failure=failure, raw_llm_response="usable answer trace")
+        sink.on_start([TaskIdentifier.from_result(result).to_key()], sink.config)
+
+        sink.on_result(result)
+
+        assert sink.completed_triples() == set()
+        assert list(sink.iter_results())[0].template.raw_llm_response == "usable answer trace"
+
+    def test_success_after_parser_failure_becomes_terminal_and_export_dedupes(self, tmp_path: Path):
+        sink = self._fresh(tmp_path)
+        parser_failure = Failure(
+            category=FailureCategory.PARSING,
+            stage="AgenticParseTemplate",
+            reason="structured extraction failed",
+        )
+        failed = _result("q1", failure=parser_failure, raw_llm_response="old trace")
+        passed = _result("q1", raw_llm_response="new trace")
+        manifest_key = TaskIdentifier.from_result(failed).to_key()
+        sink.on_start([manifest_key], sink.config)
+
+        sink.on_result(failed)
+        sink.on_result(passed)
+        sink.on_finalize(all_complete=True)
+
+        assert len(sink.completed_triples()) == 1
+        export = json.loads((tmp_path / "results.json").read_text())
+        assert len(export["results"]) == 1
+        assert export["results"][0]["template"]["raw_llm_response"] == "new trace"
+        assert not sink.state_path.exists()
+        assert not sink.jsonl_path.exists()
+
+    def test_parser_failure_keeps_resume_sidecars_even_when_batch_completed(self, tmp_path: Path):
+        sink = self._fresh(tmp_path)
+        failure = Failure(
+            category=FailureCategory.PARSING,
+            stage="parse_template",
+            reason="parse failed",
+        )
+        result = _result("q1", failure=failure, raw_llm_response="answer trace")
+        sink.on_start([TaskIdentifier.from_result(result).to_key()], sink.config)
+        sink.on_result(result)
+
+        sink.on_finalize(all_complete=True)
+
+        assert sink.output_path.exists()
+        assert sink.state_path.exists()
+        assert sink.jsonl_path.exists()
+        export = json.loads(sink.output_path.read_text())
+        assert export["metadata"]["job_summary"]["is_complete"] is False
+
+    def test_batch_partial_export_is_marked_incomplete_without_parser_failures(self, tmp_path: Path):
+        sink = self._fresh(tmp_path)
+        result = _result("q1", raw_llm_response="answer trace")
+        sink.on_start([TaskIdentifier.from_result(result).to_key(), "pending"], sink.config)
+        sink.on_result(result)
+
+        sink.on_finalize(all_complete=False)
+
+        export = json.loads(sink.output_path.read_text())
+        assert export["metadata"]["job_summary"]["is_complete"] is False
+        assert sink.state_path.exists()
+
+    def test_keep_sidecars_preserves_state_after_success(self, tmp_path: Path):
+        sink = self._fresh(tmp_path, keep_sidecars=True)
+        result = _result("q1", raw_llm_response="answer trace")
+        sink.on_start([TaskIdentifier.from_result(result).to_key()], sink.config)
+        sink.on_result(result)
+
+        sink.on_finalize(all_complete=True)
+
+        assert sink.output_path.exists()
+        assert sink.state_path.exists()
+        assert sink.jsonl_path.exists()
+
+    def test_final_export_summary_counts_content_failures_as_failed(self, tmp_path: Path):
+        sink = self._fresh(tmp_path, keep_sidecars=True)
+        passed = _result("q1", raw_llm_response="answer trace")
+        failed = _result(
+            "q2",
+            failure=Failure(
+                category=FailureCategory.CONTENT,
+                stage="verify_template",
+                reason="verify_template returned False",
+            ),
+            raw_llm_response="answer trace",
+        )
+        sink.on_start(_manifest_from_results([passed, failed]), sink.config)
+        sink.on_result(passed)
+        sink.on_result(failed)
+
+        sink.on_finalize(all_complete=True)
+
+        export = json.loads(sink.output_path.read_text())
+        summary = export["metadata"]["job_summary"]
+        assert summary["successful_count"] == 1
+        assert summary["failed_count"] == 1
+        assert summary["is_complete"] is True
+
+    def test_final_export_summary_uses_latest_row_when_retry_succeeds(self, tmp_path: Path):
+        sink = self._fresh(tmp_path, keep_sidecars=True)
+        failure = Failure(
+            category=FailureCategory.PARSING,
+            stage="AgenticParseTemplate",
+            reason="structured extraction failed",
+        )
+        failed = _result("q1", failure=failure, raw_llm_response="old trace")
+        passed = _result("q1", raw_llm_response="new trace")
+        sink.on_start([TaskIdentifier.from_result(failed).to_key()], sink.config)
+        sink.on_result(failed)
+        sink.on_result(passed)
+
+        sink.on_finalize(all_complete=True)
+
+        export = json.loads(sink.output_path.read_text())
+        summary = export["metadata"]["job_summary"]
+        assert summary["successful_count"] == 1
+        assert summary["failed_count"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/verification/test_trace_agent_metrics.py
+++ b/tests/unit/verification/test_trace_agent_metrics.py
@@ -381,6 +381,30 @@ class TestAdapterShapedTraces:
         assert metrics["tool_calls"] == 2
         assert metrics["tools_used"] == ["mcp_tool_details", "mcp_tool_search"]
 
+    def test_claude_sdk_assistant_only_tool_calls(self) -> None:
+        """claude_agent_sdk can preserve tool uses without separate tool results."""
+        msgs = [
+            Message.assistant(
+                "Inspecting workspace.",
+                tool_calls=[_tool_call("Glob", "call_1")],
+            ),
+            Message.assistant(
+                "Running setup.",
+                tool_calls=[
+                    _tool_call("Bash", "call_2"),
+                    _tool_call("Read", "call_3"),
+                ],
+            ),
+            Message.assistant("Final answer."),
+        ]
+
+        metrics = extract_agent_metrics_from_messages(msgs)
+
+        assert metrics["iterations"] == 3
+        assert metrics["tool_calls"] == 3
+        assert metrics["tools_used"] == ["Bash", "Glob", "Read"]
+        assert metrics["tool_call_counts"] == {"Glob": 1, "Bash": 1, "Read": 1}
+
     def test_manual_adapter_empty_trace(self) -> None:
         """manual adapter: returns empty trace_messages — metrics should be zeroed."""
         metrics = extract_agent_metrics_from_messages([])


### PR DESCRIPTION
## Summary
Makes karenina's agent adapters run inside sandboxed containers (Docker and Singularity/Apptainer) and capture what they produce. Adds a shared container-runtime abstraction used by the `claude_agent_sdk` and `langchain_deep_agents` adapters, workspace-output capture as verification sidecars, agentic resume, per-call usage/token accounting on the unified `Message`, and subscription OAuth-token forwarding for the Claude SDK.

## Changes Made

### Adapters and runtime
- `adapters/agent_runtime.py` (new): container profiles, backend resolution, Docker/Singularity command building, preflight checks, capability derivation, workspace path mapping.
- `claude_agent_sdk/`: new `auth.py` and `usage.py`, plus docker CLI wrapper and message/parser/trace updates.
- `langchain_deep_agents/`: new `docker_backend.py`, `read_only_backend.py`, `runtime.py`, reasoning-content and usage in traces.
- `adapters/registry.py`: new `AdapterSpec.runtime_profile` hook (external-adapter extension point).

### Ports and schemas
- `ports/messages.py`: new optional `Message.usage_metadata`, surfaced into `trace_messages` and restored on load.
- `ports/capabilities.py`: new flags `supports_file_tools`, `supports_code_execution`, `uses_sandboxed_execution`.
- `VerificationConfig`: new `workspace_output_mode` (default `none`), `workspace_output_dir`, `workspace_output_exclude_patterns`.
- `BaseAnswer` field results widened to tri-valued (`bool | None`).

### Verification and CLI
- `benchmark/verification/workspace_capture.py` (new) plus `AgenticProgressiveFileSink` with trace sidecars and resumable parser-failure semantics.
- CLI `karenina verify`: new `--workspace-output-mode`, `--workspace-output-dir`, `--workspace-output-exclude`.

## Testing
- New unit coverage for agent runtime, CSDK auth, usage recovery, workspace capture, sink resume, tri-valued scoring, and tool metrics.
- Full suite validation deferred to CI on this PR.

## Additional Context
- **Behavioral change (tri-valued scoring, commit `6bdb1037`):** `verify()` now passes only if every field is exactly `True`. Null extractions count toward total weight but not the weighted sum. This changes pass/fail and granular scores for templates whose extractor returns null fields. The change is orthogonal to the sandbox work and touches only `answer.py`, `composition.py`, `evaluator.py`, `schema_builder.py`.
- **Infra:** container backends require Docker or Singularity/Apptainer on the host (gated by preflight). Subscription auth activates only when no explicit `anthropic_api_key` is set and `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_AUTH_TOKEN` is present. Otherwise behavior is unchanged.
- **Defaults are safe:** `workspace_output_mode` defaults to `none`, preserving existing behavior.
- **Merge order:** this is the base of a stacked series landing into `dev`. Merge this first, then #179, #180, #181, #182. Each later PR is chained on this one and auto-retargets to `dev` as its parent merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9J43c7xkP3mYpvjQrzZbP
