### PR TITLE
feat(adapters): add codex_sdk agentic adapter (OpenAI Codex SDK)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,11 @@ deep-agents = [
     "deepagents>=0.4.0",
     "langchain-mcp-adapters>=0.1.0",
 ]
+codex = [
+    # Pinned: beta SDK, validated against the bundled codex CLI 0.132.0
+    # (wire_api="responses" only; see adapters/codex_sdk/endpoint_shim.py).
+    "openai-codex==0.1.0b2",
+]
 
 [project.scripts]
 karenina = "karenina.cli:app"

--- a/specs/codex_sdk_findings.md
+++ b/specs/codex_sdk_findings.md
@@ -1,0 +1,336 @@
+# OpenAI Codex Python SDK — Step-0 validation against local vLLM
+
+Contract for the karenina codex adapter. All facts verified in the worktree
+`karenina-codex-worktree` on 2026-06-11 against the vLLM endpoint
+`http://hl-codon-gpu-020:8000/v1` (model id `qwen3.5-122b-a10b`, 262k ctx,
+keyless).
+
+## Smoke result: PASS (with a vLLM-side compatibility shim)
+
+- Both smoke turns drove the **full codex agent loop to completion**
+  (`status=completed`): reasoning -> `exec_command` tool call -> shell run ->
+  `function_call_output` -> final turn. `hello.txt` was created on disk with the
+  correct contents (`'hello from codex\n'`, exit code 0).
+- The SDK itself works end to end. The only blocker is that **stock vLLM
+  Responses API is too strict for codex's prompt shape**; it needs a thin
+  request-rewriting shim (see "Critical deviation" below). With the shim in
+  place the run is clean and fast (~3s per turn).
+
+## Versions
+
+- SDK: `openai-codex == 0.1.0b2`
+- Bundled runtime: `openai-codex-cli-bin == 0.132.0`; binary reports
+  `codex-cli 0.132.0`.
+- Bundled binary path (via `codex_cli_bin.bundled_codex_path()`):
+  `<venv>/lib/python3.13/site-packages/codex_cli_bin/bin/codex`
+- Install command that targets the worktree venv (NOT miniforge):
+  `env -u VIRTUAL_ENV uv pip install --python .venv/bin/python openai-codex`
+  (plain `uv pip install` landed in `~/miniforge3`; `--python .venv/bin/python`
+  is required). Pulls pydantic 2.13.4.
+
+## Critical deviation from the plan: wire_api MUST be "responses", not "chat"
+
+- The planned `wire_api=chat` **does not work**. CLI 0.132.0 hard-rejects it:
+  `` `wire_api = "chat"` is no longer supported. `` /
+  `How to fix: set wire_api = "responses" in your provider config.`
+- vLLM **does** serve `/v1/responses` (HTTP 200, real Responses payload with
+  `output`, `usage`, `status`). So `wire_api="responses"` is the only viable
+  setting and it reaches vLLM fine.
+- BUT codex's Responses request shape trips three vLLM validation rules. Each
+  was isolated by proxying codex -> vLLM and dumping bodies:
+  1. **`role="developer"` rejected.** Codex sends its permissions/apps/skills
+     system text as `developer`-role input messages. vLLM `/v1/responses`
+     returns `400 "Unexpected message role."` for `developer` (it accepts
+     `user`, `assistant`, `system`; `developer` passes the role enum but fails a
+     later check). Fix in shim: fold all `developer`/`system` input messages and
+     the top-level `instructions` into a single `instructions` string and drop
+     those messages from `input`.
+  2. **`400 "System message must be at the beginning."`** once developer→system
+     produced multiple/late system messages. Folding into `instructions` (rule 1)
+     resolves this too.
+  3. **`reasoning` input items rejected** on follow-up turns. Codex echoes prior
+     `reasoning` items back into `input`; vLLM cannot validate the `reasoning`
+     variant and 400s. Fix in shim: strip `type=="reasoning"` items from `input`.
+- Net: to run codex against THIS vLLM build you need an OpenAI-compatible proxy
+  (or a vLLM patch) that (a) merges system/developer text into `instructions`,
+  (b) strips `reasoning` input items. A reference proxy implementing exactly this
+  lives at `/tmp/codex-proxy.py` (REWRITE_ROLES=1). The adapter should either
+  ship such a shim, point at a patched vLLM, or require a vLLM build whose
+  Responses API accepts `developer` role + `reasoning` items.
+
+## 2a. ApprovalMode + default approval handler
+
+`ApprovalMode` (in `_approval_mode.py`) has exactly two members:
+- `ApprovalMode.deny_all` → `AskForApproval(never)`, no reviewer.
+- `ApprovalMode.auto_review` → `AskForApproval(on_request)` +
+  `ApprovalsReviewer.auto_review`. **This is the default** for `thread_start`
+  (`approval_mode: ApprovalMode = ApprovalMode.auto_review`).
+
+There is no separate "yolo / approve-all" enum member. Non-interactive runs are
+achieved by **not supplying an approval handler**: the SDK's
+`CodexClient._default_approval_handler` **auto-APPROVES** — it returns
+`{"decision": "accept"}` for both `item/commandExecution/requestApproval` and
+`item/fileChange/requestApproval`, and `{}` otherwise. So with no handler set,
+escalation requests are auto-accepted and the run is fully non-interactive. (A
+custom `approval_handler` can be passed to `CodexClient` directly, but the
+public `Codex(...)` facade does not expose it — it always uses the
+auto-approve default.) `auto_review` does NOT block; it routes escalations to an
+auto-review subagent, but the transport-level approval callback still resolves
+via the auto-approve default. In the smoke, commands ran without any prompt.
+
+## 2b. TokenUsageBreakdown fields (generated/v2_all.py:4219)
+
+Snake-case attribute (JSON alias):
+- `cached_input_tokens` (`cachedInputTokens`)
+- `input_tokens` (`inputTokens`)
+- `output_tokens` (`outputTokens`)
+- `reasoning_output_tokens` (`reasoningOutputTokens`)
+- `total_tokens` (`totalTokens`)
+
+`TurnResult.usage` is a `ThreadTokenUsage` (v2_all.py:6574), NOT a bare
+breakdown:
+- `.last: TokenUsageBreakdown` — usage of the most recent model call
+- `.total: TokenUsageBreakdown` — cumulative usage for the turn/thread
+- `.model_context_window: int | None` (`modelContextWindow`)
+
+Real payload from smoke1 (`result.usage.model_dump(by_alias=True)`):
+```json
+{
+  "last":  {"cachedInputTokens": 0, "inputTokens": 14753, "outputTokens": 49,
+            "reasoningOutputTokens": 0, "totalTokens": 14802},
+  "modelContextWindow": 258400,
+  "total": {"cachedInputTokens": 0, "inputTokens": 29306, "outputTokens": 125,
+            "reasoningOutputTokens": 0, "totalTokens": 29431}
+}
+```
+For karenina usage mapping use `usage.total` (or `.last` for per-call). Note
+vLLM/this model reports `reasoningOutputTokens: 0` even though reasoning items
+are produced.
+
+## 2c. TurnHandle mechanics — how to get the final TurnResult
+
+`thread.turn(input, ...)` **starts the turn immediately** (it calls
+`turn_start`) and returns a `TurnHandle(thread_id, id)`. The turn is already
+running on the app-server; notifications are being routed to its queue.
+
+Two ways to get the `TurnResult`:
+- **`handle.run()`** — calls `handle.stream()` internally and feeds it to
+  `_collect_turn_result`. Use this if you did NOT manually consume the stream.
+- **Iterate `handle.stream()` yourself**, then collect. `stream()` is a generator
+  that registers the turn queue and yields every `Notification` until it sees
+  `turn/completed`, then stops. The notification objects are consumed **once**
+  (single shared queue). So:
+  - If you fully drain `.stream()` yourself, **do NOT then call `.run()`** — it
+    would register a fresh stream on an already-completed/empty queue and block
+    forever.
+  - To both observe notifications AND get a `TurnResult`, tee the SAME stream:
+    wrap `handle.stream()` in your own generator that records `ev.method` and
+    re-yields, and pass that to
+    `openai_codex._run._collect_turn_result(gen, turn_id=handle.id)`. This is
+    what the smoke does and it works.
+- `thread.run(input)` is sugar: it does `turn(...)` then `stream()` +
+  `_collect_turn_result` for you. Use it for the simple blocking case.
+- `handle.run()` does NOT re-run the turn (it never re-sends `turn/start`); it
+  only collects the in-flight turn's notification stream.
+- `TurnHandle.interrupt()` exists (calls `turn/interrupt`); `.steer(input)`
+  exists (calls `turn/steer`). Confirmed `hasattr(handle, "interrupt") is True`.
+
+`TurnResult` fields (`_run.py:21`): `id, status (TurnStatus), error (TurnError|
+None), started_at, completed_at, duration_ms, final_response (str|None),
+items (list[ThreadItem]), usage (ThreadTokenUsage|None)`.
+`final_response` is derived from the last agentMessage item whose
+`phase == final_answer` (else last unknown-phase agentMessage). In the smoke it
+came back `''`/`None` because this model emitted an empty final agentMessage and
+expressed the result through the command output, not a final-answer text. Do not
+rely on `final_response` being populated; reconstruct from `items` if needed.
+
+## 2d. Config plumbing: per-thread `config={}` vs `CodexConfig.config_overrides`
+
+Two independent channels, both verified:
+
+1. **`CodexConfig(config_overrides=("k=v", ...))`** → becomes **CLI `--config k=v`
+   args** when launching `codex app-server` (`client.py:228-230`,
+   `args.extend(["--config", kv])`). The codex CLI parses the value as **TOML**
+   (`-c, --config <key=value>`, dotted path for nested, falls back to literal
+   string if not valid TOML). This is the channel used for provider setup. So
+   strings need embedded quotes: `model_providers.vllm.base_url="http://..."`.
+   Nested dotted keys like `model_providers.vllm.base_url` work and were how the
+   smoke configured the provider.
+
+2. **`thread_start(config={...})`** → a per-thread `dict[str, Any]` carried in the
+   `thread/start` JSON-RPC params as the `config` field (`ThreadStartParams.config:
+   dict[str, Any] | None`, v2_all.py:6552). It is serialized verbatim via
+   `model_dump(by_alias=True, exclude_none=True, mode="json")`
+   (`client.py:_params_dict`). Because the field is freeform `dict[str, Any]`,
+   the alias machinery does NOT rewrite nested keys — the dict you pass is sent
+   as-is. So a nested per-thread dict like
+   `config={"model_providers": {"vllm": {"base_url": "..."}}}` is transmitted
+   literally. (The app-server then applies it as a config overlay; this path was
+   NOT used in the smoke — provider config went through `config_overrides`/CLI.
+   For the adapter, prefer `config_overrides` for provider/model-provider setup
+   since the CLI TOML parsing and dotted-path semantics are well documented; use
+   per-thread `config` only for per-thread overrides if needed.)
+
+Model provider config keys recognized by the CLI (from binary strings):
+`name`, `base_url`, `wire_api`, `env_key`, `env_key_instructions`,
+`query_params`, `http_headers`, `env_http_headers`, `request_max_retries`,
+`stream_max_retries`, `stream_idle_timeout_ms`, `requires_openai_auth`,
+`supports_websockets`, `websocket_connect_timeout_ms`, `experimental_bearer_token`.
+
+### env_key: not needed for keyless vLLM
+The smoke ran with **no `env_key` and no `env`** at all. vLLM requires no auth,
+codex sent no Authorization header, and requests succeeded. Do NOT set `env_key`
+for a keyless endpoint (setting it would make codex require that env var to be
+present and inject a bearer token). If a keyed endpoint is needed later, set
+`model_providers.<p>.env_key="SOME_VAR"` and pass `CodexConfig(env={"SOME_VAR":
+"..."})`.
+
+## 2e. Sandbox values and cwd interaction
+
+`Sandbox` enum (`_sandbox.py`), wire values in parens:
+- `Sandbox.read_only` (`read-only`) — reads only.
+- `Sandbox.workspace_write` (`workspace-write`) — reads anywhere; **writes
+  restricted to `cwd` + configured writable roots**; network restricted.
+- `Sandbox.full_access` (`full-access`) — no FS restrictions
+  (maps to `dangerFullAccess`).
+
+`cwd` + `workspace_write`: yes, writes are restricted to `cwd` and the writable
+roots. In the smoke, with `cwd="/tmp/codex-smoke"` and
+`sandbox=Sandbox.workspace_write`, the model's own permissions prompt listed the
+writable roots as `/Users/carli/.codex/memories`, `/private/tmp`,
+`/private/tmp/codex-smoke`, and the macOS temp dir. The command ran in
+`/tmp/codex-smoke` and wrote `hello.txt` there without escalation. Set `cwd` on
+`thread_start` (thread-level) and/or per-turn (`thread.turn(cwd=...)`); sandbox
+can be set thread-level (`thread_start(sandbox=...)`, → `sandbox` mode) or per
+turn (`turn(sandbox=...)`, → `sandbox_policy` override).
+
+## 2f. MCP config shape
+
+The Python SDK generated models do NOT define a typed `model_providers` or
+`mcp_servers` config struct — provider and MCP config live in the **codex CLI
+config schema** (Rust), reached via `config_overrides` (`-c`) or the per-thread
+`config` dict. MCP-related strings in the binary: top-level `mcp_servers` table,
+keys include `command`, `args`, `env`, `url` (for remote/streamable HTTP),
+`bearer_token_env_var`, `http_headers`, `startup_timeout_sec`,
+`supports_parallel_tool_calls`, `experimental_environment`, `oauth`,
+`oauth_resource`, `scopes`, `client_id`. So an MCP server is configured like a
+CLI override, e.g.
+`config_overrides=('mcp_servers.fetch.command="uvx"',
+'mcp_servers.fetch.args=["mcp-server-fetch"]')`, or via the per-thread `config`
+dict `{"mcp_servers": {"fetch": {"command": "uvx", "args": [...]}}}`.
+NOTE: codex auto-injects an internal `codex_apps` MCP and tool_search; the
+tool catalog the model sees already includes `list_mcp_resources`,
+`read_mcp_resource`, etc. plus `mcp__codex_apps__*` entries (observed in the
+request `tools` array). The default tool the agent uses for shell is
+`exec_command`.
+
+## Exact working configuration (smoke, via shim proxy)
+
+```python
+from openai_codex import ApprovalMode, Codex, CodexConfig, Sandbox
+
+BASE = "http://hl-codon-gpu-020:8000/v1"   # or shim proxy in front of vLLM
+config = CodexConfig(
+    config_overrides=(
+        'model_providers.vllm.name="vLLM (local)"',
+        f'model_providers.vllm.base_url="{BASE}"',
+        'model_providers.vllm.wire_api="responses"',   # NOT "chat"
+        'model_providers.vllm.request_max_retries=2',
+        'model_providers.vllm.stream_max_retries=2',
+    ),
+    env=None,            # keyless: no env_key, no Authorization header
+)
+codex = Codex(config)
+thread = codex.thread_start(
+    model="qwen3.5-122b-a10b",
+    model_provider="vllm",
+    sandbox=Sandbox.workspace_write,
+    cwd="/tmp/codex-smoke",
+    base_instructions="You are a helpful coding agent.",
+    approval_mode=ApprovalMode.auto_review,   # default; auto-approve handler => non-interactive
+)
+result = thread.run("...prompt...")           # blocking collect
+# or: handle = thread.turn("..."); iterate handle.stream(); collect via _collect_turn_result
+codex.close()
+```
+
+## Items observed (ThreadItem shapes, real JSON)
+
+`TurnResult.items` is a list of `ThreadItem` (a pydantic `RootModel` union;
+unwrap with `.root`). Each inner item has a `.type` discriminator. Observed:
+
+- `userMessage`: `{"type":"userMessage","content":[{"type":"text","text":"...",
+  "text_elements":[]}]}`
+- `reasoning`: `{"type":"reasoning","summary":[],"content":["...chain of thought..."]}`
+  (fields: `id, content: list[str], summary: list[str]`)
+- `agentMessage`: `{"type":"agentMessage","text":"...","phase":<commentary|final_answer|None>}`
+  (fields: `id, text, phase (MessagePhase), memory_citation`)
+- `commandExecution`:
+  `{"type":"commandExecution","command":"/bin/zsh -lc \"echo 'hello from codex' > hello.txt && ls -la\"",
+    "aggregated_output":"total 8\n...hello.txt...","exit_code":0,"status":"completed",
+    "cwd":"root='/tmp/codex-smoke'","duration_ms":0}`
+  (fields: `id, command, command_actions, cwd, aggregated_output, exit_code,
+   duration_ms, status (CommandExecutionStatus: inProgress|completed|failed|declined),
+   process_id, source, type`)
+- `fileChange`: `{type:"fileChange", changes:[FileUpdateChange], status (PatchApplyStatus), id}`
+  (not emitted this run; agent used shell redirection instead of apply_patch)
+- `mcpToolCall`: `{type:"mcpToolCall", server, tool, arguments, result, error,
+   status, duration_ms, id}` (not emitted this run)
+- `webSearch`: `{type:"webSearch", query, action, id}` (not emitted)
+
+Other ThreadItem variants in the union: `hookPrompt`, `plan`,
+`dynamicToolCall`, `collabAgentToolCall`.
+
+### Streaming notification methods (smoke2, `handle.stream()`, 206 events)
+In order (deltas collapsed): `turn/started`, `item/started`, `item/completed`,
+`item/started`, `item/reasoning/textDelta` x136, `item/completed`,
+`item/started`, `item/agentMessage/delta` x62, `thread/tokenUsage/updated`,
+`turn/completed`. So you get per-item lifecycle, reasoning text deltas, agent
+message deltas, a token-usage update, and a terminal `turn/completed`. The
+`_collect_turn_result` helper keys on `item/completed`
+(`ItemCompletedNotification`), `thread/tokenUsage/updated`
+(`ThreadTokenUsageUpdatedNotification`), and `turn/completed`
+(`TurnCompletedNotification`).
+
+## Agent loop / Responses request structure (for adapter awareness)
+Codex drives a normal Responses tool loop. Per follow-up call it resends the
+full running `input` (prior user/assistant messages + `function_call` +
+`function_call_output` + `reasoning`), the top-level `instructions`, and a large
+`tools` array. The shell tool is `exec_command`; output comes back as a
+`function_call_output` whose `output` is a formatted chunk
+(`Chunk ID / Wall time / Process exited with code N / Output:` + stdout). Tools
+catalog injected by codex includes: `exec_command`, `write_stdin`,
+`update_plan`, `request_user_input`, `view_image`, `spawn_agent`/`send_input`/
+`resume_agent`/`wait_agent`/`close_agent` (multi-agent), `get_goal`/`create_goal`/
+`update_goal`, plus MCP tools (`list_mcp_resources`, `read_mcp_resource`,
+`mcp__codex_apps__*`) and freeform custom tools (apply_patch). The adapter may
+want to disable unneeded tools via config (e.g. `disabled_tools`, multi_agent
+features) to keep the prompt lean for a local model.
+
+## Surprises / gotchas
+- **`wire_api="chat"` is dead** in 0.132.0 — plan must change to `responses`.
+- **vLLM Responses API is not codex-ready out of the box**: needs `developer`→
+  `instructions` folding and `reasoning`-item stripping. This is the single
+  biggest adapter risk; decide between a shim proxy vs a patched vLLM.
+- `uv pip install` ignores the worktree venv unless `--python .venv/bin/python`
+  is passed (it defaulted to `~/miniforge3`).
+- The SDK stderr buffer is reachable via `codex._client._stderr_tail(n)`; it was
+  empty on these failures (errors arrived as structured `turn.error.message`
+  JSON via the JSON-RPC stream, not stderr). `CodexConfig(env={"RUST_LOG":
+  "info"})` is available if deeper tracing is needed.
+- `final_response` can be empty even on success; reconstruct from `items`.
+- Existing `~/.codex/config.toml` (`model="gpt-5.5"`) is overridden by `-c`
+  flags and by `thread_start(model=...)`; no conflict observed, but the adapter
+  should pass model + provider explicitly rather than relying on user config.
+- Approval is auto-accepted by the SDK default handler; the public `Codex`
+  facade gives no way to inject a custom handler (would need `CodexClient`
+  directly). Fine for non-interactive benchmarking.
+
+## Repro
+Smoke script: `scripts/codex_sdk_smoke.py` (untracked). Run with:
+`CODEX_SMOKE_BASE_URL="http://127.0.0.1:8011/v1" \
+ env -u VIRTUAL_ENV uv run --no-sync python scripts/codex_sdk_smoke.py`
+with the shim proxy `/tmp/codex-proxy.py` (REWRITE_ROLES=1) in front of vLLM.
+Pointing `CODEX_SMOKE_BASE_URL` directly at vLLM reproduces the
+`Unexpected message role` 400.
+```

--- a/src/karenina/adapters/codex_sdk/__init__.py
+++ b/src/karenina/adapters/codex_sdk/__init__.py
@@ -1,0 +1,70 @@
+"""Codex SDK adapter for natively agentic evaluation.
+
+Wraps OpenAI's Codex Python SDK (openai-codex), which drives a bundled
+``codex app-server`` binary over JSON-RPC. Agent-only: LLM and parser
+duties fall back to the langchain interface.
+
+Requires: pip install openai-codex (or pip install 'karenina[codex]')
+
+Adapter classes:
+    - CodexSDKAgentAdapter: One codex thread/turn per run with OS-level
+      sandboxing, built-in shell and patch tools, and timeout salvage.
+
+Utilities:
+    - CodexMessageConverter: Convert between unified Message and codex items
+    - check_codex_available: Check SDK and binary availability
+    - codex_items_to_raw_trace / codex_items_to_trace_messages: Trace formats
+    - extract_codex_usage: Extract UsageMetadata from ThreadTokenUsage
+    - wrap_codex_error: Map SDK exceptions to port errors
+    - EndpointShim: Local request rewriter for strict /v1/responses endpoints
+"""
+
+from typing import TYPE_CHECKING, Any
+
+__all__ = [
+    "CodexSDKAgentAdapter",
+    "CodexMessageConverter",
+    "EndpointShim",
+    "check_codex_available",
+    "codex_items_to_raw_trace",
+    "codex_items_to_trace_messages",
+    "convert_mcp_to_codex_config",
+    "extract_codex_usage",
+    "wrap_codex_error",
+]
+
+if TYPE_CHECKING:
+    from karenina.adapters.codex_sdk.agent import CodexSDKAgentAdapter
+    from karenina.adapters.codex_sdk.availability import check_codex_available
+    from karenina.adapters.codex_sdk.endpoint_shim import EndpointShim
+    from karenina.adapters.codex_sdk.errors import wrap_codex_error
+    from karenina.adapters.codex_sdk.mcp import convert_mcp_to_codex_config
+    from karenina.adapters.codex_sdk.messages import CodexMessageConverter
+    from karenina.adapters.codex_sdk.trace import (
+        codex_items_to_raw_trace,
+        codex_items_to_trace_messages,
+    )
+    from karenina.adapters.codex_sdk.usage import extract_codex_usage
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy import adapter classes to avoid circular imports."""
+    _imports = {
+        "CodexSDKAgentAdapter": "karenina.adapters.codex_sdk.agent",
+        "CodexMessageConverter": "karenina.adapters.codex_sdk.messages",
+        "EndpointShim": "karenina.adapters.codex_sdk.endpoint_shim",
+        "check_codex_available": "karenina.adapters.codex_sdk.availability",
+        "codex_items_to_raw_trace": "karenina.adapters.codex_sdk.trace",
+        "codex_items_to_trace_messages": "karenina.adapters.codex_sdk.trace",
+        "convert_mcp_to_codex_config": "karenina.adapters.codex_sdk.mcp",
+        "extract_codex_usage": "karenina.adapters.codex_sdk.usage",
+        "wrap_codex_error": "karenina.adapters.codex_sdk.errors",
+    }
+
+    if name in _imports:
+        import importlib
+
+        module = importlib.import_module(_imports[name])
+        return getattr(module, name)
+
+    raise AttributeError(f"module 'karenina.adapters.codex_sdk' has no attribute '{name}'")

--- a/src/karenina/adapters/codex_sdk/agent.py
+++ b/src/karenina/adapters/codex_sdk/agent.py
@@ -1,0 +1,563 @@
+"""Codex SDK agent adapter implementing the AgentPort interface.
+
+Wraps OpenAI's Codex Python SDK (openai-codex). Each arun() call spawns a
+fresh ``codex app-server`` subprocess via ``async with AsyncCodex(...)``,
+starts one thread, runs one turn, and tears everything down. This mirrors
+the per-run subprocess tradeoff of the Claude Agent SDK adapter: higher
+startup cost per call, but no cross-run state leakage.
+
+Custom endpoints: when ``ModelConfig.endpoint_base_url`` is set, the
+adapter starts a per-run localhost rewriting shim (see endpoint_shim.py)
+and points the codex provider config at it, because strict /v1/responses
+implementations such as stock vLLM reject codex's raw request shape.
+
+Timeout salvage: the adapter drains ``TurnHandle.stream()`` itself,
+accumulating completed items and usage notifications, racing the drain
+against ``config.timeout``. On timeout it stores a provisional partial
+result, calls ``handle.interrupt()`` (errors suppressed), and returns a
+refined partial with ``timeout_reached=True``.
+
+Known gap: codex has no per-turn iteration cap, so
+``AgentConfig.max_turns`` is best effort. ``limit_reached`` is set only
+when a turn error message indicates a limit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import contextlib
+import logging
+import shutil
+import tempfile
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from karenina.adapters.agent_runtime import get_agent_runtime_capabilities
+from karenina.ports import (
+    AgentConfig,
+    AgentResponseError,
+    AgentResult,
+    MCPServerConfig,
+    Message,
+    Role,
+    Tool,
+)
+from karenina.ports.capabilities import PortCapabilities
+
+from .config_builder import (
+    build_codex_config_overrides,
+    build_codex_env,
+    build_thread_start_kwargs,
+)
+from .endpoint_shim import DEFAULT_UPSTREAM_TIMEOUT_SECONDS, EndpointShim
+from .errors import wrap_codex_error
+from .mcp import convert_mcp_to_codex_config
+from .messages import CodexMessageConverter
+from .trace import codex_items_to_raw_trace, extract_final_response
+from .usage import extract_codex_usage
+
+if TYPE_CHECKING:
+    from karenina.schemas.config import ModelConfig
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# Placeholder for a turn that completed normally but produced no final
+# assistant text, matching the other agent adapters' phrasing.
+_NO_FINAL_RESPONSE_PLACEHOLDER = "[No final response extracted]"
+# Placeholder for limit or timeout partials where the agent was stopped.
+_STOPPED_PLACEHOLDER = "[Agent stopped before producing a final response]"
+
+# Bounded waits for the timeout-salvage path. The interrupt RPC and the
+# subsequent turn/completed normally resolve within a couple of seconds.
+_INTERRUPT_RPC_TIMEOUT = 10.0
+_INTERRUPT_DRAIN_GRACE = 15.0
+_POST_CLOSE_DRAIN_GRACE = 5.0
+
+
+def _merge_agent_message_deltas(items: list[Any], deltas_by_item_id: dict[str, list[str]]) -> list[Any]:
+    """Fold streamed agentMessage delta text into the completed item list.
+
+    The codex app-server does not always emit ``item/completed`` for the
+    final agentMessage of a turn: verified live against vLLM, the answer
+    text arrives only through ``item/agentMessage/delta`` events and
+    ``turn/completed`` carries an empty ``turn.items``. The SDK's own
+    collector loses that text the same way (``final_response`` comes back
+    empty). This helper repairs the item list:
+
+    - A completed agentMessage with empty text whose id received deltas
+      gets the joined delta text.
+    - Delta ids with no completed item at all are appended as synthesized
+      agentMessage stand-ins (duck-typed, matching the converter's
+      ``type``/``id``/``text`` access).
+
+    Args:
+        items: Items collected from ``item/completed`` notifications.
+        deltas_by_item_id: Accumulated delta strings per agentMessage id.
+
+    Returns:
+        New list with delta text folded in. Input list is not mutated.
+    """
+    from .messages import item_type, unwrap_item
+
+    remaining = {item_id: "".join(parts).strip() for item_id, parts in deltas_by_item_id.items()}
+    merged: list[Any] = []
+    for item in items:
+        inner = unwrap_item(item)
+        if item_type(item) == "agentMessage":
+            item_id = getattr(inner, "id", None)
+            if item_id in remaining:
+                delta_text = remaining.pop(item_id)
+                if not (getattr(inner, "text", "") or "").strip() and delta_text:
+                    inner.text = delta_text
+        merged.append(item)
+
+    for item_id, delta_text in remaining.items():
+        if delta_text:
+            merged.append(SimpleNamespace(type="agentMessage", id=item_id, text=delta_text, phase=None))
+    return merged
+
+
+class _PartialResultStore:
+    """Thread-safe handoff for timeout partial results."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._result: AgentResult | None = None
+
+    def set(self, result: AgentResult) -> None:
+        with self._lock:
+            self._result = result
+
+    def get(self) -> AgentResult | None:
+        with self._lock:
+            return self._result
+
+
+def _run_in_fresh_loop(
+    coro_func: Any,
+    *args: Any,
+    timeout: float = 600,
+    timeout_grace: float = 30,
+    timeout_result: Callable[[], T | None] | None = None,
+) -> Any:
+    """Run an async callable in a dedicated thread with a fresh event loop.
+
+    The codex app-server connection is loop-affine (asyncio subprocess
+    transport plus reader tasks bound to the loop that spawned them).
+    Running each synchronous call on its own fresh loop avoids sharing
+    loop-bound state with Karenina's BlockingPortal, matching the
+    langchain_deep_agents sync wrapper.
+    """
+
+    def _target() -> Any:
+        return asyncio.run(coro_func(*args))
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    shutdown_started = False
+    future: concurrent.futures.Future[Any] = executor.submit(_target)
+    try:
+        # The coroutine enforces the user-facing agent timeout with
+        # asyncio.wait_for and can return a partial trace. Give that inner
+        # timeout a grace period so this wrapper does not race it and
+        # replace the partial result with a bare TimeoutError.
+        return future.result(timeout=timeout + timeout_grace)
+    except concurrent.futures.TimeoutError:
+        if timeout_result is not None:
+            partial_result = timeout_result()
+            if partial_result is not None:
+                logger.warning(
+                    "Codex sync wrapper timed out after %ss but salvaged a partial result",
+                    timeout + timeout_grace,
+                )
+                future.cancel()
+                shutdown_started = True
+                executor.shutdown(wait=False, cancel_futures=True)
+                return partial_result
+        raise
+    finally:
+        if not shutdown_started:
+            executor.shutdown(wait=future.done(), cancel_futures=True)
+
+
+class CodexSDKAgentAdapter:
+    """Agent adapter using the OpenAI Codex Python SDK.
+
+    Implements the AgentPort Protocol. Codex provides its own deep-agent
+    runtime: built-in shell (exec_command), apply_patch, planning, and web
+    search tools driven by an OS-level sandbox (read_only or
+    workspace_write), so explicit Tool definitions are not forwarded.
+
+    Global concurrency cap: ``max_concurrent_requests`` (GlobalLLMLimiter)
+    gates single-turn LLM adapter calls and langchain-based agent model
+    calls only. This agent's internal model calls run outside that cap.
+
+    Example:
+        >>> from karenina.schemas.config import ModelConfig
+        >>> config = ModelConfig(
+        ...     id="qwen-codex",
+        ...     model_name="qwen3.5-122b-a10b",
+        ...     model_provider="openai",
+        ...     interface="codex_sdk",
+        ...     endpoint_base_url="http://my-vllm-host:8000/v1",
+        ... )
+        >>> adapter = CodexSDKAgentAdapter(config)
+        >>> result = adapter.run([Message.user("Create hello.txt and list the directory.")])
+        >>> print(result.final_response)
+    """
+
+    def __init__(self, model_config: ModelConfig) -> None:
+        """Initialize the Codex SDK agent adapter.
+
+        Args:
+            model_config: Configuration specifying model, endpoint, and interface.
+        """
+        self._config = model_config
+        self._converter = CodexMessageConverter()
+
+    @property
+    def capabilities(self) -> PortCapabilities:
+        """Declare adapter capabilities from the registered runtime profile."""
+        return get_agent_runtime_capabilities(self._config)
+
+    def _resolve_system_prompt(self, messages: list[Message], config: AgentConfig) -> str | None:
+        """Resolve the system prompt from messages, AgentConfig, or ModelConfig."""
+        system_prompt = self._converter.extract_system_prompt(messages)
+        if not system_prompt and config.system_prompt:
+            system_prompt = config.system_prompt
+        if not system_prompt and self._config.system_prompt:
+            system_prompt = self._config.system_prompt
+        return system_prompt
+
+    def _build_agent_result(
+        self,
+        items: list[Any],
+        *,
+        usage: Any,
+        session_id: str | None,
+        limit_reached: bool,
+        timeout_reached: bool,
+    ) -> AgentResult:
+        """Build an AgentResult from completed or partial codex items."""
+        raw_trace = codex_items_to_raw_trace(items)
+        if limit_reached:
+            raw_trace += "\n\n[Note: Turn limit reached - partial response shown]"
+        if timeout_reached:
+            raw_trace += "\n\n[Note: Agent timed out - partial trace shown]"
+
+        # Exclude user and system messages: system prompts are captured
+        # separately via tagged_messages injection.
+        trace_messages = [m for m in self._converter.from_provider(items) if m.role not in (Role.USER, Role.SYSTEM)]
+
+        # Codex's own final_response can be empty even on success, so the
+        # response text is always reconstructed from items.
+        placeholder = _STOPPED_PLACEHOLDER if (limit_reached or timeout_reached) else _NO_FINAL_RESPONSE_PLACEHOLDER
+        response_text = extract_final_response(items) or placeholder
+
+        turns = sum(1 for m in trace_messages if m.role == Role.ASSISTANT and (m.text or m.tool_calls))
+
+        return AgentResult(
+            final_response=response_text,
+            raw_trace=raw_trace.strip(),
+            trace_messages=trace_messages,
+            usage=extract_codex_usage(usage, model=self._config.model_name),
+            turns=turns,
+            limit_reached=limit_reached,
+            session_id=session_id,
+            actual_model=self._config.model_name,
+            timeout_reached=timeout_reached,
+        )
+
+    async def arun(
+        self,
+        messages: list[Message],
+        tools: list[Tool] | None = None,
+        mcp_servers: dict[str, MCPServerConfig] | None = None,
+        config: AgentConfig | None = None,
+        _partial_result_store: _PartialResultStore | None = None,
+    ) -> AgentResult:
+        """Execute one codex turn for the given conversation.
+
+        Args:
+            messages: Initial conversation messages.
+            tools: Ignored. Codex ships its own built-in tool set and does
+                not accept ad hoc tool definitions per turn.
+            mcp_servers: Not yet supported. Configured servers are skipped
+                with a warning (see mcp.py).
+            config: Optional AgentConfig for execution parameters.
+
+        Returns:
+            AgentResult with final response, traces, usage, and metadata.
+
+        Raises:
+            AdapterUnavailableError: If the codex binary cannot be launched.
+            AgentExecutionError: If the agent fails during execution.
+            AgentTimeoutError: If execution exceeds the timeout with no
+                partial items to salvage.
+            AgentResponseError: If the response is malformed or invalid.
+        """
+        from openai_codex import ApprovalMode, AsyncCodex, CodexConfig, Sandbox
+
+        config = config or AgentConfig()
+
+        if tools:
+            logger.warning(
+                "codex_sdk adapter ignores %d explicit tool definition(s). Codex uses its built-in tool set",
+                len(tools),
+            )
+        convert_mcp_to_codex_config(mcp_servers)
+
+        prompt_string = self._converter.to_prompt_string(messages)
+        system_prompt = self._resolve_system_prompt(messages, config)
+
+        # Workspace: codex workspace_write sandboxing restricts writes to
+        # cwd plus its configured writable roots, so always pin cwd. Fall
+        # back to a fresh temp dir, never to the host cwd or full access.
+        workspace_path = config.workspace_path
+        temp_workspace: str | None = None
+        if workspace_path is None:
+            temp_workspace = await asyncio.to_thread(tempfile.mkdtemp, prefix="karenina-codex-")
+            workspace_path = Path(temp_workspace)
+
+        shim: EndpointShim | None = None
+        items: list[Any] = []
+        agent_message_deltas: dict[str, list[str]] = {}
+        usage: Any = None
+        completed_turn: Any = None
+        thread_id: str | None = None
+        limit_reached = False
+        timeout_reached = False
+
+        try:
+            base_url: str | None = None
+            if self._config.endpoint_base_url:
+                # Per-arun shim: strict /v1/responses endpoints (stock vLLM)
+                # reject codex's developer-role messages and echoed reasoning
+                # items, so route requests through the local rewriter. Widen
+                # the upstream socket timeout when the agent timeout exceeds
+                # the shim default.
+                upstream_timeout = max(DEFAULT_UPSTREAM_TIMEOUT_SECONDS, config.timeout or 0.0)
+                shim = EndpointShim(self._config.endpoint_base_url, upstream_timeout=upstream_timeout)
+                await asyncio.to_thread(shim.start)
+                base_url = shim.base_url
+
+            codex_config = CodexConfig(
+                config_overrides=build_codex_config_overrides(self._config, base_url),
+                env=build_codex_env(self._config),
+            )
+            thread_kwargs = build_thread_start_kwargs(
+                self._config,
+                base_instructions=system_prompt,
+                cwd=str(workspace_path),
+            )
+            sandbox_mode = thread_kwargs.pop("sandbox")
+            sandbox = Sandbox.read_only if sandbox_mode == "read_only" else Sandbox.workspace_write
+
+            drain_task: asyncio.Task[None] | None = None
+            try:
+                async with AsyncCodex(codex_config) as codex:
+                    thread = await codex.thread_start(
+                        sandbox=sandbox,
+                        # auto_review keeps escalations non-interactive: the
+                        # SDK's default approval handler auto-accepts.
+                        approval_mode=ApprovalMode.auto_review,
+                        **thread_kwargs,
+                    )
+                    thread_id = thread.id
+                    handle = await thread.turn(prompt_string)
+
+                    async def drain_stream() -> None:
+                        nonlocal usage, completed_turn
+                        # Drain the single-consume notification stream
+                        # ourselves and never call handle.run() afterwards.
+                        async for event in handle.stream():
+                            method = getattr(event, "method", "")
+                            payload = getattr(event, "payload", None)
+                            if payload is None:
+                                continue
+                            if getattr(payload, "turn_id", handle.id) != handle.id:
+                                continue
+                            if method == "item/completed":
+                                items.append(payload.item)
+                            elif method == "item/agentMessage/delta":
+                                # The final agentMessage of a turn often never
+                                # gets an item/completed (verified live: only
+                                # deltas, then turn/completed with empty
+                                # turn.items), so the answer text must be
+                                # accumulated from deltas and synthesized.
+                                delta = getattr(payload, "delta", None)
+                                delta_item_id = getattr(payload, "item_id", None)
+                                if delta and delta_item_id:
+                                    agent_message_deltas.setdefault(delta_item_id, []).append(delta)
+                            elif method == "thread/tokenUsage/updated":
+                                usage = payload.token_usage
+                            elif method == "turn/completed":
+                                turn = getattr(payload, "turn", None)
+                                if turn is not None and getattr(turn, "id", None) == handle.id:
+                                    completed_turn = turn
+
+                    # Timeout handling deliberately avoids cancelling the
+                    # drain task. The SDK reads notifications via a blocking
+                    # queue.get on an executor thread. Cancelling mid-get
+                    # unregisters the queue and strands that thread forever,
+                    # which then hangs event-loop shutdown. Instead: race the
+                    # drain with asyncio.wait, interrupt the turn on timeout,
+                    # and let the stream end naturally on the interrupt's
+                    # turn/completed. AsyncCodex.close() at context exit is
+                    # the fail-safe waker (fail_all on registered queues).
+                    drain_task = asyncio.create_task(drain_stream())
+                    if config.timeout:
+                        done, _ = await asyncio.wait({drain_task}, timeout=config.timeout)
+                        if not done:
+                            timeout_reached = True
+                            logger.warning(
+                                "Codex agent timed out after %ss with %d partial item(s). Interrupting turn",
+                                config.timeout,
+                                len(items),
+                            )
+                            # Store a provisional partial immediately. The
+                            # remaining salvage steps (interrupt RPC, drain
+                            # grace, AsyncCodex.close) can outlast the sync
+                            # wrapper's deadline against an unresponsive
+                            # app-server, and the wrapper falls back to
+                            # whatever the store holds at that moment.
+                            if _partial_result_store is not None:
+                                _partial_result_store.set(
+                                    self._build_agent_result(
+                                        _merge_agent_message_deltas(list(items), agent_message_deltas),
+                                        usage=usage,
+                                        session_id=thread_id,
+                                        limit_reached=limit_reached,
+                                        timeout_reached=True,
+                                    )
+                                )
+                            with contextlib.suppress(Exception):
+                                await asyncio.wait_for(handle.interrupt(), timeout=_INTERRUPT_RPC_TIMEOUT)
+                            # Wait for the interrupted turn to emit its final
+                            # turn/completed so the stream finishes cleanly.
+                            await asyncio.wait({drain_task}, timeout=_INTERRUPT_DRAIN_GRACE)
+                        else:
+                            await drain_task
+                    else:
+                        await drain_task
+            except Exception as e:
+                mapped_error, was_limit = wrap_codex_error(e)
+                if was_limit:
+                    limit_reached = True
+                    logger.warning("Codex agent hit a limit: %s", e)
+                else:
+                    raise mapped_error from e
+            finally:
+                # The context exit above closed the app-server, which wakes
+                # any still-blocked notification read via fail_all. Give the
+                # drain task a short window to observe that, then detach.
+                if drain_task is not None and not drain_task.done():
+                    await asyncio.wait({drain_task}, timeout=_POST_CLOSE_DRAIN_GRACE)
+                    if not drain_task.done():
+                        drain_task.cancel()
+                if drain_task is not None and drain_task.done() and not drain_task.cancelled():
+                    # Retrieve to silence "exception was never retrieved" on
+                    # the expected TransportClosedError after a forced close.
+                    with contextlib.suppress(Exception):
+                        drain_task.exception()
+
+            items = _merge_agent_message_deltas(items, agent_message_deltas)
+
+            if timeout_reached:
+                partial_result = self._build_agent_result(
+                    items,
+                    usage=usage,
+                    session_id=thread_id,
+                    limit_reached=limit_reached,
+                    timeout_reached=True,
+                )
+                if _partial_result_store is not None:
+                    _partial_result_store.set(partial_result)
+                return partial_result
+
+            if completed_turn is not None:
+                status = getattr(getattr(completed_turn, "status", None), "value", None)
+                turn_error = getattr(completed_turn, "error", None)
+                if status == "failed":
+                    error_message = getattr(turn_error, "message", None) or "turn failed"
+                    mapped_error, was_limit = wrap_codex_error(RuntimeError(error_message))
+                    if was_limit:
+                        limit_reached = True
+                        logger.warning("Codex turn failed at a limit: %s", error_message)
+                    else:
+                        raise mapped_error
+
+            # A limit partial with zero items still returns a placeholder
+            # result (mirrors the deep_agents adapter) rather than raising.
+            if completed_turn is None and not items and not limit_reached:
+                raise AgentResponseError("No turn completion or items received from Codex SDK agent")
+
+            return self._build_agent_result(
+                items,
+                usage=usage,
+                session_id=thread_id,
+                limit_reached=limit_reached,
+                timeout_reached=False,
+            )
+        finally:
+            if shim is not None:
+                await asyncio.to_thread(shim.stop)
+            if temp_workspace is not None:
+                await asyncio.to_thread(shutil.rmtree, temp_workspace, ignore_errors=True)
+
+    def run(
+        self,
+        messages: list[Message],
+        tools: list[Tool] | None = None,
+        mcp_servers: dict[str, MCPServerConfig] | None = None,
+        config: AgentConfig | None = None,
+    ) -> AgentResult:
+        """Synchronous wrapper for arun().
+
+        Runs the coroutine on a dedicated thread with a fresh event loop
+        and salvages timeout partial results via a thread-safe store, the
+        same pattern as the langchain_deep_agents adapter.
+
+        Args:
+            messages: Initial conversation messages.
+            tools: Ignored (codex uses its built-in tool set).
+            mcp_servers: Not yet supported, skipped with a warning.
+            config: Optional AgentConfig for execution parameters.
+
+        Returns:
+            AgentResult from the agent execution.
+
+        Raises:
+            AdapterUnavailableError: If the codex binary cannot be launched.
+            AgentExecutionError: If the agent fails during execution.
+            AgentTimeoutError: If execution exceeds the timeout.
+            AgentResponseError: If the response is malformed or invalid.
+        """
+        timeout = config.timeout if config and config.timeout else 600
+        partial_result_store = _PartialResultStore()
+        return cast(
+            AgentResult,
+            _run_in_fresh_loop(
+                self.arun,
+                messages,
+                tools,
+                mcp_servers,
+                config,
+                partial_result_store,
+                timeout=timeout,
+                timeout_result=partial_result_store.get,
+            ),
+        )
+
+    async def aclose(self) -> None:
+        """Close underlying resources.
+
+        Each arun() owns its AsyncCodex context and endpoint shim and tears
+        them down before returning, so this is a no-op. Provided for
+        interface consistency with other adapters.
+        """

--- a/src/karenina/adapters/codex_sdk/availability.py
+++ b/src/karenina/adapters/codex_sdk/availability.py
@@ -1,0 +1,55 @@
+"""Availability check for the Codex SDK adapter.
+
+The adapter needs the openai-codex Python package plus a codex CLI binary.
+The package normally pins openai-codex-cli-bin, which bundles the binary,
+so a plain ``pip install openai-codex`` satisfies both. A codex binary on
+PATH also works when the bundled one is absent.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+from karenina.adapters.registry import AdapterAvailability
+
+_INSTALL_HINT = "Install with: pip install 'karenina[codex]' or: pip install openai-codex"
+
+
+def check_codex_available() -> AdapterAvailability:
+    """Check if the Codex SDK and a codex binary are available.
+
+    Returns:
+        AdapterAvailability with status, reason, and a langchain fallback
+        when unavailable.
+    """
+    try:
+        import openai_codex  # noqa: F401
+    except ImportError:
+        return AdapterAvailability(
+            available=False,
+            reason=f"openai-codex package not installed. {_INSTALL_HINT}",
+            fallback_interface="langchain",
+        )
+
+    binary_path: str | None = None
+    try:
+        import codex_cli_bin
+
+        binary_path = str(codex_cli_bin.bundled_codex_path())
+    except (ImportError, OSError):
+        binary_path = shutil.which("codex")
+
+    if binary_path is None:
+        return AdapterAvailability(
+            available=False,
+            reason=(
+                "openai-codex is installed but no codex CLI binary was found "
+                f"(neither codex-cli-bin nor 'codex' on PATH). {_INSTALL_HINT}"
+            ),
+            fallback_interface="langchain",
+        )
+
+    return AdapterAvailability(
+        available=True,
+        reason=f"Codex SDK available with binary at: {binary_path}",
+    )

--- a/src/karenina/adapters/codex_sdk/config_builder.py
+++ b/src/karenina/adapters/codex_sdk/config_builder.py
@@ -1,0 +1,157 @@
+"""Pure configuration builders for the Codex SDK adapter.
+
+These helpers translate karenina's ModelConfig into the configuration
+channels the Codex SDK exposes:
+
+- ``CodexConfig.config_overrides``: tuples of ``key=value`` strings that
+  become ``codex app-server --config key=value`` CLI arguments. Values are
+  parsed as TOML by the codex CLI, so string values need embedded double
+  quotes. This is the channel for custom model provider setup.
+- ``CodexConfig.env``: environment variables for the spawned app-server
+  process. API secrets travel ONLY through this channel, referenced from
+  the provider config via ``env_key``. Secrets must never appear inside a
+  ``--config`` string.
+
+Everything in this module is SDK-free and side-effect free so it can be
+unit tested without the openai-codex package installed.
+
+Custom endpoint note: the codex CLI (0.132.0) only supports
+``wire_api="responses"`` (``wire_api="chat"`` was removed). Stock vLLM
+serves /v1/responses but rejects codex's request shape, so the adapter
+routes custom endpoints through a local rewriting shim (see
+``endpoint_shim.py``). The ``base_url`` passed here is therefore usually
+the shim's localhost URL, not the raw endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from karenina.adapters.agent_runtime import get_agent_runtime_access_mode
+
+if TYPE_CHECKING:
+    from karenina.schemas.config import ModelConfig
+
+# Provider table key used for custom OpenAI-compatible endpoints.
+CODEX_PROVIDER_KEY = "karenina"
+
+# Environment variable that carries the endpoint API key into the codex
+# app-server process. Referenced from the provider config via env_key so the
+# secret itself never appears in a CLI argument.
+CODEX_API_KEY_ENV_VAR = "KARENINA_CODEX_API_KEY"
+
+# Codex turn retries against the model provider. Kept low so endpoint
+# failures surface quickly instead of stalling the verification pipeline.
+CODEX_REQUEST_MAX_RETRIES = 2
+CODEX_STREAM_MAX_RETRIES = 2
+
+# Generous stream idle timeout for slow local models. Codex aborts and
+# re-sends the whole request when a stream stays idle past this limit, so
+# large models that pause between SSE chunks need ample headroom.
+CODEX_STREAM_IDLE_TIMEOUT_MS = 600_000
+
+
+def resolve_model_provider(model_config: ModelConfig) -> str | None:
+    """Return the codex model_provider key for this configuration.
+
+    Returns the custom provider key when a custom endpoint is configured,
+    or None for the native path (codex defaults to its built-in OpenAI
+    provider and authentication).
+    """
+    if model_config.endpoint_base_url:
+        return CODEX_PROVIDER_KEY
+    return None
+
+
+def resolve_sandbox_mode(model_config: ModelConfig) -> str:
+    """Return the codex sandbox mode name for this configuration.
+
+    Maps karenina's agent_runtime access_mode to the codex Sandbox enum
+    member name: read_only access maps to ``read_only``, everything else
+    maps to ``workspace_write``. ``full_access`` is intentionally never
+    produced.
+    """
+    if get_agent_runtime_access_mode(model_config) == "read_only":
+        return "read_only"
+    return "workspace_write"
+
+
+def build_codex_config_overrides(
+    model_config: ModelConfig,
+    base_url: str | None = None,
+) -> tuple[str, ...]:
+    """Build CodexConfig.config_overrides for this model configuration.
+
+    Args:
+        model_config: The karenina model configuration.
+        base_url: The URL codex should send requests to. When the adapter
+            runs its endpoint shim this is the shim's localhost URL.
+            Defaults to ``model_config.endpoint_base_url``.
+
+    Returns:
+        Tuple of ``key=value`` override strings defining a custom model
+        provider, or an empty tuple for the native OpenAI path.
+    """
+    if not model_config.endpoint_base_url:
+        return ()
+
+    effective_base_url = base_url or model_config.endpoint_base_url
+    provider = CODEX_PROVIDER_KEY
+    overrides = [
+        f'model_providers.{provider}.name="Karenina custom endpoint"',
+        f'model_providers.{provider}.base_url="{effective_base_url}"',
+        f'model_providers.{provider}.wire_api="responses"',
+        f"model_providers.{provider}.request_max_retries={CODEX_REQUEST_MAX_RETRIES}",
+        f"model_providers.{provider}.stream_max_retries={CODEX_STREAM_MAX_RETRIES}",
+        f"model_providers.{provider}.stream_idle_timeout_ms={CODEX_STREAM_IDLE_TIMEOUT_MS}",
+    ]
+    if model_config.endpoint_api_key is not None:
+        # Reference the env var by name only. The secret value goes through
+        # build_codex_env(), never through a --config string.
+        overrides.append(f'model_providers.{provider}.env_key="{CODEX_API_KEY_ENV_VAR}"')
+    return tuple(overrides)
+
+
+def build_codex_env(model_config: ModelConfig) -> dict[str, str] | None:
+    """Build the environment dict for the codex app-server process.
+
+    Returns the endpoint API key under CODEX_API_KEY_ENV_VAR when one is
+    configured for a custom endpoint, otherwise None. Keyless endpoints
+    must not set env_key at all: codex would then require the variable and
+    inject an Authorization header.
+    """
+    if model_config.endpoint_base_url and model_config.endpoint_api_key is not None:
+        return {CODEX_API_KEY_ENV_VAR: model_config.endpoint_api_key.get_secret_value()}
+    return None
+
+
+def build_thread_start_kwargs(
+    model_config: ModelConfig,
+    *,
+    base_instructions: str | None,
+    cwd: str,
+) -> dict[str, Any]:
+    """Build SDK-free keyword arguments for AsyncCodex.thread_start().
+
+    The returned dict carries plain values only. The agent adapter maps
+    ``sandbox`` (a mode name from resolve_sandbox_mode) to the SDK Sandbox
+    enum and adds the approval mode at call time.
+
+    Args:
+        model_config: The karenina model configuration.
+        base_instructions: System prompt for the thread, or None.
+        cwd: Working directory for the thread (workspace boundary).
+
+    Returns:
+        Dict with model, model_provider, cwd, sandbox (mode name string),
+        and base_instructions (only when set).
+    """
+    kwargs: dict[str, Any] = {
+        "model": model_config.model_name,
+        "model_provider": resolve_model_provider(model_config),
+        "cwd": cwd,
+        "sandbox": resolve_sandbox_mode(model_config),
+    }
+    if base_instructions:
+        kwargs["base_instructions"] = base_instructions
+    return kwargs

--- a/src/karenina/adapters/codex_sdk/endpoint_shim.py
+++ b/src/karenina/adapters/codex_sdk/endpoint_shim.py
@@ -1,0 +1,289 @@
+"""Local request-rewriting shim for custom OpenAI-compatible endpoints.
+
+The codex CLI (0.132.0) only speaks ``wire_api="responses"`` to custom
+providers, and stock vLLM's /v1/responses implementation rejects codex's
+request shape in three ways (verified live, see
+specs/codex_sdk_findings.md):
+
+1. ``role="developer"`` input messages return 400 "Unexpected message role".
+2. Mapping developer to system trips 400 "System message must be at the
+   beginning" because codex emits several late system blocks.
+3. ``type="reasoning"`` input items, which codex echoes back on follow-up
+   turns, fail vLLM validation with 400.
+
+This module runs a localhost HTTP server on an ephemeral port that forwards
+requests to the real endpoint after rewriting /responses POST bodies:
+developer and system input messages are folded into the top-level
+``instructions`` string and reasoning items are stripped from ``input``.
+All other requests pass through untouched.
+
+Streaming: codex requests SSE (``stream: true``) and aborts streams that
+stay idle past its ``stream_idle_timeout_ms``. The shim therefore relays
+upstream response bodies incrementally as chunked transfer encoding,
+flushing each piece as it arrives, instead of buffering to EOF.
+
+Lifecycle: the agent adapter starts one shim per arun() call and stops it
+in a finally block. A shim is a daemon thread plus a loopback socket, so
+per-run startup cost is negligible and there is no shared state to leak
+across concurrent runs.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import logging
+import threading
+import urllib.error
+import urllib.request
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_HOP_BY_HOP_REQUEST_HEADERS = frozenset({"host", "content-length", "connection"})
+_HOP_BY_HOP_RESPONSE_HEADERS = frozenset({"transfer-encoding", "connection", "content-length"})
+DEFAULT_UPSTREAM_TIMEOUT_SECONDS = 600.0
+_RELAY_CHUNK_SIZE = 8192
+
+
+def _text_of_message_item(item: dict[str, Any]) -> str:
+    """Extract plain text from a Responses API input message item."""
+    content = item.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(part.get("text", "") for part in content if isinstance(part, dict) and "text" in part)
+    return ""
+
+
+def rewrite_responses_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Rewrite a codex Responses API request body for strict endpoints.
+
+    Folds the top-level ``instructions`` plus every developer-role and
+    system-role input message into a single ``instructions`` string (in
+    original order) and drops those messages from ``input``. Also strips
+    ``type="reasoning"`` items, which codex echoes back on follow-up turns
+    and strict endpoints cannot validate.
+
+    Args:
+        payload: Parsed JSON request body.
+
+    Returns:
+        The rewritten payload. The input dict is not mutated.
+    """
+    result = dict(payload)
+    system_parts: list[str] = []
+    instructions = result.get("instructions")
+    if instructions:
+        system_parts.append(str(instructions))
+
+    kept: list[Any] = []
+    for item in result.get("input") or []:
+        if isinstance(item, dict) and item.get("type") == "message" and item.get("role") in ("developer", "system"):
+            system_parts.append(_text_of_message_item(item))
+            continue
+        if isinstance(item, dict) and item.get("type") == "reasoning":
+            continue
+        kept.append(item)
+
+    if system_parts:
+        result["instructions"] = "\n\n".join(part for part in system_parts if part)
+    result["input"] = kept
+    return result
+
+
+class _ShimRequestHandler(http.server.BaseHTTPRequestHandler):
+    """Forward one request to the upstream endpoint, rewriting if needed."""
+
+    # HTTP/1.1 is required for the chunked transfer encoding used to relay
+    # streaming (SSE) upstream bodies incrementally.
+    protocol_version = "HTTP/1.1"
+
+    # Set by EndpointShim when building the server.
+    upstream_base_url: str = ""
+    upstream_timeout: float = DEFAULT_UPSTREAM_TIMEOUT_SECONDS
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        """Route handler logging through the module logger at debug level."""
+        logger.debug("codex endpoint shim: " + format, *args)
+
+    def _maybe_rewrite(self, body: bytes) -> bytes:
+        if "/responses" not in self.path or not body:
+            return body
+        try:
+            payload = json.loads(body)
+        except (ValueError, UnicodeDecodeError):
+            return body
+        if not isinstance(payload, dict):
+            return body
+        return json.dumps(rewrite_responses_payload(payload)).encode()
+
+    def _upstream_url(self) -> str:
+        # The shim serves under /v1/... and maps /v1/<rest> onto the
+        # configured base URL (which itself usually ends in /v1).
+        path = self.path
+        if path.startswith("/v1/"):
+            path = path[len("/v1") :]
+        elif path == "/v1":
+            path = ""
+        return self.upstream_base_url.rstrip("/") + path
+
+    def _send_buffered_response(self, status: int, headers: Any, data: bytes) -> None:
+        """Send a fully buffered response with an explicit Content-Length."""
+        self.send_response(status)
+        for key, value in headers.items():
+            if key.lower() not in _HOP_BY_HOP_RESPONSE_HEADERS:
+                self.send_header(key, value)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _relay_streaming_response(self, response: Any) -> None:
+        """Relay the upstream body incrementally as chunked transfer encoding.
+
+        Codex streams SSE and enforces a stream idle timeout, so the body
+        must reach it as upstream produces it. ``read1`` returns whatever
+        the current upstream chunk holds without blocking for a full
+        buffer, and each piece is flushed immediately in chunked framing.
+        """
+        self.send_response(response.status)
+        for key, value in response.headers.items():
+            if key.lower() not in _HOP_BY_HOP_RESPONSE_HEADERS:
+                self.send_header(key, value)
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+
+        read_available = getattr(response, "read1", response.read)
+        while True:
+            chunk = read_available(_RELAY_CHUNK_SIZE)
+            if not chunk:
+                break
+            self.wfile.write(f"{len(chunk):X}\r\n".encode() + chunk + b"\r\n")
+            self.wfile.flush()
+        self.wfile.write(b"0\r\n\r\n")
+        self.wfile.flush()
+
+    def _proxy(self, method: str) -> None:
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length) if length else b""
+        body = self._maybe_rewrite(body)
+
+        request = urllib.request.Request(  # noqa: S310
+            self._upstream_url(),
+            data=body if body else None,
+            method=method,
+        )
+        for key, value in self.headers.items():
+            if key.lower() not in _HOP_BY_HOP_REQUEST_HEADERS:
+                request.add_header(key, value)
+
+        try:
+            with urllib.request.urlopen(request, timeout=self.upstream_timeout) as response:  # noqa: S310
+                self._relay_streaming_response(response)
+        except urllib.error.HTTPError as e:
+            data = e.read()
+            logger.debug(
+                "codex endpoint shim: upstream returned HTTP %s for %s: %s",
+                e.code,
+                self.path,
+                data[:500].decode(errors="replace"),
+            )
+            self._send_buffered_response(e.code, e.headers, data)
+        except OSError as e:
+            logger.warning("codex endpoint shim: upstream request failed for %s: %s", self.path, e)
+            message = json.dumps({"error": {"message": f"karenina codex shim upstream failure: {e}"}}).encode()
+            self.send_response(502)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(message)))
+            self.end_headers()
+            self.wfile.write(message)
+
+    def do_GET(self) -> None:  # noqa: N802
+        """Proxy a GET request upstream."""
+        self._proxy("GET")
+
+    def do_POST(self) -> None:  # noqa: N802
+        """Proxy a POST request upstream."""
+        self._proxy("POST")
+
+
+class EndpointShim:
+    """Localhost rewriting proxy in front of a custom OpenAI-compatible endpoint.
+
+    Example:
+        >>> shim = EndpointShim("http://my-vllm-host:8000/v1")
+        >>> shim.start()
+        >>> shim.base_url
+        'http://127.0.0.1:54321/v1'
+        >>> shim.stop()
+    """
+
+    def __init__(
+        self,
+        upstream_base_url: str,
+        upstream_timeout: float = DEFAULT_UPSTREAM_TIMEOUT_SECONDS,
+    ) -> None:
+        """Create a shim for the given upstream base URL.
+
+        Args:
+            upstream_base_url: The real endpoint base URL, typically ending
+                in /v1 (e.g. ``http://host:8000/v1``).
+            upstream_timeout: Per-request socket timeout (seconds) for the
+                upstream connection. Applies per socket operation, so a
+                streaming response only times out when it stays idle this
+                long. The adapter widens this when AgentConfig.timeout is
+                larger than the default.
+        """
+        self._upstream_base_url = upstream_base_url
+        self._upstream_timeout = upstream_timeout
+        self._server: http.server.ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def base_url(self) -> str:
+        """The localhost base URL codex should be pointed at."""
+        if self._server is None:
+            raise RuntimeError("EndpointShim is not running. Call start() first.")
+        port = self._server.server_address[1]
+        return f"http://127.0.0.1:{port}/v1"
+
+    def start(self) -> None:
+        """Bind an ephemeral loopback port and start serving in a daemon thread."""
+        if self._server is not None:
+            return
+        handler = type(
+            "BoundShimRequestHandler",
+            (_ShimRequestHandler,),
+            {
+                "upstream_base_url": self._upstream_base_url,
+                "upstream_timeout": self._upstream_timeout,
+            },
+        )
+        self._server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="karenina-codex-endpoint-shim",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.debug("codex endpoint shim listening on %s for upstream %s", self.base_url, self._upstream_base_url)
+
+    def stop(self) -> None:
+        """Shut down the server and join the serving thread. Safe to call twice."""
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        self._server = None
+        self._thread = None
+
+    def __enter__(self) -> EndpointShim:
+        """Start the shim on context entry."""
+        self.start()
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        """Stop the shim on context exit."""
+        self.stop()

--- a/src/karenina/adapters/codex_sdk/errors.py
+++ b/src/karenina/adapters/codex_sdk/errors.py
@@ -1,0 +1,131 @@
+"""Error wrapping for the Codex SDK adapter.
+
+Maps openai-codex exceptions onto karenina's port error hierarchy. All SDK
+exception detection uses type-name strings so this module imports and works
+without the openai-codex package installed.
+
+SDK exception mapping:
+    FileNotFoundError (binary spawn)      -> AdapterUnavailableError
+    TransportClosedError                  -> AgentExecutionError
+    ServerBusyError / RetryLimitExceeded  -> AgentExecutionError (transient)
+    JSON-RPC errors (ParseError, Invalid* ,
+    MethodNotFoundError, InternalRpcError,
+    CodexRpcError, JsonRpcError)          -> AgentResponseError
+    TimeoutError / asyncio.TimeoutError   -> AgentTimeoutError
+    CodexError / anything else            -> AgentExecutionError
+
+Codex has no max_turns equivalent, so the limit_reached flag is best
+effort: it is set only when the error message mentions a turn, recursion,
+or context limit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from karenina.ports.errors import (
+    AdapterUnavailableError,
+    AgentExecutionError,
+    AgentResponseError,
+    AgentTimeoutError,
+    PortError,
+)
+
+logger = logging.getLogger(__name__)
+
+_TRANSIENT_ERROR_TYPES = frozenset({"ServerBusyError", "RetryLimitExceededError"})
+_JSONRPC_ERROR_TYPES = frozenset(
+    {
+        "JsonRpcError",
+        "CodexRpcError",
+        "ParseError",
+        "InvalidRequestError",
+        "MethodNotFoundError",
+        "InvalidParamsError",
+        "InternalRpcError",
+    }
+)
+_LIMIT_HINTS = ("recursion", "turn limit", "max_turns", "context window", "context limit", "token limit")
+
+
+def _is_limit_message(message: str) -> bool:
+    lowered = message.lower()
+    return any(hint in lowered for hint in _LIMIT_HINTS)
+
+
+def wrap_codex_error(e: Exception) -> tuple[PortError, bool]:
+    """Wrap a Codex SDK exception into a karenina port error.
+
+    Args:
+        e: The exception raised while driving the codex app-server.
+
+    Returns:
+        Tuple of (mapped_error, limit_reached). The limit_reached flag is
+        True when the message indicates a turn, recursion, or context
+        limit. Codex exposes no structured limit signal, so this is a
+        best-effort message check.
+
+    Example:
+        >>> try:
+        ...     result = await thread.run(prompt)
+        ... except Exception as e:
+        ...     mapped, was_limit = wrap_codex_error(e)
+        ...     raise mapped from e
+    """
+    exc_type_name = type(e).__name__
+    message = str(e)
+
+    if isinstance(e, FileNotFoundError):
+        return (
+            AdapterUnavailableError(
+                message=(
+                    f"Codex CLI binary could not be launched: {e}. "
+                    "Install the SDK with its bundled binary: pip install openai-codex"
+                ),
+                reason="codex binary not found",
+                fallback_interface="langchain",
+            ),
+            False,
+        )
+
+    if isinstance(e, TimeoutError | asyncio.TimeoutError):
+        return AgentTimeoutError(f"Codex agent execution timed out: {e}"), False
+
+    if exc_type_name in _TRANSIENT_ERROR_TYPES:
+        return (
+            AgentExecutionError(
+                message=f"Codex model provider is overloaded (transient, retryable): {e}",
+                stderr=message or None,
+            ),
+            False,
+        )
+
+    if exc_type_name == "TransportClosedError":
+        return (
+            AgentExecutionError(
+                message=f"Codex app-server transport closed unexpectedly: {e}",
+                stderr=message or None,
+            ),
+            False,
+        )
+
+    if exc_type_name in _JSONRPC_ERROR_TYPES:
+        return (
+            AgentResponseError(message=f"Codex app-server JSON-RPC error ({exc_type_name}): {e}"),
+            False,
+        )
+
+    if _is_limit_message(message):
+        return (
+            AgentExecutionError(message=f"Codex agent hit a limit: {e}", limit_reached=True),
+            True,
+        )
+
+    return (
+        AgentExecutionError(
+            message=f"Codex SDK error ({exc_type_name}): {e}",
+            stderr=message or None,
+        ),
+        False,
+    )

--- a/src/karenina/adapters/codex_sdk/mcp.py
+++ b/src/karenina/adapters/codex_sdk/mcp.py
@@ -1,0 +1,44 @@
+"""MCP configuration conversion for the Codex SDK adapter (stub).
+
+Codex configures MCP servers through its CLI config schema (a top-level
+``mcp_servers`` table reached via ``--config`` overrides or the per-thread
+``config`` dict), not through a per-call API. Wiring karenina's
+MCPServerConfig into that channel is planned but not implemented yet, so
+this module is a converter stub: it warns and skips.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from karenina.ports import MCPServerConfig
+
+logger = logging.getLogger(__name__)
+
+
+def convert_mcp_to_codex_config(
+    mcp_servers: dict[str, MCPServerConfig] | None,
+) -> dict[str, Any]:
+    """Convert karenina MCP server configs to a codex config overlay.
+
+    Not implemented yet. Codex expects MCP servers under a ``mcp_servers``
+    config table (keys such as command, args, env, url), reachable through
+    ``CodexConfig.config_overrides`` or ``thread_start(config=...)``. Until
+    that mapping is validated end to end, requested MCP servers are
+    skipped with a warning rather than silently misconfigured.
+
+    Args:
+        mcp_servers: Karenina MCP server configuration, or None.
+
+    Returns:
+        Empty dict (no codex config overlay is produced).
+    """
+    if mcp_servers:
+        logger.warning(
+            "MCP servers are not yet supported by the codex_sdk adapter. Skipping %d configured server(s): %s",
+            len(mcp_servers),
+            ", ".join(sorted(mcp_servers)),
+        )
+    return {}

--- a/src/karenina/adapters/codex_sdk/messages.py
+++ b/src/karenina/adapters/codex_sdk/messages.py
@@ -1,0 +1,363 @@
+"""Codex SDK message converter.
+
+Converts between karenina's unified Message types and Codex SDK thread
+items. Like the Claude Agent SDK, codex takes a string prompt per turn and
+a thread-level ``base_instructions`` system prompt rather than a message
+array.
+
+Output conversion walks ``TurnResult.items`` (ThreadItem objects). Items
+are discriminated by their ``type`` string rather than isinstance checks,
+so this module imports cleanly and works on simple stand-ins without the
+openai-codex package installed.
+
+Item mapping:
+    userMessage      -> Message.user
+    reasoning        -> assistant Message with ThinkingContent
+    agentMessage     -> assistant Message with TextContent
+    commandExecution -> assistant ToolUseContent(name="shell") plus a
+                        paired Message.tool_result sharing the item id,
+                        is_error from the exit code
+    mcpToolCall      -> ToolUseContent(name="mcp__<server>__<tool>") plus
+                        paired tool result (is_error from error/status)
+    fileChange       -> ToolUseContent(name="apply_patch") plus paired
+                        tool result summarizing the changes
+    webSearch        -> ToolUseContent(name="web_search") plus paired
+                        tool result (codex does not surface result text)
+
+Unknown item types are skipped with a debug log.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from karenina.ports import (
+    Message,
+    Role,
+    TextContent,
+    ThinkingContent,
+    ToolResultContent,
+    ToolUseContent,
+)
+
+logger = logging.getLogger(__name__)
+
+SHELL_TOOL_NAME = "shell"
+APPLY_PATCH_TOOL_NAME = "apply_patch"
+WEB_SEARCH_TOOL_NAME = "web_search"
+
+# Per-message caps for serialized multi-turn history. Long shell outputs
+# replayed verbatim every turn would dominate the prompt, so tool results
+# and tool arguments are truncated with an explicit marker.
+HISTORY_TOOL_RESULT_MAX_CHARS = 2000
+HISTORY_TOOL_ARGS_MAX_CHARS = 500
+
+_FAILED_STATUSES = frozenset({"failed", "declined"})
+
+
+def _truncate_for_history(text: str, max_chars: int) -> str:
+    """Truncate history content to max_chars with an explicit marker."""
+    if len(text) <= max_chars:
+        return text
+    return f"{text[:max_chars]}... [truncated, {len(text)} chars total]"
+
+
+def unwrap_item(item: Any) -> Any:
+    """Unwrap a ThreadItem RootModel to its inner typed item."""
+    return item.root if hasattr(item, "root") else item
+
+
+def item_type(item: Any) -> str | None:
+    """Return the ``type`` discriminator string of a thread item."""
+    inner = unwrap_item(item)
+    raw_type = getattr(inner, "type", None)
+    if raw_type is None:
+        return None
+    return str(getattr(raw_type, "value", raw_type))
+
+
+def _enum_value(value: Any) -> Any:
+    """Return the wire value for enum-like objects, passthrough otherwise."""
+    return getattr(value, "value", value)
+
+
+def _stringify(value: Any) -> str:
+    """Best-effort string rendering for tool results and arguments."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(by_alias=True, exclude_none=True, mode="json")
+    try:
+        return json.dumps(value, default=str)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _user_message_text(inner: Any) -> str:
+    """Extract text from a userMessage item's content list."""
+    parts: list[str] = []
+    for entry in getattr(inner, "content", None) or []:
+        text = getattr(entry, "text", None)
+        if text is None and isinstance(entry, dict):
+            text = entry.get("text")
+        if text:
+            parts.append(str(text))
+    return "\n".join(parts)
+
+
+class CodexMessageConverter:
+    """Convert between unified Message and Codex SDK thread items.
+
+    Input conversion: SYSTEM messages are extracted separately for
+    ``thread_start(base_instructions=...)``. For single-turn input (no
+    assistant or tool messages) USER messages are joined into a plain
+    prompt string, matching the Claude SDK converter. When the message
+    list carries multi-turn history (scenario re-invocation passes the
+    full prior conversation each turn, and codex has no session resume),
+    prior turns are serialized into a role-labeled transcript ending with
+    the latest user message as the current question.
+
+    Example:
+        >>> converter = CodexMessageConverter()
+        >>> messages = [Message.system("Be helpful"), Message.user("Hello")]
+        >>> converter.to_prompt_string(messages)
+        'Hello'
+        >>> converter.extract_system_prompt(messages)
+        'Be helpful'
+    """
+
+    def to_prompt_string(self, messages: list[Message]) -> str:
+        """Build the turn input string for ``thread.turn()``.
+
+        Single-turn input (no ASSISTANT or TOOL messages) joins USER
+        messages with blank lines, byte-identical to the previous
+        behavior. Multi-turn history is rendered as a role-labeled
+        transcript (see _render_history_transcript).
+
+        Args:
+            messages: List of unified Message objects.
+
+        Returns:
+            Prompt string suitable for ``thread.turn()``.
+        """
+        has_history = any(m.role in (Role.ASSISTANT, Role.TOOL) for m in messages)
+        if not has_history:
+            user_parts = [m.text for m in messages if m.role == Role.USER]
+            return "\n\n".join(user_parts) if user_parts else ""
+        return self._render_history_transcript(messages)
+
+    def _render_history_transcript(self, messages: list[Message]) -> str:
+        """Serialize multi-turn history into a role-labeled transcript.
+
+        Prior turns appear under a "Conversation so far:" header with
+        ``User:`` and ``Assistant:`` labels. Tool activity is summarized
+        as "Assistant ran tool <name> with arguments: ..." and
+        "Tool result (<id>): ..." lines. ThinkingContent is skipped
+        because internal reasoning should not be replayed as context.
+        Tool arguments and tool result content are truncated per message
+        (HISTORY_TOOL_ARGS_MAX_CHARS / HISTORY_TOOL_RESULT_MAX_CHARS)
+        so long shell outputs in history cannot blow up the prompt. The
+        latest USER message is rendered last under "Current user
+        message:" as the question to answer now.
+
+        Args:
+            messages: Unified messages including prior-turn history.
+
+        Returns:
+            Transcript string for the codex turn input.
+        """
+        non_system = [m for m in messages if m.role != Role.SYSTEM]
+
+        # The trailing USER message is the current question. When the list
+        # does not end with a user message (unusual, but possible when a
+        # caller passes raw history), everything renders as history.
+        current: Message | None = None
+        history = non_system
+        if non_system and non_system[-1].role == Role.USER:
+            current = non_system[-1]
+            history = non_system[:-1]
+
+        lines: list[str] = ["Conversation so far:", ""]
+        for message in history:
+            if message.role == Role.USER:
+                lines.append(f"User: {message.text}")
+                lines.append("")
+            elif message.role == Role.ASSISTANT:
+                emitted = False
+                if message.text:
+                    lines.append(f"Assistant: {message.text}")
+                    emitted = True
+                for tool_call in message.tool_calls:
+                    args = _truncate_for_history(_stringify(tool_call.input), HISTORY_TOOL_ARGS_MAX_CHARS)
+                    lines.append(f"Assistant ran tool {tool_call.name} with arguments: {args}")
+                    emitted = True
+                if emitted:
+                    lines.append("")
+            elif message.role == Role.TOOL:
+                emitted = False
+                for block in message.content:
+                    if isinstance(block, ToolResultContent):
+                        content = _truncate_for_history(block.content, HISTORY_TOOL_RESULT_MAX_CHARS)
+                        prefix = "Tool result (error)" if block.is_error else "Tool result"
+                        lines.append(f"{prefix} ({block.tool_use_id}): {content}")
+                        emitted = True
+                if emitted:
+                    lines.append("")
+
+        if current is not None:
+            lines.append("Current user message:")
+            lines.append("")
+            lines.append(current.text)
+
+        return "\n".join(lines).strip()
+
+    def extract_system_prompt(self, messages: list[Message]) -> str | None:
+        """Extract SYSTEM messages for ``thread_start(base_instructions=...)``.
+
+        Args:
+            messages: List of unified Message objects.
+
+        Returns:
+            System prompt string, or None when no system messages exist.
+        """
+        system_msgs = [m for m in messages if m.role == Role.SYSTEM]
+        if system_msgs:
+            return "\n\n".join(m.text for m in system_msgs)
+        return None
+
+    def from_provider(self, items: list[Any]) -> list[Message]:
+        """Convert Codex thread items to unified Messages.
+
+        Args:
+            items: ``TurnResult.items`` entries (ThreadItem or inner items).
+
+        Returns:
+            List of unified Message objects in item order. Tool-style items
+            expand to an assistant tool-use message plus a paired tool
+            result message sharing the item id.
+        """
+        result: list[Message] = []
+        for item in items:
+            result.extend(self._convert_item(item))
+        return result
+
+    def _convert_item(self, item: Any) -> list[Message]:
+        """Convert one thread item to zero or more unified Messages."""
+        inner = unwrap_item(item)
+        kind = item_type(item)
+
+        if kind == "userMessage":
+            text = _user_message_text(inner)
+            return [Message.user(text)] if text else []
+
+        if kind == "reasoning":
+            thinking = "\n\n".join(getattr(inner, "content", None) or [])
+            if not thinking:
+                thinking = "\n\n".join(getattr(inner, "summary", None) or [])
+            if not thinking:
+                return []
+            return [Message(role=Role.ASSISTANT, content=[ThinkingContent(thinking=thinking)])]
+
+        if kind == "agentMessage":
+            text = getattr(inner, "text", "") or ""
+            return [Message(role=Role.ASSISTANT, content=[TextContent(text=text)])] if text else []
+
+        if kind == "commandExecution":
+            return self._convert_command_execution(inner)
+
+        if kind == "mcpToolCall":
+            return self._convert_mcp_tool_call(inner)
+
+        if kind == "fileChange":
+            return self._convert_file_change(inner)
+
+        if kind == "webSearch":
+            return self._convert_web_search(inner)
+
+        logger.debug("Skipping unsupported codex thread item type: %s", kind)
+        return []
+
+    def _tool_pair(
+        self,
+        *,
+        item_id: str,
+        name: str,
+        tool_input: dict[str, Any],
+        result_content: str,
+        is_error: bool,
+    ) -> list[Message]:
+        """Build the assistant tool-use plus tool-result message pair."""
+        return [
+            Message(
+                role=Role.ASSISTANT,
+                content=[ToolUseContent(id=item_id, name=name, input=tool_input)],
+            ),
+            Message.tool_result(tool_use_id=item_id, content=result_content, is_error=is_error),
+        ]
+
+    def _convert_command_execution(self, inner: Any) -> list[Message]:
+        exit_code = getattr(inner, "exit_code", None)
+        status = _enum_value(getattr(inner, "status", None))
+        is_error = (exit_code is not None and exit_code != 0) or status in _FAILED_STATUSES
+        return self._tool_pair(
+            item_id=str(getattr(inner, "id", "")),
+            name=SHELL_TOOL_NAME,
+            tool_input={"command": getattr(inner, "command", "") or ""},
+            result_content=getattr(inner, "aggregated_output", None) or "",
+            is_error=is_error,
+        )
+
+    def _convert_mcp_tool_call(self, inner: Any) -> list[Message]:
+        server = getattr(inner, "server", "") or "unknown"
+        tool = getattr(inner, "tool", "") or "unknown"
+        arguments = getattr(inner, "arguments", None)
+        tool_input = arguments if isinstance(arguments, dict) else {"arguments": _stringify(arguments)}
+
+        error = getattr(inner, "error", None)
+        status = _enum_value(getattr(inner, "status", None))
+        is_error = error is not None or status in _FAILED_STATUSES
+        if error is not None:
+            result_content = getattr(error, "message", None) or _stringify(error)
+        else:
+            result_content = _stringify(getattr(inner, "result", None))
+
+        return self._tool_pair(
+            item_id=str(getattr(inner, "id", "")),
+            name=f"mcp__{server}__{tool}",
+            tool_input=tool_input,
+            result_content=result_content,
+            is_error=is_error,
+        )
+
+    def _convert_file_change(self, inner: Any) -> list[Message]:
+        changes = getattr(inner, "changes", None) or []
+        change_summaries = [
+            {
+                "path": getattr(change, "path", "") or "",
+                "kind": str(_enum_value(getattr(change, "kind", "")) or ""),
+            }
+            for change in changes
+        ]
+        status = _enum_value(getattr(inner, "status", None))
+        result_lines = [f"{entry['kind']} {entry['path']}".strip() for entry in change_summaries]
+        result_content = "\n".join(line for line in result_lines if line) or f"status: {status}"
+        return self._tool_pair(
+            item_id=str(getattr(inner, "id", "")),
+            name=APPLY_PATCH_TOOL_NAME,
+            tool_input={"changes": change_summaries},
+            result_content=result_content,
+            is_error=status in _FAILED_STATUSES,
+        )
+
+    def _convert_web_search(self, inner: Any) -> list[Message]:
+        return self._tool_pair(
+            item_id=str(getattr(inner, "id", "")),
+            name=WEB_SEARCH_TOOL_NAME,
+            tool_input={"query": getattr(inner, "query", "") or ""},
+            result_content="",
+            is_error=False,
+        )

--- a/src/karenina/adapters/codex_sdk/registration.py
+++ b/src/karenina/adapters/codex_sdk/registration.py
@@ -1,0 +1,69 @@
+"""Registration module for the Codex SDK adapter.
+
+Registers the codex_sdk interface with the AdapterRegistry. The adapter is
+agent-only: LLM and parser duties fall back to the langchain interface.
+The runtime profile registers codex capabilities with the shared agent
+runtime helpers so pipeline prompts report the correct feature set.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from karenina.adapters.agent_runtime import AgentRuntimeProfile, get_agent_runtime_access_mode
+from karenina.adapters.registry import AdapterAvailability, AdapterRegistry, AdapterSpec
+from karenina.ports.capabilities import PortCapabilities
+
+if TYPE_CHECKING:
+    from karenina.ports import AgentPort
+    from karenina.schemas.config import ModelConfig
+
+
+def _check_availability() -> AdapterAvailability:
+    """Check availability via the dedicated module."""
+    from karenina.adapters.codex_sdk.availability import check_codex_available
+
+    return check_codex_available()
+
+
+def _create_agent(config: ModelConfig) -> AgentPort:
+    """Factory function to create the Codex SDK agent adapter."""
+    from karenina.adapters.codex_sdk.agent import CodexSDKAgentAdapter
+
+    return CodexSDKAgentAdapter(config)
+
+
+def _codex_capabilities(model_config: ModelConfig) -> PortCapabilities:
+    """Capabilities implied by the codex runtime for this model config.
+
+    Codex always executes inside its own OS-level sandbox (read_only or
+    workspace_write), so uses_sandboxed_execution is unconditionally True.
+    """
+    access_mode = get_agent_runtime_access_mode(model_config)
+    return PortCapabilities(
+        supports_system_prompt=True,
+        supports_file_tools=True,
+        supports_code_execution=access_mode != "read_only",
+        uses_sandboxed_execution=True,
+    )
+
+
+_codex_sdk_spec = AdapterSpec(
+    interface="codex_sdk",
+    description="OpenAI Codex SDK for natively agentic execution",
+    agent_factory=_create_agent,
+    llm_factory=None,
+    parser_factory=None,
+    availability_checker=_check_availability,
+    fallback_interface="langchain",
+    routes_to=None,
+    runtime_profile=AgentRuntimeProfile(capabilities=_codex_capabilities),
+    # MCP wiring is a warn-and-skip stub (see mcp.py). Flip this to True
+    # when the mcp_servers config-table mapping lands and is validated.
+    supports_mcp=False,
+    supports_tools=True,
+    agent_tier="deep_agent",
+    requires_provider=False,
+)
+
+AdapterRegistry.register(_codex_sdk_spec)

--- a/src/karenina/adapters/codex_sdk/trace.py
+++ b/src/karenina/adapters/codex_sdk/trace.py
@@ -1,0 +1,145 @@
+"""Trace conversion for Codex SDK thread items.
+
+Converts ``TurnResult.items`` into karenina's two trace formats:
+
+- ``codex_items_to_raw_trace``: the canonical delimited string format shared
+  by the langchain, claude_agent_sdk, and langchain_deep_agents adapters
+  (``--- AI Message ---``, inline ``Tool Calls:`` blocks,
+  ``--- Tool Message (call_id: ...) ---``, ``--- Thinking ---``).
+- ``codex_items_to_trace_messages``: the structured list[dict] format
+  consumed by the frontend TraceMessage component.
+
+Both formats are derived from the unified Message conversion in
+``messages.py`` so the two stay consistent by construction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from karenina.ports import Role, ThinkingContent, ToolResultContent
+
+from .messages import CodexMessageConverter
+
+_converter = CodexMessageConverter()
+
+
+def codex_items_to_raw_trace(
+    items: list[Any],
+    include_user_messages: bool = False,
+) -> str:
+    """Convert Codex thread items to the canonical raw_trace string.
+
+    Args:
+        items: ``TurnResult.items`` entries.
+        include_user_messages: If True, include user messages in the trace.
+            Defaults to False to match the other agent adapters.
+
+    Returns:
+        Formatted trace string with ``---`` delimiters.
+
+    Example:
+        >>> trace = codex_items_to_raw_trace(turn_result.items)
+        >>> print(trace)
+        --- Thinking ---
+        The user wants a file created...
+        <BLANKLINE>
+        --- AI Message ---
+        <BLANKLINE>
+        Tool Calls:
+          shell (call_item_1)
+           Call ID: item_1
+           Args: {'command': "echo hi > hello.txt"}
+        <BLANKLINE>
+        --- Tool Message (call_id: item_1) ---
+        hi
+    """
+    parts: list[str] = []
+    for message in _converter.from_provider(items):
+        if message.role == Role.SYSTEM:
+            continue
+
+        if message.role == Role.USER:
+            if include_user_messages and message.text:
+                parts.append(f"--- Human Message ---\n{message.text}")
+            continue
+
+        if message.role == Role.ASSISTANT:
+            thinking = "\n".join(c.thinking for c in message.content if isinstance(c, ThinkingContent))
+            if thinking:
+                parts.append(f"--- Thinking ---\n{thinking}")
+
+            text = message.text
+            tool_calls = message.tool_calls
+            if text or tool_calls:
+                content_parts: list[str] = []
+                if text:
+                    content_parts.append(text)
+                if tool_calls:
+                    content_parts.append("\nTool Calls:")
+                    for tc in tool_calls:
+                        content_parts.append(f"  {tc.name} (call_{tc.id})")
+                        content_parts.append(f"   Call ID: {tc.id}")
+                        if tc.input:
+                            content_parts.append(f"   Args: {tc.input}")
+                parts.append("--- AI Message ---\n" + "\n".join(content_parts))
+            continue
+
+        if message.role == Role.TOOL:
+            for block in message.content:
+                if isinstance(block, ToolResultContent):
+                    content = block.content
+                    if block.is_error:
+                        content = f"[ERROR] {content}"
+                    parts.append(f"--- Tool Message (call_id: {block.tool_use_id}) ---\n{content}")
+
+    return "\n\n".join(parts)
+
+
+def codex_items_to_trace_messages(
+    items: list[Any],
+    include_user_messages: bool = False,
+) -> list[dict[str, Any]]:
+    """Convert Codex thread items to the structured TraceMessage list.
+
+    Args:
+        items: ``TurnResult.items`` entries.
+        include_user_messages: If True, include user messages.
+
+    Returns:
+        List of TraceMessage dicts (role, content, block_index, plus
+        optional tool_calls, tool_result, thinking) matching the format
+        produced by the other agent adapters.
+    """
+    result: list[dict[str, Any]] = []
+    block_index = 0
+    for message in _converter.from_provider(items):
+        if message.role == Role.SYSTEM:
+            continue
+        if message.role == Role.USER and not include_user_messages:
+            continue
+        entry = message.to_dict()
+        entry["block_index"] = block_index
+        result.append(entry)
+        block_index += 1
+    return result
+
+
+def extract_final_response(items: list[Any]) -> str | None:
+    """Reconstruct the final assistant response from thread items.
+
+    Codex's own ``TurnResult.final_response`` can be empty even on success
+    (observed against vLLM, see specs/codex_sdk_findings.md), so this
+    helper walks items in reverse and returns the last non-empty
+    agentMessage text.
+
+    Args:
+        items: ``TurnResult.items`` entries.
+
+    Returns:
+        The last non-empty assistant text, or None.
+    """
+    for message in reversed(_converter.from_provider(items)):
+        if message.role == Role.ASSISTANT and message.text:
+            return message.text
+    return None

--- a/src/karenina/adapters/codex_sdk/usage.py
+++ b/src/karenina/adapters/codex_sdk/usage.py
@@ -1,0 +1,76 @@
+"""Usage extraction for Codex SDK turn results.
+
+Codex reports token usage through ``ThreadTokenUsage`` objects carried on
+``TurnResult.usage`` and on ``thread/tokenUsage/updated`` notifications.
+Each holds two ``TokenUsageBreakdown`` records (``last`` for the most
+recent model call, ``total`` for the cumulative turn) with fields
+``cached_input_tokens``, ``input_tokens``, ``output_tokens``,
+``reasoning_output_tokens``, and ``total_tokens``.
+
+Karenina maps the cumulative ``total`` breakdown. Cost is always None:
+custom endpoints have no price table and codex does not report cost.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from karenina.ports import UsageMetadata
+
+logger = logging.getLogger(__name__)
+
+
+def _breakdown_int(breakdown: Any, field: str) -> int:
+    """Read an int field from a TokenUsageBreakdown defensively."""
+    value = getattr(breakdown, field, None)
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def extract_codex_usage(
+    usage: Any,
+    model: str | None = None,
+) -> UsageMetadata:
+    """Extract UsageMetadata from a Codex ThreadTokenUsage object.
+
+    Uses the cumulative ``total`` breakdown when present, falling back to
+    ``last``. Returns zeroed usage when nothing was reported (for example
+    on a timeout before the first ``thread/tokenUsage/updated``
+    notification arrived).
+
+    Args:
+        usage: A ThreadTokenUsage (from ``TurnResult.usage`` or a token
+            usage notification), or None.
+        model: Optional model name recorded on the result.
+
+    Returns:
+        UsageMetadata with token counts. ``cached_input_tokens`` maps to
+        ``cache_read_tokens``. ``cost_usd`` is always None.
+    """
+    if usage is None:
+        return UsageMetadata(model=model)
+
+    breakdown = getattr(usage, "total", None) or getattr(usage, "last", None)
+    if breakdown is None:
+        # Tolerate being handed a bare breakdown instead of the wrapper.
+        breakdown = usage
+
+    input_tokens = _breakdown_int(breakdown, "input_tokens")
+    output_tokens = _breakdown_int(breakdown, "output_tokens")
+    total_tokens = _breakdown_int(breakdown, "total_tokens") or (input_tokens + output_tokens)
+    cached_input = getattr(breakdown, "cached_input_tokens", None)
+
+    return UsageMetadata(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        cost_usd=None,
+        cache_read_tokens=int(cached_input) if cached_input is not None else None,
+        cache_creation_tokens=None,
+        model=model,
+    )

--- a/src/karenina/adapters/registry.py
+++ b/src/karenina/adapters/registry.py
@@ -527,6 +527,11 @@ class AdapterRegistry:
         except ImportError:
             logger.debug("TaskEval registration module not available")
 
+        try:
+            from karenina.adapters.codex_sdk import registration as _codex  # noqa: F401
+        except ImportError:
+            logger.debug("Codex SDK registration module not available")
+
     @classmethod
     def _discover_entry_points(cls) -> None:
         """Discover and load external adapters via ``karenina.adapters`` entry points.

--- a/tests/live/test_codex_sdk_live.py
+++ b/tests/live/test_codex_sdk_live.py
@@ -1,0 +1,374 @@
+"""Live acceptance tests for the codex_sdk agent adapter.
+
+Runs against a real vLLM endpoint through the full adapter stack: per-run
+endpoint shim, codex app-server subprocess, and the live model. Opt-in via
+``KARENINA_LIVE_TESTS=1``. Endpoint and model are configurable so the suite
+stays portable:
+
+    KARENINA_CODEX_LIVE_BASE_URL: OpenAI-compatible base URL
+        (default http://hl-codon-gpu-020:8000/v1)
+    KARENINA_CODEX_LIVE_MODEL: served model name
+        (default qwen3.5-122b-a10b)
+
+Coverage:
+    1. End-to-end shell run with canonical trace and usage assertions.
+    2. Short-timeout run against an in-flight shell command, confirming
+       interrupt plus partial-trace salvage instead of an exception or hang.
+    3. Two-turn scenario through the real scenario machinery, proving the
+       serialized conversation history reaches the model.
+    4. Concurrency: 4 parallel arun calls (asyncio.gather) and 4 parallel
+       run() calls (ThreadPoolExecutor) on one adapter instance, with
+       cross-contamination and process/thread leak checks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import os
+import subprocess
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from karenina.adapters import get_agent
+from karenina.ports import AgentConfig, Message, Role
+from karenina.schemas.config import ModelConfig
+
+_LIVE_OPT_IN = os.getenv("KARENINA_LIVE_TESTS") == "1"
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(not _LIVE_OPT_IN, reason="set KARENINA_LIVE_TESTS=1 to run"),
+]
+
+LIVE_CODEX_BASE_URL = os.getenv("KARENINA_CODEX_LIVE_BASE_URL", "http://hl-codon-gpu-020:8000/v1")
+LIVE_CODEX_MODEL = os.getenv("KARENINA_CODEX_LIVE_MODEL", "qwen3.5-122b-a10b")
+
+END_TO_END_PROMPT = (
+    "Create a file named hello.txt containing 'hello from the codex adapter' "
+    "and then list the directory contents using the shell. Finish with a one "
+    "sentence summary of what you did."
+)
+
+TIMEOUT_PROMPT = (
+    "First run the shell command 'sleep 60' and wait for it to finish. "
+    "Then create a file named done.txt and summarize what you did."
+)
+
+
+def _codex_model(role_id: str = "codex-live") -> ModelConfig:
+    """ModelConfig for the codex_sdk adapter against the live endpoint."""
+    return ModelConfig(
+        id=role_id,
+        model_name=LIVE_CODEX_MODEL,
+        model_provider="openai",
+        interface="codex_sdk",
+        endpoint_base_url=LIVE_CODEX_BASE_URL,
+    )
+
+
+def _shell_use_result_pairs(result) -> list[str]:
+    """Return tool_use ids of shell calls that have a paired tool result."""
+    tool_result_ids = {
+        getattr(block, "tool_use_id", None)
+        for message in result.trace_messages
+        if message.role == Role.TOOL
+        for block in message.content
+    }
+    return [
+        tc.id
+        for message in result.trace_messages
+        for tc in message.tool_calls
+        if tc.name == "shell" and tc.id in tool_result_ids
+    ]
+
+
+def test_codex_end_to_end_shell_run(tmp_path: Path) -> None:
+    """Full agent run: shell tool round trip, canonical trace, real usage."""
+    agent = get_agent(_codex_model())
+
+    result = agent.run(
+        [Message.system("You are a helpful coding agent."), Message.user(END_TO_END_PROMPT)],
+        config=AgentConfig(timeout=300, workspace_path=tmp_path),
+    )
+
+    assert result.final_response.strip()
+    assert result.timeout_reached is False
+
+    # Canonical delimited raw trace with a shell tool call round trip.
+    assert "--- AI Message ---" in result.raw_trace
+    assert "Tool Calls:" in result.raw_trace
+    assert "shell (call_" in result.raw_trace
+    assert "--- Tool Message (call_id:" in result.raw_trace
+
+    # Structured trace carries at least one shell use/result pair.
+    assert _shell_use_result_pairs(result), "no shell use/result pair in trace_messages"
+
+    # Real token accounting from the live endpoint.
+    assert result.usage.input_tokens > 0
+    assert result.usage.output_tokens > 0
+    assert result.usage.model == LIVE_CODEX_MODEL
+
+    # The agent actually wrote into the pinned workspace.
+    assert (tmp_path / "hello.txt").exists()
+
+
+def test_codex_timeout_interrupt_salvages_partial_trace(tmp_path: Path) -> None:
+    """Wall-clock timeout against an in-flight shell command.
+
+    The 'sleep 60' keeps the turn running when the timeout fires, forcing
+    the interrupt path. The adapter must return a partial result (not raise
+    and not hang) with timeout_reached=True and the timeout note appended.
+    """
+    agent = get_agent(_codex_model(role_id="codex-live-timeout"))
+
+    result = agent.run(
+        [Message.user(TIMEOUT_PROMPT)],
+        config=AgentConfig(timeout=8, workspace_path=tmp_path),
+    )
+
+    assert result.timeout_reached is True
+    assert "[Note: Agent timed out" in result.raw_trace
+    assert result.final_response  # placeholder or partial text, never empty
+
+
+# ---------------------------------------------------------------------------
+# Two-turn scenario: history must reach the model
+# ---------------------------------------------------------------------------
+
+_FRUITS = ("durian", "rambutan", "persimmon", "quince")
+
+_FRUIT_TEMPLATE = """
+from karenina.schemas.entities import BaseAnswer
+from pydantic import Field
+
+class Answer(BaseAnswer):
+    fruit: str = Field(description="The fruit named in the response")
+
+    def model_post_init(self, __context):
+        self.correct = {"fruit": ""}
+
+    def verify(self) -> bool:
+        return bool(self.fruit.strip())
+"""
+
+
+def _parsing_model(role_id: str = "qwen-parser") -> ModelConfig:
+    """Plain langchain ChatOpenAI judge against the same vLLM endpoint."""
+    return ModelConfig(
+        id=role_id,
+        model_name=LIVE_CODEX_MODEL,
+        model_provider="openai",
+        interface="openai_endpoint",
+        endpoint_base_url=LIVE_CODEX_BASE_URL,
+        endpoint_api_key="EMPTY",
+        temperature=0.0,
+        extra_kwargs={"extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
+    )
+
+
+def test_codex_scenario_history_reaches_model() -> None:
+    """Two-turn scenario where turn 2 is only answerable from turn 1's answer.
+
+    Turn 1 asks the model to pick one fruit from a list. Turn 2 asks which
+    fruit it picked earlier, without naming any fruit. A correct turn 2
+    answer therefore proves the serialized conversation history (the
+    role-labeled transcript built by CodexMessageConverter) actually
+    reached the model through the real scenario machinery.
+    """
+    from karenina.benchmark import Benchmark
+    from karenina.scenario.builder import Scenario
+    from karenina.schemas.entities import Question
+    from karenina.schemas.scenario.types import END
+    from karenina.schemas.verification import VerificationConfig
+
+    scenario = Scenario("codex-fruit-recall")
+    scenario.add_node(
+        "pick",
+        question=Question(
+            question=(
+                f"Pick exactly one fruit from this list: {', '.join(_FRUITS)}. State clearly which fruit you picked."
+            ),
+            raw_answer="any fruit from the list",
+            answer_template=_FRUIT_TEMPLATE,
+        ),
+    )
+    scenario.add_node(
+        "recall",
+        question=Question(
+            question="Which fruit did you pick earlier? Answer with just the fruit name.",
+            raw_answer="the fruit picked in the previous turn",
+            answer_template=_FRUIT_TEMPLATE,
+        ),
+    )
+    scenario.add_edge("pick", "recall")
+    scenario.add_edge("recall", END)
+    scenario.set_entry("pick")
+
+    benchmark = Benchmark.create(
+        name="codex-live-scenario",
+        description="codex_sdk 2-turn history recall scenario",
+        workspace_root=Path(tempfile.mkdtemp(prefix="karenina_codex_scenario_ws_")),
+    )
+    benchmark.add_scenario(scenario.validate())
+
+    config = VerificationConfig(
+        answering_models=[_codex_model(role_id="codex-scenario")],
+        parsing_models=[_parsing_model()],
+        evaluation_mode="template_only",
+        async_enabled=False,
+    )
+
+    result_set = benchmark.run_verification(config=config, run_name="codex-live-scenario")
+    assert len(result_set.results) == 2, f"expected 2 turn results, got {len(result_set.results)}"
+
+    by_node: dict[str, object] = {}
+    for result in result_set.results:
+        if "Pick exactly one fruit" in result.metadata.question_text:
+            by_node["pick"] = result
+        else:
+            by_node["recall"] = result
+    assert set(by_node) == {"pick", "recall"}
+
+    pick_template = by_node["pick"].template
+    recall_template = by_node["recall"].template
+    assert pick_template is not None and recall_template is not None
+    assert by_node["pick"].metadata.failure is None
+    assert by_node["recall"].metadata.failure is None
+
+    picked = (pick_template.parsed_llm_response or {}).get("fruit", "").strip().lower()
+    assert picked in _FRUITS, f"turn 1 did not pick a listed fruit: {picked!r}"
+
+    # Evidence that history reached the model: turn 2 names turn 1's fruit
+    # even though turn 2's question mentions no fruit at all.
+    recalled = (recall_template.parsed_llm_response or {}).get("fruit", "").strip().lower()
+    recall_blob = f"{recalled} {recall_template.raw_llm_response}".lower()
+    assert picked in recall_blob, f"turn 2 did not recall {picked!r}: parsed={recalled!r}"
+    # And no OTHER listed fruit was recalled instead.
+    if recalled in _FRUITS:
+        assert recalled == picked
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: gather, threadpool, leak checks
+# ---------------------------------------------------------------------------
+
+_CONCURRENCY = 4
+
+
+def _count_codex_processes() -> int:
+    """Count live codex app-server subprocesses spawned from this venv.
+
+    Matches on the bundled binary path segment (codex_cli_bin) so other
+    codex installs on the machine (IDE integrations) are excluded.
+    """
+    proc = subprocess.run(["pgrep", "-f", "codex_cli_bin"], capture_output=True, text=True, check=False)
+    return len([line for line in proc.stdout.splitlines() if line.strip()])
+
+
+def _count_shim_threads() -> int:
+    return sum(1 for t in threading.enumerate() if t.name.startswith("karenina-codex-endpoint-shim"))
+
+
+def _concurrency_prompt(token: str) -> str:
+    return f"Run the shell command `echo {token}` using the shell tool, then state exactly what it printed."
+
+
+def _tokens() -> list[str]:
+    return [
+        f"CODEX-CONC-{i}-{suffix}"
+        for i, suffix in zip(range(_CONCURRENCY), ("ALPHA", "BRAVO", "CHARLIE", "DELTA"), strict=False)
+    ]
+
+
+def _assert_no_cross_contamination(results: list, tokens: list[str]) -> None:
+    for i, (result, token) in enumerate(zip(results, tokens, strict=False)):
+        assert token in result.raw_trace, f"run {i} trace missing its own token {token}"
+        for other in tokens:
+            if other != token:
+                assert other not in result.raw_trace, f"run {i} trace contaminated with {other}"
+        assert result.usage.input_tokens > 0
+
+
+@pytest.fixture(scope="module")
+def single_run_seconds(tmp_path_factory: pytest.TempPathFactory) -> float:
+    """Wall-clock of one solo run, the baseline for concurrency speedup."""
+    if not _LIVE_OPT_IN:
+        pytest.skip("set KARENINA_LIVE_TESTS=1 to run")
+    agent = get_agent(_codex_model(role_id="codex-baseline"))
+    workspace = tmp_path_factory.mktemp("codex-baseline")
+    t0 = time.time()
+    result = agent.run(
+        [Message.user(_concurrency_prompt("CODEX-BASELINE-0"))],
+        config=AgentConfig(timeout=180, workspace_path=workspace),
+    )
+    elapsed = time.time() - t0
+    assert "CODEX-BASELINE-0" in result.raw_trace
+    return elapsed
+
+
+def test_codex_concurrent_arun_gather(tmp_path: Path, single_run_seconds: float) -> None:
+    """4 concurrent arun calls on one adapter instance, asyncio.gather."""
+    adapter = get_agent(_codex_model(role_id="codex-gather"))
+    tokens = _tokens()
+    baseline_procs = _count_codex_processes()
+    baseline_threads = _count_shim_threads()
+
+    async def run_all() -> list:
+        tasks = []
+        for i, token in enumerate(tokens):
+            workspace = tmp_path / f"ws-{i}"
+            workspace.mkdir()
+            tasks.append(
+                adapter.arun(
+                    [Message.user(_concurrency_prompt(token))],
+                    config=AgentConfig(timeout=180, workspace_path=workspace),
+                )
+            )
+        return await asyncio.gather(*tasks)
+
+    t0 = time.time()
+    results = asyncio.run(run_all())
+    elapsed = time.time() - t0
+
+    assert len(results) == _CONCURRENCY
+    _assert_no_cross_contamination(results, tokens)
+    # Meaningfully better than serial: well under 4x a single run.
+    assert elapsed < 3 * single_run_seconds, f"gather took {elapsed:.1f}s vs single {single_run_seconds:.1f}s"
+
+    time.sleep(1)
+    assert _count_codex_processes() == baseline_procs, "codex app-server process leaked"
+    assert _count_shim_threads() == baseline_threads, "endpoint shim thread leaked"
+
+
+def test_codex_concurrent_run_threadpool(tmp_path: Path, single_run_seconds: float) -> None:
+    """4 concurrent sync run() calls, the pipeline's parallelization shape."""
+    adapter = get_agent(_codex_model(role_id="codex-threadpool"))
+    tokens = _tokens()
+    baseline_procs = _count_codex_processes()
+    baseline_threads = _count_shim_threads()
+
+    def one(i: int, token: str):
+        workspace = tmp_path / f"ws-{i}"
+        workspace.mkdir()
+        return adapter.run(
+            [Message.user(_concurrency_prompt(token))],
+            config=AgentConfig(timeout=180, workspace_path=workspace),
+        )
+
+    t0 = time.time()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=_CONCURRENCY) as pool:
+        results = list(pool.map(one, range(_CONCURRENCY), tokens))
+    elapsed = time.time() - t0
+
+    assert len(results) == _CONCURRENCY
+    _assert_no_cross_contamination(results, tokens)
+    assert elapsed < 3 * single_run_seconds, f"threadpool took {elapsed:.1f}s vs single {single_run_seconds:.1f}s"
+
+    time.sleep(1)
+    assert _count_codex_processes() == baseline_procs, "codex app-server process leaked"
+    assert _count_shim_threads() == baseline_threads, "endpoint shim thread leaked"

--- a/tests/unit/adapters/codex_sdk/conftest.py
+++ b/tests/unit/adapters/codex_sdk/conftest.py
@@ -1,0 +1,94 @@
+"""Shared fixtures for Codex SDK adapter tests.
+
+The adapter discriminates codex thread items by their ``type`` string, so
+tests use lightweight stand-in objects instead of the real pydantic
+models. The agent tests install a fake ``openai_codex`` module in
+sys.modules so no app-server subprocess or network is involved.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from karenina.schemas.config import ModelConfig
+
+
+@pytest.fixture
+def endpoint_model_config() -> ModelConfig:
+    """ModelConfig for the custom-endpoint (vLLM-style) path."""
+    return ModelConfig(
+        id="qwen-codex",
+        model_name="qwen3.5-122b-a10b",
+        model_provider="openai",
+        interface="codex_sdk",
+        endpoint_base_url="http://example-endpoint:8000/v1",
+    )
+
+
+@pytest.fixture
+def native_model_config() -> ModelConfig:
+    """ModelConfig for the native OpenAI path (no custom endpoint)."""
+    return ModelConfig(
+        id="gpt-codex",
+        model_name="gpt-5.2-codex",
+        interface="codex_sdk",
+    )
+
+
+def make_item(item_type: str, **fields: Any) -> SimpleNamespace:
+    """Build a fake codex thread item with a type discriminator."""
+    return SimpleNamespace(type=item_type, **fields)
+
+
+def make_reasoning(item_id: str = "item_r", content: list[str] | None = None) -> SimpleNamespace:
+    return make_item("reasoning", id=item_id, content=content or ["thinking about it"], summary=[])
+
+
+def make_agent_message(text: str, item_id: str = "item_a", phase: str | None = None) -> SimpleNamespace:
+    return make_item("agentMessage", id=item_id, text=text, phase=phase)
+
+
+def make_command_execution(
+    item_id: str = "item_c",
+    command: str = "ls -la",
+    output: str = "total 0",
+    exit_code: int | None = 0,
+    status: str = "completed",
+) -> SimpleNamespace:
+    return make_item(
+        "commandExecution",
+        id=item_id,
+        command=command,
+        aggregated_output=output,
+        exit_code=exit_code,
+        status=status,
+        cwd="/tmp/work",
+        duration_ms=12,
+    )
+
+
+def make_usage(
+    input_tokens: int = 100,
+    output_tokens: int = 20,
+    cached: int = 5,
+    reasoning: int = 3,
+) -> SimpleNamespace:
+    """Build a fake ThreadTokenUsage with last/total breakdowns."""
+    breakdown = SimpleNamespace(
+        cached_input_tokens=cached,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        reasoning_output_tokens=reasoning,
+        total_tokens=input_tokens + output_tokens,
+    )
+    half = SimpleNamespace(
+        cached_input_tokens=0,
+        input_tokens=input_tokens // 2,
+        output_tokens=output_tokens // 2,
+        reasoning_output_tokens=0,
+        total_tokens=(input_tokens + output_tokens) // 2,
+    )
+    return SimpleNamespace(last=half, total=breakdown, model_context_window=258400)

--- a/tests/unit/adapters/codex_sdk/test_agent.py
+++ b/tests/unit/adapters/codex_sdk/test_agent.py
@@ -1,0 +1,432 @@
+"""Tests for CodexSDKAgentAdapter using a fake openai_codex module.
+
+The fake module is installed in sys.modules per test, so no codex
+app-server subprocess is spawned and no network is touched. The adapter
+imports the SDK lazily inside arun(), which makes per-test substitution
+via monkeypatch.setitem reliable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from karenina.ports import (
+    AgentConfig,
+    AgentExecutionError,
+    AgentResponseError,
+    Message,
+)
+from karenina.schemas.config import ModelConfig
+
+from .conftest import make_agent_message, make_command_execution, make_reasoning, make_usage
+
+TURN_ID = "turn_1"
+THREAD_ID = "thread_1"
+
+
+def _notification(method: str, payload: Any) -> SimpleNamespace:
+    return SimpleNamespace(method=method, payload=payload)
+
+
+def _item_event(item: Any) -> SimpleNamespace:
+    return _notification("item/completed", SimpleNamespace(turn_id=TURN_ID, item=item))
+
+
+def _usage_event(usage: Any) -> SimpleNamespace:
+    return _notification("thread/tokenUsage/updated", SimpleNamespace(turn_id=TURN_ID, token_usage=usage))
+
+
+def _agent_delta_event(item_id: str, delta: str) -> SimpleNamespace:
+    return _notification(
+        "item/agentMessage/delta",
+        SimpleNamespace(turn_id=TURN_ID, item_id=item_id, delta=delta),
+    )
+
+
+def _completed_event(status: str = "completed", error_message: str | None = None) -> SimpleNamespace:
+    error = SimpleNamespace(message=error_message) if error_message else None
+    turn = SimpleNamespace(id=TURN_ID, status=SimpleNamespace(value=status), error=error)
+    return _notification("turn/completed", SimpleNamespace(turn=turn))
+
+
+def _successful_events() -> list[SimpleNamespace]:
+    return [
+        _item_event(make_reasoning(content=["plan the command"])),
+        _item_event(make_command_execution(item_id="cmd_1", command="echo hi > hello.txt", output="", exit_code=0)),
+        _item_event(make_agent_message("Created hello.txt.", phase="final_answer")),
+        _usage_event(make_usage(input_tokens=200, output_tokens=40)),
+        _completed_event("completed"),
+    ]
+
+
+class _FakeTurnHandle:
+    def __init__(
+        self,
+        events: list[SimpleNamespace],
+        hang: bool,
+        stream_error: Exception | None,
+        ignore_interrupt: bool = False,
+    ) -> None:
+        self.id = TURN_ID
+        self._events = events
+        self._hang = hang
+        self._stream_error = stream_error
+        self._ignore_interrupt = ignore_interrupt
+        self._interrupted = asyncio.Event()
+        self.interrupt_called = False
+
+    async def interrupt(self) -> None:
+        self.interrupt_called = True
+        if not self._ignore_interrupt:
+            self._interrupted.set()
+
+    async def stream(self) -> Any:
+        for event in self._events:
+            yield event
+        if self._stream_error is not None:
+            raise self._stream_error
+        if self._hang:
+            # Like the real app-server: an in-flight turn blocks the stream
+            # until interrupt, which then emits turn/completed (interrupted).
+            await self._interrupted.wait()
+            yield _completed_event("interrupted")
+
+
+class _FakeThread:
+    def __init__(self, handle: _FakeTurnHandle, record: dict[str, Any]) -> None:
+        self.id = THREAD_ID
+        self._handle = handle
+        self._record = record
+
+    async def turn(self, prompt: str) -> _FakeTurnHandle:
+        self._record["prompt"] = prompt
+        return self._handle
+
+
+def build_fake_codex_module(
+    events: list[SimpleNamespace],
+    *,
+    hang: bool = False,
+    stream_error: Exception | None = None,
+    ignore_interrupt: bool = False,
+    close_hang_s: float = 0.0,
+) -> tuple[types.ModuleType, dict[str, Any]]:
+    """Build a fake openai_codex module plus a record of observed calls."""
+    record: dict[str, Any] = {}
+    handle = _FakeTurnHandle(events, hang, stream_error, ignore_interrupt)
+    record["handle"] = handle
+
+    class FakeCodexConfig:
+        def __init__(self, config_overrides: tuple[str, ...] = (), env: dict[str, str] | None = None) -> None:
+            record["config_overrides"] = config_overrides
+            record["env"] = env
+
+    class FakeAsyncCodex:
+        def __init__(self, config: Any) -> None:
+            record["codex_config"] = config
+
+        async def __aenter__(self) -> FakeAsyncCodex:
+            return self
+
+        async def __aexit__(self, *_exc: Any) -> None:
+            if close_hang_s:
+                # Bounded hang so abandoned worker threads still finish
+                # before interpreter exit joins them.
+                await asyncio.sleep(close_hang_s)
+            record["closed"] = True
+
+        async def thread_start(self, **kwargs: Any) -> _FakeThread:
+            record["thread_start_kwargs"] = kwargs
+            return _FakeThread(handle, record)
+
+    module = types.ModuleType("openai_codex")
+    module.AsyncCodex = FakeAsyncCodex
+    module.CodexConfig = FakeCodexConfig
+    module.ApprovalMode = SimpleNamespace(auto_review="auto_review", deny_all="deny_all")
+    module.Sandbox = SimpleNamespace(
+        read_only="read_only", workspace_write="workspace_write", full_access="full_access"
+    )
+    return module, record
+
+
+@pytest.fixture
+def codex_model_config() -> ModelConfig:
+    return ModelConfig(
+        id="qwen-codex",
+        model_name="qwen3.5-122b-a10b",
+        interface="codex_sdk",
+        endpoint_base_url="http://example-endpoint:8000/v1",
+    )
+
+
+def _make_adapter(model_config: ModelConfig) -> Any:
+    from karenina.adapters.codex_sdk.agent import CodexSDKAgentAdapter
+
+    return CodexSDKAgentAdapter(model_config)
+
+
+class TestSuccessfulRun:
+    def test_full_turn_builds_agent_result(
+        self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig
+    ) -> None:
+        module, record = build_fake_codex_module(_successful_events())
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        result = asyncio.run(adapter.arun([Message.system("Be helpful"), Message.user("Create hello.txt")]))
+
+        assert result.final_response == "Created hello.txt."
+        assert "--- Thinking ---" in result.raw_trace
+        assert "--- AI Message ---" in result.raw_trace
+        assert "--- Tool Message (call_id: cmd_1) ---" in result.raw_trace
+        assert result.usage.input_tokens == 200
+        assert result.usage.output_tokens == 40
+        assert result.session_id == THREAD_ID
+        assert result.timeout_reached is False
+        assert result.limit_reached is False
+        assert result.turns == 2  # shell tool-use turn plus final text turn
+        roles = [m.role.value for m in result.trace_messages]
+        assert "user" not in roles
+        assert record["prompt"] == "Create hello.txt"
+
+    def test_thread_start_receives_expected_kwargs(
+        self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig
+    ) -> None:
+        module, record = build_fake_codex_module(_successful_events())
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        asyncio.run(adapter.arun([Message.system("Be helpful"), Message.user("hi")]))
+
+        kwargs = record["thread_start_kwargs"]
+        assert kwargs["model"] == "qwen3.5-122b-a10b"
+        assert kwargs["model_provider"] == "karenina"
+        assert kwargs["base_instructions"] == "Be helpful"
+        assert kwargs["sandbox"] == "workspace_write"
+        assert kwargs["approval_mode"] == "auto_review"
+        assert kwargs["cwd"]  # temp workspace fallback was created
+
+    def test_endpoint_overrides_point_at_local_shim(
+        self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig
+    ) -> None:
+        module, record = build_fake_codex_module(_successful_events())
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        asyncio.run(adapter.arun([Message.user("hi")]))
+
+        overrides = "\n".join(record["config_overrides"])
+        assert 'wire_api="responses"' in overrides
+        assert "http://127.0.0.1:" in overrides
+        # The raw endpoint URL must not be handed to codex directly.
+        assert "example-endpoint" not in overrides
+
+    def test_final_message_synthesized_from_deltas(
+        self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig
+    ) -> None:
+        # Live-observed behavior: the final agentMessage of a turn never gets
+        # item/completed. Its text arrives only via item/agentMessage/delta
+        # events, so the adapter must synthesize the assistant message.
+        events = [
+            _item_event(make_reasoning(content=["simple factual question"])),
+            _agent_delta_event("msg_final", "\n\nPar"),
+            _agent_delta_event("msg_final", "is"),
+            _usage_event(make_usage(input_tokens=50, output_tokens=5)),
+            _completed_event("completed"),
+        ]
+        module, _ = build_fake_codex_module(events)
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        result = asyncio.run(adapter.arun([Message.user("Capital of France?")]))
+
+        assert result.final_response == "Paris"
+        assert "--- AI Message ---\nParis" in result.raw_trace
+        # The synthesized message is the last assistant entry.
+        assert result.trace_messages[-1].role.value == "assistant"
+        assert result.trace_messages[-1].text == "Paris"
+
+    def test_empty_completed_message_filled_from_deltas(
+        self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig
+    ) -> None:
+        # Variant: the agentMessage item DOES complete but with empty text
+        # (observed in the step-0 smoke). Delta text fills it in place.
+        events = [
+            _agent_delta_event("msg_1", "Paris"),
+            _item_event(make_agent_message("", item_id="msg_1", phase="final_answer")),
+            _completed_event("completed"),
+        ]
+        module, _ = build_fake_codex_module(events)
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        result = asyncio.run(adapter.arun([Message.user("Capital of France?")]))
+
+        assert result.final_response == "Paris"
+        # No duplicate synthesized message.
+        assistant_texts = [m.text for m in result.trace_messages if m.role.value == "assistant" and m.text]
+        assert assistant_texts == ["Paris"]
+
+    def test_sync_run_wrapper(self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig) -> None:
+        module, _ = build_fake_codex_module(_successful_events())
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        result = adapter.run([Message.user("hi")])
+        assert result.final_response == "Created hello.txt."
+
+
+class TestTimeoutSalvage:
+    def test_timeout_sets_flag_and_interrupts(
+        self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig
+    ) -> None:
+        events = [
+            _item_event(make_command_execution(item_id="cmd_1", command="sleep 100", output="", exit_code=None)),
+        ]
+        module, record = build_fake_codex_module(events, hang=True)
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        result = asyncio.run(adapter.arun([Message.user("hi")], config=AgentConfig(timeout=0.3)))
+
+        assert result.timeout_reached is True
+        assert record["handle"].interrupt_called is True
+        assert "[Note: Agent timed out - partial trace shown]" in result.raw_trace
+        assert "--- Tool Message (call_id: cmd_1) ---" in result.raw_trace
+        assert result.final_response == "[Agent stopped before producing a final response]"
+
+    def test_timeout_with_no_items_still_returns_partial(
+        self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig
+    ) -> None:
+        module, record = build_fake_codex_module([], hang=True)
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        result = asyncio.run(adapter.arun([Message.user("hi")], config=AgentConfig(timeout=0.2)))
+
+        assert result.timeout_reached is True
+        assert result.trace_messages == []
+        assert record["handle"].interrupt_called is True
+
+    def test_unresponsive_interrupt_still_returns_within_grace(
+        self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig
+    ) -> None:
+        # Pathological case: the app-server never reacts to the interrupt,
+        # so the stream stays open. The adapter must still return a partial
+        # result after its bounded grace waits instead of hanging.
+        import karenina.adapters.codex_sdk.agent as agent_module
+
+        monkeypatch.setattr(agent_module, "_INTERRUPT_DRAIN_GRACE", 0.2)
+        monkeypatch.setattr(agent_module, "_POST_CLOSE_DRAIN_GRACE", 0.2)
+        events = [_item_event(make_agent_message("partial"))]
+        module, record = build_fake_codex_module(events, hang=True, ignore_interrupt=True)
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        result = asyncio.run(adapter.arun([Message.user("hi")], config=AgentConfig(timeout=0.2)))
+
+        assert result.timeout_reached is True
+        assert record["handle"].interrupt_called is True
+        assert result.final_response == "partial"
+
+    def test_hanging_close_still_returns_partial_from_run(
+        self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig
+    ) -> None:
+        # AsyncCodex.close() hangs after the timeout was detected. The
+        # provisional partial stored at timeout detection must reach the
+        # sync wrapper before its deadline, so run() returns a salvaged
+        # result instead of leaking concurrent.futures.TimeoutError.
+        import karenina.adapters.codex_sdk.agent as agent_module
+
+        original_run_in_fresh_loop = agent_module._run_in_fresh_loop
+
+        def fast_wrapper(coro_func: Any, *args: Any, **kwargs: Any) -> Any:
+            kwargs["timeout_grace"] = 1.0
+            return original_run_in_fresh_loop(coro_func, *args, **kwargs)
+
+        monkeypatch.setattr(agent_module, "_run_in_fresh_loop", fast_wrapper)
+
+        events = [_item_event(make_agent_message("salvaged partial"))]
+        module, record = build_fake_codex_module(events, hang=True, close_hang_s=5.0)
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        result = adapter.run([Message.user("hi")], config=AgentConfig(timeout=0.3))
+
+        assert result.timeout_reached is True
+        assert result.final_response == "salvaged partial"
+        assert record["handle"].interrupt_called is True
+
+
+class TestFailures:
+    def test_failed_turn_raises_mapped_error(
+        self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig
+    ) -> None:
+        events = [_completed_event("failed", error_message="upstream exploded")]
+        module, _ = build_fake_codex_module(events)
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        with pytest.raises(AgentExecutionError, match="upstream exploded"):
+            asyncio.run(adapter.arun([Message.user("hi")]))
+
+    def test_failed_turn_with_limit_message_sets_limit_reached(
+        self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig
+    ) -> None:
+        events = [
+            _item_event(make_agent_message("partial answer")),
+            _completed_event("failed", error_message="model context window exceeded"),
+        ]
+        module, _ = build_fake_codex_module(events)
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        result = asyncio.run(adapter.arun([Message.user("hi")]))
+        assert result.limit_reached is True
+        assert result.final_response == "partial answer"
+
+    def test_limit_error_with_zero_items_returns_placeholder_partial(
+        self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig
+    ) -> None:
+        # A stream error that classifies as a limit before anything was
+        # drained returns a placeholder partial (mirrors deep_agents)
+        # instead of raising AgentResponseError.
+        limit_error = RuntimeError("recursion limit reached for this turn")
+        module, _ = build_fake_codex_module([], stream_error=limit_error)
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        result = asyncio.run(adapter.arun([Message.user("hi")]))
+
+        assert result.limit_reached is True
+        assert result.trace_messages == []
+        assert result.final_response == "[Agent stopped before producing a final response]"
+        assert "[Note: Turn limit reached - partial response shown]" in result.raw_trace
+
+    def test_stream_error_is_wrapped_and_chained(
+        self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig
+    ) -> None:
+        sdk_error = type("ServerBusyError", (Exception,), {})("server overloaded")
+        module, _ = build_fake_codex_module([], stream_error=sdk_error)
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        with pytest.raises(AgentExecutionError, match="overloaded") as exc_info:
+            asyncio.run(adapter.arun([Message.user("hi")]))
+        assert exc_info.value.__cause__ is sdk_error
+
+    def test_empty_stream_raises_response_error(
+        self, monkeypatch: pytest.MonkeyPatch, codex_model_config: ModelConfig
+    ) -> None:
+        module, _ = build_fake_codex_module([])
+        monkeypatch.setitem(sys.modules, "openai_codex", module)
+        adapter = _make_adapter(codex_model_config)
+
+        with pytest.raises(AgentResponseError, match="No turn completion"):
+            asyncio.run(adapter.arun([Message.user("hi")]))

--- a/tests/unit/adapters/codex_sdk/test_config_builder.py
+++ b/tests/unit/adapters/codex_sdk/test_config_builder.py
@@ -1,0 +1,109 @@
+"""Tests for the SDK-free codex configuration builders."""
+
+from __future__ import annotations
+
+from karenina.adapters.codex_sdk.config_builder import (
+    CODEX_API_KEY_ENV_VAR,
+    CODEX_PROVIDER_KEY,
+    build_codex_config_overrides,
+    build_codex_env,
+    build_thread_start_kwargs,
+    resolve_model_provider,
+    resolve_sandbox_mode,
+)
+from karenina.schemas.config import ModelConfig
+
+
+def _keyed_config() -> ModelConfig:
+    return ModelConfig(
+        id="keyed",
+        model_name="qwen3.5-122b-a10b",
+        interface="codex_sdk",
+        endpoint_base_url="http://example-endpoint:8000/v1",
+        endpoint_api_key="super-secret-token",
+    )
+
+
+class TestBuildCodexConfigOverrides:
+    def test_endpoint_overrides_use_responses_wire_api(self, endpoint_model_config: ModelConfig) -> None:
+        overrides = build_codex_config_overrides(endpoint_model_config, "http://127.0.0.1:9999/v1")
+        joined = "\n".join(overrides)
+        assert f'model_providers.{CODEX_PROVIDER_KEY}.wire_api="responses"' in overrides
+        assert f'model_providers.{CODEX_PROVIDER_KEY}.base_url="http://127.0.0.1:9999/v1"' in overrides
+        assert 'wire_api="chat"' not in joined
+
+    def test_base_url_defaults_to_endpoint(self, endpoint_model_config: ModelConfig) -> None:
+        overrides = build_codex_config_overrides(endpoint_model_config)
+        assert any("http://example-endpoint:8000/v1" in entry for entry in overrides)
+
+    def test_generous_stream_idle_timeout_emitted(self, endpoint_model_config: ModelConfig) -> None:
+        overrides = build_codex_config_overrides(endpoint_model_config)
+        assert f"model_providers.{CODEX_PROVIDER_KEY}.stream_idle_timeout_ms=600000" in overrides
+
+    def test_native_path_emits_no_overrides(self, native_model_config: ModelConfig) -> None:
+        assert build_codex_config_overrides(native_model_config) == ()
+
+    def test_secret_never_in_overrides(self) -> None:
+        config = _keyed_config()
+        overrides = build_codex_config_overrides(config, "http://127.0.0.1:9999/v1")
+        joined = "\n".join(overrides)
+        assert "super-secret-token" not in joined
+        # The env var is referenced by name only.
+        assert f'model_providers.{CODEX_PROVIDER_KEY}.env_key="{CODEX_API_KEY_ENV_VAR}"' in overrides
+
+    def test_keyless_endpoint_sets_no_env_key(self, endpoint_model_config: ModelConfig) -> None:
+        overrides = build_codex_config_overrides(endpoint_model_config)
+        assert not any("env_key" in entry for entry in overrides)
+
+
+class TestBuildCodexEnv:
+    def test_keyless_endpoint_returns_none(self, endpoint_model_config: ModelConfig) -> None:
+        assert build_codex_env(endpoint_model_config) is None
+
+    def test_native_path_returns_none(self, native_model_config: ModelConfig) -> None:
+        assert build_codex_env(native_model_config) is None
+
+    def test_keyed_endpoint_carries_secret_in_env_only(self) -> None:
+        env = build_codex_env(_keyed_config())
+        assert env == {CODEX_API_KEY_ENV_VAR: "super-secret-token"}
+
+
+class TestResolvers:
+    def test_model_provider_for_endpoint(self, endpoint_model_config: ModelConfig) -> None:
+        assert resolve_model_provider(endpoint_model_config) == CODEX_PROVIDER_KEY
+
+    def test_model_provider_native_is_none(self, native_model_config: ModelConfig) -> None:
+        assert resolve_model_provider(native_model_config) is None
+
+    def test_sandbox_defaults_to_workspace_write(self, endpoint_model_config: ModelConfig) -> None:
+        assert resolve_sandbox_mode(endpoint_model_config) == "workspace_write"
+
+    def test_sandbox_read_only_access_mode(self) -> None:
+        config = ModelConfig(
+            id="ro",
+            model_name="m",
+            interface="codex_sdk",
+            extra_kwargs={"agent_runtime": {"access_mode": "read_only"}},
+        )
+        assert resolve_sandbox_mode(config) == "read_only"
+
+
+class TestBuildThreadStartKwargs:
+    def test_endpoint_kwargs(self, endpoint_model_config: ModelConfig) -> None:
+        kwargs = build_thread_start_kwargs(
+            endpoint_model_config,
+            base_instructions="Be helpful",
+            cwd="/tmp/workspace",
+        )
+        assert kwargs == {
+            "model": "qwen3.5-122b-a10b",
+            "model_provider": CODEX_PROVIDER_KEY,
+            "cwd": "/tmp/workspace",
+            "sandbox": "workspace_write",
+            "base_instructions": "Be helpful",
+        }
+
+    def test_no_system_prompt_omits_base_instructions(self, native_model_config: ModelConfig) -> None:
+        kwargs = build_thread_start_kwargs(native_model_config, base_instructions=None, cwd="/tmp/w")
+        assert "base_instructions" not in kwargs
+        assert kwargs["model_provider"] is None

--- a/tests/unit/adapters/codex_sdk/test_endpoint_shim.py
+++ b/tests/unit/adapters/codex_sdk/test_endpoint_shim.py
@@ -1,0 +1,231 @@
+"""Tests for the request-rewriting endpoint shim.
+
+The rewrite cases mirror the recorded request shapes from the step-0
+validation (specs/codex_sdk_findings.md): codex sends its system text as
+``instructions`` plus developer-role input messages, and echoes prior
+``reasoning`` items back into ``input`` on follow-up turns. Stock vLLM
+rejects both.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import threading
+import time
+import urllib.request
+from typing import Any
+
+import pytest
+
+from karenina.adapters.codex_sdk.endpoint_shim import EndpointShim, rewrite_responses_payload
+
+
+def _recorded_codex_request() -> dict[str, Any]:
+    """First-turn request shape as recorded through the reference proxy."""
+    return {
+        "model": "qwen3.5-122b-a10b",
+        "instructions": "You are a helpful coding agent.",
+        "input": [
+            {
+                "type": "message",
+                "role": "developer",
+                "content": [{"type": "input_text", "text": "Permissions: workspace-write."}],
+            },
+            {
+                "type": "message",
+                "role": "developer",
+                "content": [{"type": "input_text", "text": "Apps and skills catalog."}],
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Create hello.txt"}],
+            },
+        ],
+        "tools": [{"type": "function", "name": "exec_command"}],
+        "stream": True,
+    }
+
+
+def _recorded_followup_request() -> dict[str, Any]:
+    """Follow-up turn: echoed reasoning plus function call round trip."""
+    return {
+        "model": "qwen3.5-122b-a10b",
+        "instructions": "You are a helpful coding agent.",
+        "input": [
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Create hello.txt"}]},
+            {"type": "reasoning", "content": [{"type": "reasoning_text", "text": "I should run a command."}]},
+            {"type": "function_call", "name": "exec_command", "call_id": "call_1", "arguments": "{}"},
+            {"type": "function_call_output", "call_id": "call_1", "output": "exit 0"},
+            {"type": "message", "role": "system", "content": [{"type": "input_text", "text": "Late system note."}]},
+        ],
+    }
+
+
+class TestRewriteResponsesPayload:
+    def test_developer_messages_folded_into_instructions(self) -> None:
+        rewritten = rewrite_responses_payload(_recorded_codex_request())
+        assert rewritten["instructions"] == (
+            "You are a helpful coding agent.\n\nPermissions: workspace-write.\n\nApps and skills catalog."
+        )
+        roles = [item.get("role") for item in rewritten["input"] if item.get("type") == "message"]
+        assert roles == ["user"]
+
+    def test_reasoning_items_stripped(self) -> None:
+        rewritten = rewrite_responses_payload(_recorded_followup_request())
+        types = [item["type"] for item in rewritten["input"]]
+        assert "reasoning" not in types
+        # Function call round trips survive untouched.
+        assert "function_call" in types
+        assert "function_call_output" in types
+
+    def test_system_messages_folded(self) -> None:
+        rewritten = rewrite_responses_payload(_recorded_followup_request())
+        assert rewritten["instructions"].endswith("Late system note.")
+        assert all(item.get("role") != "system" for item in rewritten["input"])
+
+    def test_original_payload_not_mutated(self) -> None:
+        payload = _recorded_codex_request()
+        rewrite_responses_payload(payload)
+        assert len(payload["input"]) == 3
+        assert payload["instructions"] == "You are a helpful coding agent."
+
+    def test_payload_without_system_text_passes_through(self) -> None:
+        payload = {"model": "m", "input": [{"type": "message", "role": "user", "content": "hi"}]}
+        rewritten = rewrite_responses_payload(payload)
+        assert rewritten["input"] == payload["input"]
+        assert "instructions" not in rewritten
+
+
+class _RecordingUpstreamHandler(http.server.BaseHTTPRequestHandler):
+    """Loopback upstream that records the request it receives."""
+
+    recorded: dict[str, Any] = {}
+
+    def log_message(self, *args: Any) -> None:
+        pass
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        type(self).recorded = {"path": self.path, "body": json.loads(body)}
+        response = json.dumps({"ok": True}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+
+@pytest.fixture
+def upstream_server() -> Any:
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _RecordingUpstreamHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+class TestEndpointShimRoundTrip:
+    def test_shim_rewrites_and_forwards_to_upstream(self, upstream_server: Any) -> None:
+        port = upstream_server.server_address[1]
+        shim = EndpointShim(f"http://127.0.0.1:{port}/v1")
+        shim.start()
+        try:
+            request = urllib.request.Request(
+                shim.base_url + "/responses",
+                data=json.dumps(_recorded_codex_request()).encode(),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=10) as response:
+                assert response.status == 200
+        finally:
+            shim.stop()
+
+        recorded = _RecordingUpstreamHandler.recorded
+        assert recorded["path"] == "/v1/responses"
+        body = recorded["body"]
+        assert "Permissions: workspace-write." in body["instructions"]
+        assert all(item.get("role") not in ("developer", "system") for item in body["input"])
+
+    def test_base_url_requires_start(self) -> None:
+        shim = EndpointShim("http://127.0.0.1:1/v1")
+        with pytest.raises(RuntimeError, match="not running"):
+            _ = shim.base_url
+
+    def test_stop_is_idempotent(self) -> None:
+        shim = EndpointShim("http://127.0.0.1:1/v1")
+        shim.start()
+        shim.stop()
+        shim.stop()
+
+    def test_upstream_timeout_configurable(self) -> None:
+        shim = EndpointShim("http://127.0.0.1:1/v1", upstream_timeout=1234.5)
+        assert shim._upstream_timeout == 1234.5
+
+
+class _StreamingUpstreamHandler(http.server.BaseHTTPRequestHandler):
+    """Loopback upstream that streams two SSE chunks with a delay between."""
+
+    protocol_version = "HTTP/1.1"
+    second_chunk_written = threading.Event()
+    first_chunk = b"data: first\n\n"
+    second_chunk = b"data: second\n\n"
+
+    def log_message(self, *args: Any) -> None:
+        pass
+
+    def _write_chunk(self, data: bytes) -> None:
+        self.wfile.write(f"{len(data):X}\r\n".encode() + data + b"\r\n")
+        self.wfile.flush()
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+        self._write_chunk(self.first_chunk)
+        time.sleep(0.5)
+        self._write_chunk(self.second_chunk)
+        type(self).second_chunk_written.set()
+        self.wfile.write(b"0\r\n\r\n")
+        self.wfile.flush()
+
+
+class TestEndpointShimStreaming:
+    def test_sse_body_is_relayed_incrementally(self) -> None:
+        """The first SSE chunk must reach the client before upstream finishes.
+
+        Codex aborts streams that stay idle past its stream idle timeout,
+        so the shim cannot buffer the upstream body to EOF.
+        """
+        _StreamingUpstreamHandler.second_chunk_written.clear()
+        upstream = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _StreamingUpstreamHandler)
+        upstream_thread = threading.Thread(target=upstream.serve_forever, daemon=True)
+        upstream_thread.start()
+        shim = EndpointShim(f"http://127.0.0.1:{upstream.server_address[1]}/v1")
+        shim.start()
+        try:
+            request = urllib.request.Request(
+                shim.base_url + "/stream-test",
+                data=b"{}",
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=10) as response:
+                first = response.read(len(_StreamingUpstreamHandler.first_chunk))
+                # The first chunk arrived while upstream was still sleeping
+                # before its second chunk, proving incremental relay.
+                assert first == _StreamingUpstreamHandler.first_chunk
+                assert not _StreamingUpstreamHandler.second_chunk_written.is_set()
+                rest = response.read()
+            assert _StreamingUpstreamHandler.second_chunk in rest
+        finally:
+            shim.stop()
+            upstream.shutdown()
+            upstream.server_close()

--- a/tests/unit/adapters/codex_sdk/test_errors.py
+++ b/tests/unit/adapters/codex_sdk/test_errors.py
@@ -1,0 +1,85 @@
+"""Tests for the codex error wrapping matrix."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.adapters.codex_sdk.errors import wrap_codex_error
+from karenina.ports import (
+    AdapterUnavailableError,
+    AgentExecutionError,
+    AgentResponseError,
+    AgentTimeoutError,
+)
+
+
+def _named_exception(name: str, message: str = "boom") -> Exception:
+    """Build an exception whose type name matches a codex SDK error class."""
+    return type(name, (Exception,), {})(message)
+
+
+class TestWrapCodexError:
+    def test_missing_binary_maps_to_adapter_unavailable(self) -> None:
+        error, limit = wrap_codex_error(FileNotFoundError("No such file or directory: 'codex'"))
+        assert isinstance(error, AdapterUnavailableError)
+        assert error.fallback_interface == "langchain"
+        assert limit is False
+
+    def test_timeout_maps_to_agent_timeout(self) -> None:
+        error, limit = wrap_codex_error(TimeoutError("took too long"))
+        assert isinstance(error, AgentTimeoutError)
+        assert limit is False
+
+    def test_asyncio_timeout_maps_to_agent_timeout(self) -> None:
+        error, _ = wrap_codex_error(TimeoutError())
+        assert isinstance(error, AgentTimeoutError)
+
+    @pytest.mark.parametrize("name", ["ServerBusyError", "RetryLimitExceededError"])
+    def test_overload_errors_are_execution_errors(self, name: str) -> None:
+        error, limit = wrap_codex_error(_named_exception(name, "server overloaded"))
+        assert isinstance(error, AgentExecutionError)
+        assert not isinstance(error, AgentTimeoutError)
+        assert "transient" in str(error)
+        assert limit is False
+
+    def test_transport_closed_is_execution_error(self) -> None:
+        error, _ = wrap_codex_error(_named_exception("TransportClosedError"))
+        assert isinstance(error, AgentExecutionError)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "JsonRpcError",
+            "CodexRpcError",
+            "ParseError",
+            "InvalidRequestError",
+            "MethodNotFoundError",
+            "InvalidParamsError",
+            "InternalRpcError",
+        ],
+    )
+    def test_jsonrpc_errors_map_to_response_error(self, name: str) -> None:
+        error, limit = wrap_codex_error(_named_exception(name, "rpc failure"))
+        assert isinstance(error, AgentResponseError)
+        assert name in str(error)
+        assert limit is False
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "hit the turn limit for this thread",
+            "model context window exceeded",
+            "recursion depth reached",
+        ],
+    )
+    def test_limit_messages_set_limit_reached(self, message: str) -> None:
+        error, limit = wrap_codex_error(RuntimeError(message))
+        assert isinstance(error, AgentExecutionError)
+        assert limit is True
+        assert error.limit_reached is True
+
+    def test_unknown_error_falls_back_to_execution_error(self) -> None:
+        error, limit = wrap_codex_error(ValueError("something odd"))
+        assert isinstance(error, AgentExecutionError)
+        assert "ValueError" in str(error)
+        assert limit is False

--- a/tests/unit/adapters/codex_sdk/test_messages.py
+++ b/tests/unit/adapters/codex_sdk/test_messages.py
@@ -1,0 +1,248 @@
+"""Tests for CodexMessageConverter conversions per thread item type."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from karenina.adapters.codex_sdk.messages import CodexMessageConverter
+from karenina.ports import Message, Role, ThinkingContent, ToolResultContent
+
+from .conftest import make_agent_message, make_command_execution, make_item, make_reasoning
+
+
+class TestInputConversion:
+    def test_to_prompt_string_joins_user_messages(self) -> None:
+        converter = CodexMessageConverter()
+        messages = [
+            Message.system("Be helpful"),
+            Message.user("Question 1"),
+            Message.user("Question 2"),
+        ]
+        assert converter.to_prompt_string(messages) == "Question 1\n\nQuestion 2"
+
+    def test_extract_system_prompt(self) -> None:
+        converter = CodexMessageConverter()
+        messages = [Message.system("Be helpful"), Message.system("Be concise"), Message.user("Hi")]
+        assert converter.extract_system_prompt(messages) == "Be helpful\n\nBe concise"
+
+    def test_extract_system_prompt_none_when_absent(self) -> None:
+        converter = CodexMessageConverter()
+        assert converter.extract_system_prompt([Message.user("Hi")]) is None
+
+
+class TestHistoryTranscript:
+    """Multi-turn history serialization for scenario re-invocation."""
+
+    def setup_method(self) -> None:
+        self.converter = CodexMessageConverter()
+
+    def test_single_turn_behavior_unchanged(self) -> None:
+        messages = [Message.system("Be helpful"), Message.user("Q1"), Message.user("Q2")]
+        assert self.converter.to_prompt_string(messages) == "Q1\n\nQ2"
+
+    def test_history_renders_labeled_transcript(self) -> None:
+        messages = [
+            Message.system("Be helpful"),
+            Message.user("Pick a fruit"),
+            Message.assistant("I pick mango."),
+            Message.user("Which fruit did you pick?"),
+        ]
+        prompt = self.converter.to_prompt_string(messages)
+        assert prompt.startswith("Conversation so far:")
+        assert "User: Pick a fruit" in prompt
+        assert "Assistant: I pick mango." in prompt
+        assert prompt.endswith("Current user message:\n\nWhich fruit did you pick?")
+        # System prompt stays out of the transcript.
+        assert "Be helpful" not in prompt
+
+    def test_history_order_preserved(self) -> None:
+        messages = [
+            Message.user("Q1"),
+            Message.assistant("A1"),
+            Message.user("Q2"),
+            Message.assistant("A2"),
+            Message.user("Q3"),
+        ]
+        prompt = self.converter.to_prompt_string(messages)
+        assert prompt.index("User: Q1") < prompt.index("Assistant: A1")
+        assert prompt.index("Assistant: A1") < prompt.index("User: Q2")
+        assert prompt.index("Assistant: A2") < prompt.index("Current user message:")
+        assert prompt.rstrip().endswith("Q3")
+
+    def test_tool_activity_summarized(self) -> None:
+        from karenina.ports import ToolUseContent
+
+        messages = [
+            Message.user("List the files"),
+            Message.assistant(
+                "",
+                tool_calls=[ToolUseContent(id="call_1", name="shell", input={"command": "ls"})],
+            ),
+            Message.tool_result(tool_use_id="call_1", content="hello.txt"),
+            Message.user("What did you see?"),
+        ]
+        prompt = self.converter.to_prompt_string(messages)
+        assert "Assistant ran tool shell with arguments:" in prompt
+        assert '"command": "ls"' in prompt
+        assert "Tool result (call_1): hello.txt" in prompt
+
+    def test_error_tool_result_labeled(self) -> None:
+        messages = [
+            Message.user("Run it"),
+            Message.tool_result(tool_use_id="call_2", content="boom", is_error=True),
+            Message.user("And now?"),
+        ]
+        prompt = self.converter.to_prompt_string(messages)
+        assert "Tool result (error) (call_2): boom" in prompt
+
+    def test_thinking_content_skipped(self) -> None:
+        messages = [
+            Message.user("Q1"),
+            Message(role=Role.ASSISTANT, content=[ThinkingContent(thinking="secret reasoning")]),
+            Message.assistant("A1"),
+            Message.user("Q2"),
+        ]
+        prompt = self.converter.to_prompt_string(messages)
+        assert "secret reasoning" not in prompt
+        assert "Assistant: A1" in prompt
+
+    def test_long_tool_result_truncated(self) -> None:
+        long_output = "x" * 5000
+        messages = [
+            Message.user("Run it"),
+            Message.tool_result(tool_use_id="call_3", content=long_output),
+            Message.user("Summarize"),
+        ]
+        prompt = self.converter.to_prompt_string(messages)
+        assert "... [truncated, 5000 chars total]" in prompt
+        assert "x" * 2001 not in prompt
+
+    def test_history_without_trailing_user_message(self) -> None:
+        messages = [Message.user("Q1"), Message.assistant("A1")]
+        prompt = self.converter.to_prompt_string(messages)
+        assert "Assistant: A1" in prompt
+        assert "Current user message:" not in prompt
+
+
+class TestFromProvider:
+    def setup_method(self) -> None:
+        self.converter = CodexMessageConverter()
+
+    def test_agent_message_becomes_assistant_text(self) -> None:
+        result = self.converter.from_provider([make_agent_message("The answer is 42.")])
+        assert len(result) == 1
+        assert result[0].role == Role.ASSISTANT
+        assert result[0].text == "The answer is 42."
+
+    def test_empty_agent_message_skipped(self) -> None:
+        assert self.converter.from_provider([make_agent_message("")]) == []
+
+    def test_reasoning_becomes_thinking_content(self) -> None:
+        result = self.converter.from_provider([make_reasoning(content=["step one", "step two"])])
+        assert len(result) == 1
+        assert result[0].role == Role.ASSISTANT
+        thinking = [c for c in result[0].content if isinstance(c, ThinkingContent)]
+        assert thinking[0].thinking == "step one\n\nstep two"
+
+    def test_reasoning_falls_back_to_summary(self) -> None:
+        item = make_item("reasoning", id="r1", content=[], summary=["summarized thought"])
+        result = self.converter.from_provider([item])
+        assert isinstance(result[0].content[0], ThinkingContent)
+        assert result[0].content[0].thinking == "summarized thought"
+
+    def test_command_execution_becomes_shell_pair(self) -> None:
+        item = make_command_execution(item_id="cmd_1", command="echo hi", output="hi\n", exit_code=0)
+        result = self.converter.from_provider([item])
+        assert len(result) == 2
+        use, tool = result
+        assert use.role == Role.ASSISTANT
+        assert use.tool_calls[0].name == "shell"
+        assert use.tool_calls[0].id == "cmd_1"
+        assert use.tool_calls[0].input == {"command": "echo hi"}
+        assert tool.role == Role.TOOL
+        block = tool.content[0]
+        assert isinstance(block, ToolResultContent)
+        assert block.tool_use_id == "cmd_1"
+        assert block.content == "hi\n"
+        assert block.is_error is False
+
+    def test_command_execution_nonzero_exit_is_error(self) -> None:
+        item = make_command_execution(exit_code=1, output="boom")
+        _, tool = self.converter.from_provider([item])
+        assert tool.content[0].is_error is True
+
+    def test_command_execution_failed_status_is_error(self) -> None:
+        item = make_command_execution(exit_code=None, status="failed")
+        _, tool = self.converter.from_provider([item])
+        assert tool.content[0].is_error is True
+
+    def test_mcp_tool_call_pair(self) -> None:
+        item = make_item(
+            "mcpToolCall",
+            id="mcp_1",
+            server="fetch",
+            tool="get_url",
+            arguments={"url": "http://x"},
+            result=SimpleNamespace(content=["ok"]),
+            error=None,
+            status="completed",
+        )
+        use, tool = self.converter.from_provider([item])
+        assert use.tool_calls[0].name == "mcp__fetch__get_url"
+        assert use.tool_calls[0].input == {"url": "http://x"}
+        assert tool.content[0].tool_use_id == "mcp_1"
+        assert tool.content[0].is_error is False
+
+    def test_mcp_tool_call_error(self) -> None:
+        item = make_item(
+            "mcpToolCall",
+            id="mcp_2",
+            server="fetch",
+            tool="get_url",
+            arguments=None,
+            result=None,
+            error=SimpleNamespace(message="connection refused"),
+            status="failed",
+        )
+        use, tool = self.converter.from_provider([item])
+        assert tool.content[0].is_error is True
+        assert tool.content[0].content == "connection refused"
+        assert use.tool_calls[0].input == {"arguments": ""}
+
+    def test_file_change_pair(self) -> None:
+        item = make_item(
+            "fileChange",
+            id="fc_1",
+            changes=[SimpleNamespace(path="src/main.py", kind="update", diff="...")],
+            status="completed",
+        )
+        use, tool = self.converter.from_provider([item])
+        assert use.tool_calls[0].name == "apply_patch"
+        assert use.tool_calls[0].input == {"changes": [{"path": "src/main.py", "kind": "update"}]}
+        assert "src/main.py" in tool.content[0].content
+        assert tool.content[0].is_error is False
+
+    def test_web_search_pair(self) -> None:
+        item = make_item("webSearch", id="ws_1", query="codex sdk docs", action=None)
+        use, tool = self.converter.from_provider([item])
+        assert use.tool_calls[0].name == "web_search"
+        assert use.tool_calls[0].input == {"query": "codex sdk docs"}
+        assert tool.content[0].tool_use_id == "ws_1"
+
+    def test_user_message_converted(self) -> None:
+        item = make_item(
+            "userMessage",
+            id="u1",
+            content=[SimpleNamespace(text="hello there")],
+        )
+        result = self.converter.from_provider([item])
+        assert result[0].role == Role.USER
+        assert result[0].text == "hello there"
+
+    def test_unknown_item_type_skipped(self) -> None:
+        assert self.converter.from_provider([make_item("plan", id="p1")]) == []
+
+    def test_root_model_wrapper_unwrapped(self) -> None:
+        wrapped = SimpleNamespace(root=make_agent_message("wrapped"))
+        result = self.converter.from_provider([wrapped])
+        assert result[0].text == "wrapped"

--- a/tests/unit/adapters/codex_sdk/test_registration.py
+++ b/tests/unit/adapters/codex_sdk/test_registration.py
@@ -1,0 +1,89 @@
+"""Tests for codex_sdk registration, availability, and ModelConfig validation."""
+
+from __future__ import annotations
+
+import builtins
+from typing import Any
+
+import pytest
+
+from karenina.adapters.codex_sdk.availability import check_codex_available
+from karenina.adapters.registry import AdapterRegistry
+from karenina.schemas.config import ModelConfig
+
+
+class TestRegistration:
+    def test_spec_registered(self) -> None:
+        spec = AdapterRegistry.get_spec("codex_sdk")
+        assert spec is not None
+        assert spec.interface == "codex_sdk"
+        assert spec.agent_factory is not None
+        assert spec.llm_factory is None
+        assert spec.parser_factory is None
+        assert spec.fallback_interface == "langchain"
+        assert spec.agent_tier == "deep_agent"
+        assert spec.requires_provider is False
+        # MCP is a warn-and-skip stub for now (see mcp.py), so the spec
+        # must not advertise support.
+        assert spec.supports_mcp is False
+        assert spec.supports_tools is True
+
+    def test_model_config_validates_interface(self) -> None:
+        config = ModelConfig(
+            id="codex",
+            model_name="qwen3.5-122b-a10b",
+            interface="codex_sdk",
+            endpoint_base_url="http://example-endpoint:8000/v1",
+        )
+        assert config.interface == "codex_sdk"
+
+    def test_model_provider_not_required(self) -> None:
+        config = ModelConfig(id="codex", model_name="m", interface="codex_sdk")
+        assert config.model_provider is None
+
+    def test_agent_factory_returns_adapter(self) -> None:
+        from karenina.adapters.codex_sdk.agent import CodexSDKAgentAdapter
+
+        spec = AdapterRegistry.get_spec("codex_sdk")
+        assert spec is not None and spec.agent_factory is not None
+        adapter = spec.agent_factory(ModelConfig(id="codex", model_name="m", interface="codex_sdk"))
+        assert isinstance(adapter, CodexSDKAgentAdapter)
+
+    def test_runtime_capabilities_profile_registered(self) -> None:
+        from karenina.adapters.agent_runtime import get_agent_runtime_capabilities
+
+        read_write = ModelConfig(id="c", model_name="m", interface="codex_sdk")
+        caps = get_agent_runtime_capabilities(read_write)
+        assert caps.supports_file_tools is True
+        assert caps.supports_code_execution is True
+        assert caps.uses_sandboxed_execution is True
+
+        read_only = ModelConfig(
+            id="c",
+            model_name="m",
+            interface="codex_sdk",
+            extra_kwargs={"agent_runtime": {"access_mode": "read_only"}},
+        )
+        assert get_agent_runtime_capabilities(read_only).supports_code_execution is False
+
+
+class TestAvailability:
+    def test_available_when_sdk_installed(self) -> None:
+        pytest.importorskip("openai_codex", reason="openai-codex not installed")
+        availability = check_codex_available()
+        assert availability.available is True
+        assert "binary" in availability.reason
+
+    def test_unavailable_when_sdk_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "openai_codex":
+                raise ImportError("No module named 'openai_codex'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        availability = check_codex_available()
+        assert availability.available is False
+        assert availability.fallback_interface == "langchain"
+        assert "openai-codex" in availability.reason

--- a/tests/unit/adapters/codex_sdk/test_trace.py
+++ b/tests/unit/adapters/codex_sdk/test_trace.py
@@ -1,0 +1,85 @@
+"""Tests for codex trace conversion: canonical raw_trace and trace_messages."""
+
+from __future__ import annotations
+
+from karenina.adapters.codex_sdk.trace import (
+    codex_items_to_raw_trace,
+    codex_items_to_trace_messages,
+    extract_final_response,
+)
+
+from .conftest import make_agent_message, make_command_execution, make_item, make_reasoning
+
+
+def _full_turn_items() -> list:
+    return [
+        make_reasoning(content=["I should create the file."]),
+        make_command_execution(item_id="cmd_1", command="echo hi > hello.txt", output="", exit_code=0),
+        make_command_execution(item_id="cmd_2", command="cat missing.txt", output="no such file", exit_code=1),
+        make_agent_message("Created hello.txt.", phase="final_answer"),
+    ]
+
+
+class TestRawTrace:
+    def test_canonical_delimiters_present(self) -> None:
+        trace = codex_items_to_raw_trace(_full_turn_items())
+        assert "--- Thinking ---\nI should create the file." in trace
+        assert "--- AI Message ---" in trace
+        assert "--- Tool Message (call_id: cmd_1) ---" in trace
+
+    def test_shell_tool_call_block_format(self) -> None:
+        trace = codex_items_to_raw_trace(_full_turn_items())
+        assert "Tool Calls:" in trace
+        assert "  shell (call_cmd_1)" in trace
+        assert "   Call ID: cmd_1" in trace
+        assert "   Args: {'command': 'echo hi > hello.txt'}" in trace
+
+    def test_failed_command_marked_as_error(self) -> None:
+        trace = codex_items_to_raw_trace(_full_turn_items())
+        assert "--- Tool Message (call_id: cmd_2) ---\n[ERROR] no such file" in trace
+
+    def test_final_text_in_ai_message_section(self) -> None:
+        trace = codex_items_to_raw_trace(_full_turn_items())
+        assert "--- AI Message ---\nCreated hello.txt." in trace
+
+    def test_user_messages_excluded_by_default(self) -> None:
+        items = [make_item("userMessage", id="u1", content=[]), make_agent_message("hi")]
+        trace = codex_items_to_raw_trace(items)
+        assert "Human Message" not in trace
+
+    def test_empty_items_give_empty_trace(self) -> None:
+        assert codex_items_to_raw_trace([]) == ""
+
+
+class TestTraceMessages:
+    def test_structure_and_block_indices(self) -> None:
+        messages = codex_items_to_trace_messages(_full_turn_items())
+        assert [m["block_index"] for m in messages] == list(range(len(messages)))
+        roles = [m["role"] for m in messages]
+        # thinking, shell use, shell result, shell use, shell result, final text
+        assert roles == ["assistant", "assistant", "tool", "assistant", "tool", "assistant"]
+
+    def test_tool_use_and_result_pair_share_id(self) -> None:
+        messages = codex_items_to_trace_messages(_full_turn_items())
+        use = next(m for m in messages if m.get("tool_calls"))
+        result = next(m for m in messages if m.get("tool_result"))
+        assert use["tool_calls"][0]["id"] == result["tool_result"]["tool_use_id"] == "cmd_1"
+        assert use["tool_calls"][0]["name"] == "shell"
+
+    def test_error_result_flagged(self) -> None:
+        messages = codex_items_to_trace_messages(_full_turn_items())
+        failing = [m for m in messages if m.get("tool_result", {}).get("tool_use_id") == "cmd_2"]
+        assert failing[0]["tool_result"]["is_error"] is True
+
+    def test_thinking_metadata_present(self) -> None:
+        messages = codex_items_to_trace_messages(_full_turn_items())
+        assert messages[0]["thinking"] == {"thinking": "I should create the file."}
+
+
+class TestExtractFinalResponse:
+    def test_last_agent_message_wins(self) -> None:
+        items = [make_agent_message("first"), make_agent_message("second")]
+        assert extract_final_response(items) == "second"
+
+    def test_none_when_no_text(self) -> None:
+        assert extract_final_response([make_command_execution()]) is None

--- a/tests/unit/adapters/codex_sdk/test_usage.py
+++ b/tests/unit/adapters/codex_sdk/test_usage.py
@@ -1,0 +1,61 @@
+"""Tests for codex usage extraction."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from karenina.adapters.codex_sdk.usage import extract_codex_usage
+
+from .conftest import make_usage
+
+
+class TestExtractCodexUsage:
+    def test_total_breakdown_mapped(self) -> None:
+        usage = extract_codex_usage(make_usage(input_tokens=29306, output_tokens=125, cached=7), model="qwen")
+        assert usage.input_tokens == 29306
+        assert usage.output_tokens == 125
+        assert usage.total_tokens == 29431
+        assert usage.cache_read_tokens == 7
+        assert usage.cache_creation_tokens is None
+        assert usage.cost_usd is None
+        assert usage.model == "qwen"
+
+    def test_none_usage_returns_zeroed(self) -> None:
+        usage = extract_codex_usage(None, model="qwen")
+        assert usage.input_tokens == 0
+        assert usage.output_tokens == 0
+        assert usage.total_tokens == 0
+        assert usage.model == "qwen"
+
+    def test_falls_back_to_last_breakdown(self) -> None:
+        wrapper = SimpleNamespace(
+            total=None,
+            last=SimpleNamespace(
+                cached_input_tokens=0,
+                input_tokens=10,
+                output_tokens=5,
+                reasoning_output_tokens=0,
+                total_tokens=15,
+            ),
+        )
+        usage = extract_codex_usage(wrapper)
+        assert usage.input_tokens == 10
+        assert usage.total_tokens == 15
+
+    def test_bare_breakdown_tolerated(self) -> None:
+        breakdown = SimpleNamespace(
+            cached_input_tokens=1,
+            input_tokens=8,
+            output_tokens=2,
+            reasoning_output_tokens=0,
+            total_tokens=10,
+        )
+        usage = extract_codex_usage(breakdown)
+        assert usage.input_tokens == 8
+        assert usage.output_tokens == 2
+
+    def test_missing_total_tokens_computed(self) -> None:
+        breakdown = SimpleNamespace(input_tokens=3, output_tokens=4)
+        usage = extract_codex_usage(SimpleNamespace(total=breakdown, last=None))
+        assert usage.total_tokens == 7
+        assert usage.cache_read_tokens is None

--- a/uv.lock
+++ b/uv.lock
@@ -2320,6 +2320,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+codex = [
+    { name = "openai-codex" },
+]
 deep-agents = [
     { name = "deepagents" },
     { name = "langchain-mcp-adapters" },
@@ -2424,6 +2427,7 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.20.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "numpy", specifier = "<2.3" },
+    { name = "openai-codex", marker = "extra == 'codex'", specifier = "==0.1.0b2" },
     { name = "openpyxl", specifier = ">=3.0.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
@@ -3803,6 +3807,32 @@ wheels = [
 ]
 
 [[package]]
+name = "openai-codex"
+version = "0.1.0b2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openai-codex-cli-bin" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/b7/216fa0e7725c33791fe97621c663a9ec0e6e98c2240bffae89661de55602/openai_codex-0.1.0b2.tar.gz", hash = "sha256:44dd51f004ce2ed51cf7b9f34e8b2e6a207ab06e8739b45d5a0cfe338e460587", size = 57665 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/38/59e86bc20bdd4390faa979d2a0235d7be60ae895cd3ac6a92a49bfe080a7/openai_codex-0.1.0b2-py3-none-any.whl", hash = "sha256:9edf0871e9e0d6e3951cd6c3b9b187641e6247d9413402dfc66ac3a5f6ba66ff", size = 64285 },
+]
+
+[[package]]
+name = "openai-codex-cli-bin"
+version = "0.132.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/a1/b92b7a1b73a83785d2e1dcd0faecd1b7f886a38cf02a30abe1c35f42f0f7/openai_codex_cli_bin-0.132.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:1c22b51dbd679413f84f00b9d8fd4e5cf8a1c0d1c7cc8c42bcb3f9f1b33e2334", size = 89403211 },
+    { url = "https://files.pythonhosted.org/packages/5f/68/163272e582de55a7f460e2329281267908d75d0fbcbbbb2c6749a6329e6b/openai_codex_cli_bin-0.132.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:56217495e6635c8a5d96df820cc0da5f46cd9b6ec6f3a5f67f1607d69ef74256", size = 79058685 },
+    { url = "https://files.pythonhosted.org/packages/0b/18/a60c6b137e7cd3959cae16ba757f57ca5702979b0ea107a21f516ba15d98/openai_codex_cli_bin-0.132.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:09642e7578a3078bfccc82af4077b085d42b0022b529e4b5c645e0a0af3397a4", size = 78689038 },
+    { url = "https://files.pythonhosted.org/packages/f8/eb/1b184307a67c1006d59b61636bcfcea73a89aa95271f6516ed28dce554ca/openai_codex_cli_bin-0.132.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:85aec095f9d144d7a2d1aff39fce77b7240f42014580c35801ba74b9317aa5f7", size = 85528820 },
+    { url = "https://files.pythonhosted.org/packages/0e/e8/1b823a8bf7b96d1513905ad79b16a146d797f81a19a6bc350a2f95a16661/openai_codex_cli_bin-0.132.0-py3-none-win_amd64.whl", hash = "sha256:3cb5c90c55baa39bd5ddc890d2068d3e1322a57a54d1d0e623819009a205c7f5", size = 86916218 },
+    { url = "https://files.pythonhosted.org/packages/6b/e6/bb8634bd4f3adaea299c95d7b03105ac417e32dd6d8bc2af5dda141d6f28/openai_codex_cli_bin-0.132.0-py3-none-win_arm64.whl", hash = "sha256:74ef93d3deef7cb83c71d19fc667defe749cdab337ec331f59a23511561b6f6a", size = 79892931 },
+]
+
+[[package]]
 name = "openpyxl"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -4378,7 +4408,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.7"
+version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -4386,74 +4416,103 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db", size = 788350 }
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782 },
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262 },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.33.2"
+version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195 }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/8d/71db63483d518cbbf290261a1fc2839d17ff89fce7089e08cad07ccfce67/pydantic_core-2.33.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c5b0a576fb381edd6d27f0a85915c6daf2f8138dc5c267a57c08a62900758c7", size = 2028584 },
-    { url = "https://files.pythonhosted.org/packages/24/2f/3cfa7244ae292dd850989f328722d2aef313f74ffc471184dc509e1e4e5a/pydantic_core-2.33.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e799c050df38a639db758c617ec771fd8fb7a5f8eaaa4b27b101f266b216a246", size = 1855071 },
-    { url = "https://files.pythonhosted.org/packages/b3/d3/4ae42d33f5e3f50dd467761304be2fa0a9417fbf09735bc2cce003480f2a/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc46a01bf8d62f227d5ecee74178ffc448ff4e5197c756331f71efcc66dc980f", size = 1897823 },
-    { url = "https://files.pythonhosted.org/packages/f4/f3/aa5976e8352b7695ff808599794b1fba2a9ae2ee954a3426855935799488/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a144d4f717285c6d9234a66778059f33a89096dfb9b39117663fd8413d582dcc", size = 1983792 },
-    { url = "https://files.pythonhosted.org/packages/d5/7a/cda9b5a23c552037717f2b2a5257e9b2bfe45e687386df9591eff7b46d28/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73cf6373c21bc80b2e0dc88444f41ae60b2f070ed02095754eb5a01df12256de", size = 2136338 },
-    { url = "https://files.pythonhosted.org/packages/2b/9f/b8f9ec8dd1417eb9da784e91e1667d58a2a4a7b7b34cf4af765ef663a7e5/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3dc625f4aa79713512d1976fe9f0bc99f706a9dee21dfd1810b4bbbf228d0e8a", size = 2730998 },
-    { url = "https://files.pythonhosted.org/packages/47/bc/cd720e078576bdb8255d5032c5d63ee5c0bf4b7173dd955185a1d658c456/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b21b5549499972441da4758d662aeea93f1923f953e9cbaff14b8b9565aef", size = 2003200 },
-    { url = "https://files.pythonhosted.org/packages/ca/22/3602b895ee2cd29d11a2b349372446ae9727c32e78a94b3d588a40fdf187/pydantic_core-2.33.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bdc25f3681f7b78572699569514036afe3c243bc3059d3942624e936ec93450e", size = 2113890 },
-    { url = "https://files.pythonhosted.org/packages/ff/e6/e3c5908c03cf00d629eb38393a98fccc38ee0ce8ecce32f69fc7d7b558a7/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fe5b32187cbc0c862ee201ad66c30cf218e5ed468ec8dc1cf49dec66e160cc4d", size = 2073359 },
-    { url = "https://files.pythonhosted.org/packages/12/e7/6a36a07c59ebefc8777d1ffdaf5ae71b06b21952582e4b07eba88a421c79/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:bc7aee6f634a6f4a95676fcb5d6559a2c2a390330098dba5e5a5f28a2e4ada30", size = 2245883 },
-    { url = "https://files.pythonhosted.org/packages/16/3f/59b3187aaa6cc0c1e6616e8045b284de2b6a87b027cce2ffcea073adf1d2/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:235f45e5dbcccf6bd99f9f472858849f73d11120d76ea8707115415f8e5ebebf", size = 2241074 },
-    { url = "https://files.pythonhosted.org/packages/e0/ed/55532bb88f674d5d8f67ab121a2a13c385df382de2a1677f30ad385f7438/pydantic_core-2.33.2-cp311-cp311-win32.whl", hash = "sha256:6368900c2d3ef09b69cb0b913f9f8263b03786e5b2a387706c5afb66800efd51", size = 1910538 },
-    { url = "https://files.pythonhosted.org/packages/fe/1b/25b7cccd4519c0b23c2dd636ad39d381abf113085ce4f7bec2b0dc755eb1/pydantic_core-2.33.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e063337ef9e9820c77acc768546325ebe04ee38b08703244c1309cccc4f1bab", size = 1952909 },
-    { url = "https://files.pythonhosted.org/packages/49/a9/d809358e49126438055884c4366a1f6227f0f84f635a9014e2deb9b9de54/pydantic_core-2.33.2-cp311-cp311-win_arm64.whl", hash = "sha256:6b99022f1d19bc32a4c2a0d544fc9a76e3be90f0b3f4af413f87d38749300e65", size = 1897786 },
-    { url = "https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc", size = 2009000 },
-    { url = "https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7", size = 1847996 },
-    { url = "https://files.pythonhosted.org/packages/d6/46/6dcdf084a523dbe0a0be59d054734b86a981726f221f4562aed313dbcb49/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025", size = 1880957 },
-    { url = "https://files.pythonhosted.org/packages/ec/6b/1ec2c03837ac00886ba8160ce041ce4e325b41d06a034adbef11339ae422/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011", size = 1964199 },
-    { url = "https://files.pythonhosted.org/packages/2d/1d/6bf34d6adb9debd9136bd197ca72642203ce9aaaa85cfcbfcf20f9696e83/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f", size = 2120296 },
-    { url = "https://files.pythonhosted.org/packages/e0/94/2bd0aaf5a591e974b32a9f7123f16637776c304471a0ab33cf263cf5591a/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88", size = 2676109 },
-    { url = "https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1", size = 2002028 },
-    { url = "https://files.pythonhosted.org/packages/cb/d5/7bb781bf2748ce3d03af04d5c969fa1308880e1dca35a9bd94e1a96a922e/pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b", size = 2100044 },
-    { url = "https://files.pythonhosted.org/packages/fe/36/def5e53e1eb0ad896785702a5bbfd25eed546cdcf4087ad285021a90ed53/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1", size = 2058881 },
-    { url = "https://files.pythonhosted.org/packages/01/6c/57f8d70b2ee57fc3dc8b9610315949837fa8c11d86927b9bb044f8705419/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6", size = 2227034 },
-    { url = "https://files.pythonhosted.org/packages/27/b9/9c17f0396a82b3d5cbea4c24d742083422639e7bb1d5bf600e12cb176a13/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea", size = 2234187 },
-    { url = "https://files.pythonhosted.org/packages/b0/6a/adf5734ffd52bf86d865093ad70b2ce543415e0e356f6cacabbc0d9ad910/pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290", size = 1892628 },
-    { url = "https://files.pythonhosted.org/packages/43/e4/5479fecb3606c1368d496a825d8411e126133c41224c1e7238be58b87d7e/pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2", size = 1955866 },
-    { url = "https://files.pythonhosted.org/packages/0d/24/8b11e8b3e2be9dd82df4b11408a67c61bb4dc4f8e11b5b0fc888b38118b5/pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab", size = 1888894 },
-    { url = "https://files.pythonhosted.org/packages/46/8c/99040727b41f56616573a28771b1bfa08a3d3fe74d3d513f01251f79f172/pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f", size = 2015688 },
-    { url = "https://files.pythonhosted.org/packages/3a/cc/5999d1eb705a6cefc31f0b4a90e9f7fc400539b1a1030529700cc1b51838/pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6", size = 1844808 },
-    { url = "https://files.pythonhosted.org/packages/6f/5e/a0a7b8885c98889a18b6e376f344da1ef323d270b44edf8174d6bce4d622/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef", size = 1885580 },
-    { url = "https://files.pythonhosted.org/packages/3b/2a/953581f343c7d11a304581156618c3f592435523dd9d79865903272c256a/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a", size = 1973859 },
-    { url = "https://files.pythonhosted.org/packages/e6/55/f1a813904771c03a3f97f676c62cca0c0a4138654107c1b61f19c644868b/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916", size = 2120810 },
-    { url = "https://files.pythonhosted.org/packages/aa/c3/053389835a996e18853ba107a63caae0b9deb4a276c6b472931ea9ae6e48/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a", size = 2676498 },
-    { url = "https://files.pythonhosted.org/packages/eb/3c/f4abd740877a35abade05e437245b192f9d0ffb48bbbbd708df33d3cda37/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d", size = 2000611 },
-    { url = "https://files.pythonhosted.org/packages/59/a7/63ef2fed1837d1121a894d0ce88439fe3e3b3e48c7543b2a4479eb99c2bd/pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56", size = 2107924 },
-    { url = "https://files.pythonhosted.org/packages/04/8f/2551964ef045669801675f1cfc3b0d74147f4901c3ffa42be2ddb1f0efc4/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5", size = 2063196 },
-    { url = "https://files.pythonhosted.org/packages/26/bd/d9602777e77fc6dbb0c7db9ad356e9a985825547dce5ad1d30ee04903918/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e", size = 2236389 },
-    { url = "https://files.pythonhosted.org/packages/42/db/0e950daa7e2230423ab342ae918a794964b053bec24ba8af013fc7c94846/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162", size = 2239223 },
-    { url = "https://files.pythonhosted.org/packages/58/4d/4f937099c545a8a17eb52cb67fe0447fd9a373b348ccfa9a87f141eeb00f/pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849", size = 1900473 },
-    { url = "https://files.pythonhosted.org/packages/a0/75/4a0a9bac998d78d889def5e4ef2b065acba8cae8c93696906c3a91f310ca/pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9", size = 1955269 },
-    { url = "https://files.pythonhosted.org/packages/f9/86/1beda0576969592f1497b4ce8e7bc8cbdf614c352426271b1b10d5f0aa64/pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9", size = 1893921 },
-    { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162 },
-    { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560 },
-    { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777 },
-    { url = "https://files.pythonhosted.org/packages/7b/27/d4ae6487d73948d6f20dddcd94be4ea43e74349b56eba82e9bdee2d7494c/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:dd14041875d09cc0f9308e37a6f8b65f5585cf2598a53aa0123df8b129d481f8", size = 2025200 },
-    { url = "https://files.pythonhosted.org/packages/f1/b8/b3cb95375f05d33801024079b9392a5ab45267a63400bf1866e7ce0f0de4/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d87c561733f66531dced0da6e864f44ebf89a8fba55f31407b00c2f7f9449593", size = 1859123 },
-    { url = "https://files.pythonhosted.org/packages/05/bc/0d0b5adeda59a261cd30a1235a445bf55c7e46ae44aea28f7bd6ed46e091/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f82865531efd18d6e07a04a17331af02cb7a651583c418df8266f17a63c6612", size = 1892852 },
-    { url = "https://files.pythonhosted.org/packages/3e/11/d37bdebbda2e449cb3f519f6ce950927b56d62f0b84fd9cb9e372a26a3d5/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bfb5112df54209d820d7bf9317c7a6c9025ea52e49f46b6a2060104bba37de7", size = 2067484 },
-    { url = "https://files.pythonhosted.org/packages/8c/55/1f95f0a05ce72ecb02a8a8a1c3be0579bbc29b1d5ab68f1378b7bebc5057/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:64632ff9d614e5eecfb495796ad51b0ed98c453e447a76bcbeeb69615079fc7e", size = 2108896 },
-    { url = "https://files.pythonhosted.org/packages/53/89/2b2de6c81fa131f423246a9109d7b2a375e83968ad0800d6e57d0574629b/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f889f7a40498cc077332c7ab6b4608d296d852182211787d4f3ee377aaae66e8", size = 2069475 },
-    { url = "https://files.pythonhosted.org/packages/b8/e9/1f7efbe20d0b2b10f6718944b5d8ece9152390904f29a78e68d4e7961159/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf", size = 2239013 },
-    { url = "https://files.pythonhosted.org/packages/3c/b2/5309c905a93811524a49b4e031e9851a6b00ff0fb668794472ea7746b448/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb", size = 2238715 },
-    { url = "https://files.pythonhosted.org/packages/32/56/8a7ca5d2cd2cda1d245d34b1c9a942920a718082ae8e54e5f3e5a58b7add/pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1", size = 2066757 },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872 },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255 },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827 },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051 },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314 },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146 },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685 },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420 },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122 },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573 },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139 },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433 },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513 },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114 },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298 },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158 },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724 },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742 },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418 },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274 },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940 },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516 },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854 },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306 },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044 },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133 },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464 },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823 },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919 },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604 },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306 },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906 },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802 },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446 },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757 },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275 },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467 },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417 },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782 },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782 },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334 },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986 },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693 },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819 },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411 },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079 },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179 },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926 },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785 },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733 },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534 },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732 },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627 },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141 },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325 },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990 },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978 },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354 },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238 },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251 },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593 },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226 },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605 },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777 },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641 },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404 },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219 },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594 },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542 },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146 },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309 },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736 },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575 },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624 },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325 },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782 },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146 },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492 },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604 },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828 },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000 },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286 },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071 },
 ]
 
 [[package]]
@@ -5859,11 +5918,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.0"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4", size = 107423 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af", size = 43839 },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614 },
 ]
 
 [[package]]
@@ -5881,14 +5940,14 @@ wheels = [
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.1"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726 }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552 },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Adds a new AgentPort adapter (`interface="codex_sdk"`) wrapping OpenAI's Codex Python SDK, which drives a bundled `codex app-server` binary over JSON-RPC. Each run spawns a fresh `AsyncCodex` subprocess, runs one turn, and tears it down (per-run subprocess model, mirroring the Claude Agent SDK adapter). Codex brings its own deep-agent runtime (shell, apply_patch, planning, web search) under an OS-level sandbox, and targets OpenAI-compatible endpoints such as vLLM.

## Changes Made

### New adapter package
- `src/karenina/adapters/codex_sdk/` with `agent.py`, `config_builder.py`, `endpoint_shim.py`, `messages.py`, `trace.py`, `usage.py`, `errors.py`, `availability.py`, `mcp.py`, `registration.py`.
- The vLLM path uses `wire_api="responses"` plus a per-run localhost rewriting shim (`endpoint_shim.py`) that folds developer and system messages into the top-level `instructions` string and strips reasoning items, because the codex CLI dropped `wire_api="chat"` and stock vLLM `/v1/responses` rejects codex's raw shape. The API key travels only via an env var, never inside a `--config` string.

### Registration and packaging
- New interface name `codex_sdk`, registered via an append-only `try/except` block in `AdapterRegistry`. Agent-only spec (`llm_factory=None`, `parser_factory=None`), `fallback_interface="langchain"`, `agent_tier="deep_agent"`.
- Selected via `ModelConfig(interface="codex_sdk", ...)`. No new `ModelConfig` fields; reuses `model_name`, `endpoint_base_url`, `endpoint_api_key`, `system_prompt`, and the shared `agent_runtime` access mode.
- New optional dependency behind a `[codex]` extra: `openai-codex==0.1.0b2` (pinned), lazily imported.

## Testing
- New unit tests under the `codex_sdk` namespace, using duck-typed stand-ins so they run without `openai-codex` installed.
- New live suite validating QA, agentic shell tasks, a two-turn scenario, and concurrency against vLLM.
- Full suite validation deferred to CI on this PR.

## Additional Context
- **Purely additive to shared code.** The only edit to a shared runtime file is the appended registry import block. `factory.py` is not touched. The package imports fine without `openai-codex` installed (lazy imports plus fallback).
- **One broad ripple:** `uv.lock` regeneration bumps `pydantic` to `2.13.4` for everyone using the lockfile (forced by `openai-codex`'s floor), not only `[codex]` users.
- Adapter model calls run outside the `GlobalLLMLimiter` cap (documented).
- Known documented gaps: no per-turn cap (`max_turns` best-effort), MCP servers warn and skip, cost is `None` for custom endpoints.
- **Merge order:** top of a stacked series into `dev`. Merge #178, #179, #180, #181 first, then this PR. It is chained on `fix/async-consistency` and auto-retargets to `dev` once its parents merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9J43c7xkP3mYpvjQrzZbP
