### PR TITLE
fix: preserve literal callable classes in checkpoints

### DIFF
--- a/src/karenina/utils/checkpoint_trait_converters.py
+++ b/src/karenina/utils/checkpoint_trait_converters.py
@@ -130,6 +130,8 @@ def _convert_callable_trait_to_rating(trait: CallableRubricTrait, rubric_type: s
             additional_props.append(SchemaOrgPropertyValue(name="max_score", value=trait.max_score))
     if trait.summary is not None:
         additional_props.append(SchemaOrgPropertyValue(name="summary", value=trait.summary))
+    if trait.classes is not None:
+        additional_props.append(SchemaOrgPropertyValue(name="classes", value=trait.classes))
 
     # Determine best/worst rating based on kind
     if trait.kind == "boolean":
@@ -442,19 +444,20 @@ def _convert_rating_to_callable_trait(rating: SchemaOrgRating) -> CallableRubric
     """Convert SchemaOrgRating to CallableRubricTrait."""
     # Extract configuration from additionalProperty
     callable_code = b""
-    kind: Literal["boolean", "score"] = "boolean"
+    kind: TraitKind = "boolean"
     invert_result = False
     min_score = None
     max_score = None
     higher_is_better = True  # Legacy default
     summary: str | None = None
+    classes: dict[str, str] | None = None
 
     if rating.additionalProperty:
         for prop in rating.additionalProperty:
             if prop.name == "callable_code":
                 callable_code = base64.b64decode(prop.value)
             elif prop.name == "kind":
-                kind = cast(Literal["boolean", "score"], prop.value)
+                kind = cast(TraitKind, prop.value)
             elif prop.name == "invert_result":
                 invert_result = prop.value
             elif prop.name == "min_score":
@@ -465,6 +468,14 @@ def _convert_rating_to_callable_trait(rating: SchemaOrgRating) -> CallableRubric
                 higher_is_better = prop.value
             elif prop.name == "summary":
                 summary = prop.value
+            elif prop.name == "classes":
+                if isinstance(prop.value, dict):
+                    classes = prop.value
+                elif isinstance(prop.value, str):
+                    try:
+                        classes = json.loads(prop.value)
+                    except json.JSONDecodeError:
+                        logger.warning("Failed to parse classes JSON for trait '%s'", rating.name)
 
     return CallableRubricTrait(
         name=rating.name,
@@ -476,7 +487,7 @@ def _convert_rating_to_callable_trait(rating: SchemaOrgRating) -> CallableRubric
         max_score=max_score,
         invert_result=invert_result,
         higher_is_better=higher_is_better,
-        classes=None,
+        classes=classes,
     )
 
 

--- a/tests/unit/benchmark/test_literal_callable_checkpoint.py
+++ b/tests/unit/benchmark/test_literal_callable_checkpoint.py
@@ -1,0 +1,37 @@
+"""Regression coverage for literal callable checkpoint persistence."""
+
+from pathlib import Path
+
+import pytest
+
+from karenina.benchmark import Benchmark
+from karenina.schemas.entities.rubric import CallableRubricTrait, Rubric
+
+
+@pytest.mark.unit
+def test_literal_callable_trait_attaches_and_survives_checkpoint_roundtrip(tmp_path: Path) -> None:
+    """Literal callable classes survive eager cache rebuild and save/load."""
+    classes = {
+        "refuted": "Database refutes it",
+        "supported": "Database supports it",
+    }
+    trait = CallableRubricTrait.from_callable(
+        name="kb_verdict",
+        func=lambda _text: "supported",
+        kind="literal",
+        classes=classes,
+    )
+    benchmark = Benchmark.create(name="literal-callable", description="")
+    benchmark.add_question(question="q", raw_answer="a", question_id="q1")
+
+    benchmark.set_question_rubric("q1", Rubric(callable_traits=[trait]))
+
+    checkpoint_path = tmp_path / "literal_callable.jsonld"
+    benchmark.save(checkpoint_path)
+    restored = Benchmark.load(checkpoint_path)
+    rubric = restored.get_question_rubric("q1")
+
+    assert rubric is not None
+    restored_trait = rubric.callable_traits[0]
+    assert restored_trait.classes == classes
+    assert restored_trait.evaluate("anything") == 1


### PR DESCRIPTION
## Summary
- persist classes for callable rubric traits in JSON-LD checkpoints
- restore literal callable classes from dict and JSON-string checkpoint values
- cover attachment plus save/load round-trip with a regression test

## Testing
- PYTHONPATH=src pytest tests/unit/benchmark/test_literal_callable_checkpoint.py tests/unit/utils/test_checkpoint.py -q
- ruff check src/karenina/utils/checkpoint_trait_converters.py tests/unit/benchmark/test_literal_callable_checkpoint.py

This supersedes #188, which merged the stale remote branch before the fix commit reached GitHub.