### PR TITLE
fix(taskeval): wire callable registry overrides

### DIFF
--- a/docs/core_concepts/task-eval.md
+++ b/docs/core_concepts/task-eval.md
@@ -193,7 +193,7 @@ task = TaskEval(
 
 The global scope evaluates all logs together. Per-step scopes evaluate only the logs, templates, and rubrics attached to that step. When you call `evaluate()` without a `step_id`, TaskEval runs global evaluation first, then automatically evaluates each step that has data.
 
-The constructor accepts two additional parameters: `merge_strategy` (see [Merge Strategies](#8-merge-strategies)) and `callable_registry`, a `dict[str, Callable]` for pre-registering functions used by [callable rubric traits](../rubrics/callable-traits/).
+The constructor accepts two additional parameters: `merge_strategy` (see [Merge Strategies](#8-merge-strategies)) and `callable_registry`, a `dict[str, Callable]` of runtime overrides for [callable rubric traits](../rubrics/callable-traits/). When a registry key exactly matches a callable trait name, TaskEval uses the registered function instead of deserializing the function stored on that trait.
 
 ## 6. Attaching Evaluation Criteria
 
@@ -230,11 +230,13 @@ task.add_rubric(
 <p><code>add_template()</code> extracts the source code of your <code>BaseAnswer</code> subclass using <code>inspect.getsource()</code>. The class must be defined in a <code>.py</code> file or Jupyter notebook, not constructed dynamically at runtime. For dynamically defined templates, use <code>add_question()</code> with template source code passed as a string in the <code>answer_template</code> field.</p>
 </div>
 
-If your rubric includes [callable traits](../rubrics/callable-traits/), register the callable functions before calling `evaluate()`:
+[Callable traits](../rubrics/callable-traits/) created with `CallableRubricTrait.from_callable()` carry a serialized function and do not require registration. You can override that function at evaluation time by registering a callable under the same trait name:
 
 ```python
 task.register_callable("under_150_words", lambda text: len(text.split()) < 150)
 ```
+
+Unmatched callable traits fall back to their serialized functions. A registry therefore avoids deserialization for matching traits, but it is not by itself a security boundary for an otherwise untrusted rubric.
 
 When multiple rubrics are attached to the same scope, TaskEval merges them into a single rubric. Trait names must be unique across all rubrics in the same scope; duplicate names raise a `ValueError`.
 

--- a/docs/notebooks/core_concepts/task-eval.ipynb
+++ b/docs/notebooks/core_concepts/task-eval.ipynb
@@ -226,7 +226,7 @@
     "\n",
     "The global scope evaluates all logs together. Per-step scopes evaluate only the logs, templates, and rubrics attached to that step. When you call `evaluate()` without a `step_id`, TaskEval runs global evaluation first, then automatically evaluates each step that has data.\n",
     "\n",
-    "The constructor accepts two additional parameters: `merge_strategy` (see [Merge Strategies](#8-merge-strategies)) and `callable_registry`, a `dict[str, Callable]` for pre-registering functions used by [callable rubric traits](../rubrics/callable-traits/).\n",
+    "The constructor accepts two additional parameters: `merge_strategy` (see [Merge Strategies](#8-merge-strategies)) and `callable_registry`, a `dict[str, Callable]` of runtime overrides for [callable rubric traits](../rubrics/callable-traits/). When a registry key exactly matches a callable trait name, TaskEval uses the registered function instead of deserializing the function stored on that trait.\n",
     "\n",
     "## 6. Attaching Evaluation Criteria\n",
     "\n",
@@ -282,7 +282,7 @@
     "<p><code>add_template()</code> extracts the source code of your <code>BaseAnswer</code> subclass using <code>inspect.getsource()</code>. The class must be defined in a <code>.py</code> file or Jupyter notebook, not constructed dynamically at runtime. For dynamically defined templates, use <code>add_question()</code> with template source code passed as a string in the <code>answer_template</code> field.</p>\n",
     "</div>\n",
     "\n",
-    "If your rubric includes [callable traits](../rubrics/callable-traits/), register the callable functions before calling `evaluate()`:"
+    "[Callable traits](../rubrics/callable-traits/) created with `CallableRubricTrait.from_callable()` carry a serialized function and do not require registration. You can override that function at evaluation time by registering a callable under the same trait name:"
    ]
   },
   {
@@ -300,6 +300,8 @@
    "id": "1307c035",
    "metadata": {},
    "source": [
+    "Unmatched callable traits fall back to their serialized functions. A registry therefore avoids deserialization for matching traits, but it is not by itself a security boundary for an otherwise untrusted rubric.\n",
+    "\n",
     "When multiple rubrics are attached to the same scope, TaskEval merges them into a single rubric. Trait names must be unique across all rubrics in the same scope; duplicate names raise a `ValueError`.\n",
     "\n",
     "See the [workflow](../../task-eval/#step-3-attach-evaluation-criteria) for complete examples including all trait types and step-scoped criteria.\n",

--- a/docs/notebooks/task-eval/basic-evaluation.ipynb
+++ b/docs/notebooks/task-eval/basic-evaluation.ipynb
@@ -378,7 +378,7 @@
     "| `task_id` | `str \\| None` | `None` | Identifier for tracking |\n",
     "| `metadata` | `dict \\| None` | `None` | Arbitrary metadata dict |\n",
     "| `merge_strategy` | `\"concatenate\" \\| \"traces_only\"` | `\"concatenate\"` | How to combine logs before evaluation (see [Merge Strategies](#merge-strategies)) |\n",
-    "| `callable_registry` | `dict[str, Callable]` | `None` | Registry for callable trait evaluation (see [Rubrics](../../core_concepts/rubrics/index.md)) |\n",
+    "| `callable_registry` | `dict[str, Callable]` | `None` | Runtime overrides keyed by callable trait name (see [Rubrics](../../core_concepts/rubrics/index.md)) |\n",
     "\n",
     "---\n",
     "\n",

--- a/docs/notebooks/task-eval/quality-assessment.ipynb
+++ b/docs/notebooks/task-eval/quality-assessment.ipynb
@@ -15,7 +15,7 @@
     "- Define LLM traits: boolean and ordinal score kinds\n",
     "- Define regex traits for pattern detection\n",
     "- Define callable traits for custom Python checks\n",
-    "- Register callables with `callable_registry`\n",
+    "- Override serialized callables with `callable_registry`\n",
     "- Combine multiple trait types in a single rubric\n",
     "- Inspect rubric scores by trait type\n",
     "- Compare quality across multiple logged outputs"
@@ -651,9 +651,9 @@
    "id": "2af1df38",
    "metadata": {},
    "source": [
-    "### Register Callables\n",
+    "### Override Callable Implementations\n",
     "\n",
-    "Callable traits require registration in a `callable_registry` so TaskEval can find them at evaluation time. Pass the registry at construction:"
+    "`CallableRubricTrait.from_callable()` stores a serialized copy of its function, so registration is not required. A `callable_registry` lets TaskEval use a runtime implementation instead when a registry key exactly matches the trait name. Pass overrides at construction:"
    ]
   },
   {
@@ -697,7 +697,7 @@
    "id": "7cc3eae7",
    "metadata": {},
    "source": [
-    "Or register after construction:"
+    "Or register overrides after construction:"
    ]
   },
   {
@@ -733,6 +733,8 @@
    "id": "45e344b0",
    "metadata": {},
    "source": [
+    "Registered functions bypass deserialization for matching traits. Traits without a matching registry entry still use their serialized functions, so a partial registry does not make an otherwise untrusted rubric safe to evaluate.\n",
+    "\n",
     "### Create CallableTraits"
    ]
   },

--- a/docs/workflows/task-eval/basic-evaluation.md
+++ b/docs/workflows/task-eval/basic-evaluation.md
@@ -219,7 +219,7 @@ print(f"Created TaskEval: {task.task_id}")
 | `task_id` | `str \| None` | `None` | Identifier for tracking |
 | `metadata` | `dict \| None` | `None` | Arbitrary metadata dict |
 | `merge_strategy` | `"concatenate" \| "traces_only"` | `"concatenate"` | How to combine logs before evaluation (see [Merge Strategies](#merge-strategies)) |
-| `callable_registry` | `dict[str, Callable]` | `None` | Registry for callable trait evaluation (see [Rubrics](../../core_concepts/rubrics/index.md)) |
+| `callable_registry` | `dict[str, Callable]` | `None` | Runtime overrides keyed by callable trait name (see [Rubrics](../../core_concepts/rubrics/index.md)) |
 
 ---
 

--- a/docs/workflows/task-eval/quality-assessment.md
+++ b/docs/workflows/task-eval/quality-assessment.md
@@ -23,7 +23,7 @@ This tutorial shows how to evaluate response quality using rubrics without an an
 - Define LLM traits: boolean and ordinal score kinds
 - Define regex traits for pattern detection
 - Define callable traits for custom Python checks
-- Register callables with `callable_registry`
+- Override serialized callables with `callable_registry`
 - Combine multiple trait types in a single rubric
 - Inspect rubric scores by trait type
 - Compare quality across multiple logged outputs
@@ -311,9 +311,9 @@ print(f"check_word_count: {check_word_count.__doc__.strip()}")
 print(f"count_sentences: {count_sentences.__doc__.strip()}")
 ```
 
-### Register Callables
+### Override Callable Implementations
 
-Callable traits require registration in a `callable_registry` so TaskEval can find them at evaluation time. Pass the registry at construction:
+`CallableRubricTrait.from_callable()` stores a serialized copy of its function, so registration is not required. A `callable_registry` lets TaskEval use a runtime implementation instead when a registry key exactly matches the trait name. Pass overrides at construction:
 
 ```python
 registry = {
@@ -330,7 +330,7 @@ task_with_callables = TaskEval(
 print(f"Registry has {len(registry)} callable(s)")
 ```
 
-Or register after construction:
+Or register overrides after construction:
 
 ```python
 task.register_callable("check_word_count", check_word_count)
@@ -338,6 +338,8 @@ task.register_callable("count_sentences", count_sentences)
 
 print("Registered callables on existing TaskEval")
 ```
+
+Registered functions bypass deserialization for matching traits. Traits without a matching registry entry still use their serialized functions, so a partial registry does not make an otherwise untrusted rubric safe to evaluate.
 
 ### Create CallableTraits
 

--- a/src/karenina/benchmark/task_eval/task_eval.py
+++ b/src/karenina/benchmark/task_eval/task_eval.py
@@ -12,13 +12,12 @@ Example:
 """
 
 import logging
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, Union
 
 if TYPE_CHECKING:
     from karenina.ports.messages import Message
     from karenina.schemas.entities import Question, Rubric
-    from karenina.schemas.entities.rubric import DynamicRubric
+    from karenina.schemas.entities.rubric import DynamicRubric, RubricCallable
 
 from karenina.exceptions import KareninaError
 from karenina.schemas.config import ModelConfig
@@ -48,7 +47,7 @@ class TaskEval:
         self,
         task_id: str | None = None,
         metadata: dict[str, Any] | None = None,
-        callable_registry: dict[str, Callable[[str], bool]] | None = None,
+        callable_registry: dict[str, "RubricCallable"] | None = None,
         merge_strategy: Literal["concatenate", "traces_only"] = "concatenate",
     ) -> None:
         """Initialize TaskEval instance.
@@ -56,14 +55,16 @@ class TaskEval:
         Args:
             task_id: Optional task identifier for tracking
             metadata: Optional metadata dictionary
-            callable_registry: Registry of callable functions for manual trait evaluation
+            callable_registry: Runtime callable overrides keyed by callable trait
+                name. Registered functions take precedence over serialized
+                callables stored on matching traits.
             merge_strategy: Default strategy for merging logs before evaluation.
                 "concatenate" combines text and trace logs; "traces_only" uses
                 only logs with trace_messages.
         """
         self.task_id = task_id
         self.metadata = metadata or {}
-        self.callable_registry = callable_registry or {}
+        self.callable_registry = dict(callable_registry or {})
         self.merge_strategy: Literal["concatenate", "traces_only"] = merge_strategy
 
         # Storage for logs, questions, rubrics, and dynamic rubrics
@@ -284,12 +285,13 @@ class TaskEval:
         else:
             self.global_dynamic_rubrics.append(dynamic_rubric)
 
-    def register_callable(self, name: str, func: Callable[[str], bool]) -> None:
-        """Register a callable function for manual trait evaluation.
+    def register_callable(self, name: str, func: "RubricCallable") -> None:
+        """Register a runtime override for a callable rubric trait.
 
         Args:
-            name: Name to register the function under
-            func: Function that takes a string and returns a boolean
+            name: Callable trait name to override.
+            func: Function that takes a string and returns a boolean, numeric
+                score, or literal class label.
 
         Raises:
             ValueError: If function doesn't have correct signature
@@ -866,6 +868,7 @@ class Answer(BaseAnswer):
             rubric_evaluation_strategy="batch",
             evaluation_mode=evaluation_mode,
             task_eval_mode=True,
+            callable_registry=self.callable_registry,
         )
 
         return verification_result

--- a/src/karenina/benchmark/verification/evaluators/rubric/evaluator.py
+++ b/src/karenina/benchmark/verification/evaluators/rubric/evaluator.py
@@ -23,6 +23,7 @@ from karenina.adapters.registry import close_adapter
 from karenina.ports import LLMPort
 from karenina.schemas.config import ModelConfig
 from karenina.schemas.entities import CallableRubricTrait, MetricRubricTrait, RegexRubricTrait, Rubric
+from karenina.schemas.entities.rubric import RubricCallable
 
 from .deep_judgment import RubricDeepJudgmentHandler
 from .llm_trait import LLMTraitEvaluator
@@ -51,6 +52,7 @@ class RubricEvaluator:
         model_config: ModelConfig,
         evaluation_strategy: str = "batch",
         prompt_config: "PromptConfig | None" = None,
+        callable_registry: dict[str, RubricCallable] | None = None,
     ):
         """
         Initialize the rubric evaluator with an LLM model.
@@ -61,6 +63,8 @@ class RubricEvaluator:
                 - "batch": Evaluate all traits in single LLM call (efficient)
                 - "sequential": Evaluate traits one-by-one (reliable)
             prompt_config: Optional per-task-type user instructions for prompt assembly.
+            callable_registry: Runtime callable overrides keyed by trait name.
+                Matching functions take precedence over serialized trait callables.
 
         Raises:
             ValueError: If model configuration is invalid (validated by adapter factory)
@@ -69,6 +73,7 @@ class RubricEvaluator:
         self.model_config = model_config
         self.evaluation_strategy = evaluation_strategy
         self._prompt_config = prompt_config
+        self.callable_registry = callable_registry or {}
 
         # Note: ValueError from validate_model_config propagates directly;
         # only runtime errors (adapter unavailable, etc.) are wrapped.
@@ -288,7 +293,20 @@ class RubricEvaluator:
         Returns:
             Dictionary mapping trait names to boolean or int results (depending on trait kind)
         """
-        return self._evaluate_deterministic_traits(answer, callable_traits, "callable")
+        results: dict[str, bool | int | float] = {}
+
+        for trait in callable_traits:
+            try:
+                result = trait.evaluate(
+                    answer,
+                    callable_override=self.callable_registry.get(trait.name),
+                )
+                results[trait.name] = result
+            except Exception as e:
+                logger.warning("Failed to evaluate callable trait '%s': %s", trait.name, e)
+                results[trait.name] = None  # type: ignore[assignment]
+
+        return results
 
     # ========== Metric Trait Evaluation Methods ==========
 

--- a/src/karenina/benchmark/verification/runner.py
+++ b/src/karenina/benchmark/verification/runner.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from karenina.schemas.config import ModelConfig
 from karenina.schemas.entities import Rubric
-from karenina.schemas.entities.rubric import DynamicRubric
+from karenina.schemas.entities.rubric import DynamicRubric, RubricCallable
 from karenina.schemas.verification import PromptConfig, VerificationResult
 from karenina.schemas.verification.config import (
     DEFAULT_DEEP_JUDGMENT_FUZZY_THRESHOLD,
@@ -120,6 +120,8 @@ def run_single_model_verification(
     replay_parse_on_hydration_mismatch: str = "fall_through",
     # TaskEval signal (set by TaskEval entry; suppresses QUESTION slot in rubric prompts)
     task_eval_mode: bool = False,
+    # Runtime callable overrides (used by TaskEval)
+    callable_registry: dict[str, RubricCallable] | None = None,
 ) -> VerificationResult:
     """
     Run verification for a single question with specific answering and parsing models.
@@ -147,6 +149,7 @@ def run_single_model_verification(
         rubric_evaluation_strategy: Strategy for evaluating LLM rubric traits:
             - "batch": All traits evaluated in single LLM call (default, efficient)
             - "sequential": Traits evaluated one-by-one (reliable, more expensive)
+        callable_registry: Runtime callable overrides keyed by callable trait name.
         deep_judgment_max_excerpts_per_attribute: Max excerpts per attribute (deep-judgment)
         deep_judgment_fuzzy_match_threshold: Similarity threshold for excerpts (deep-judgment)
         deep_judgment_excerpt_retry_attempts: Retry attempts for excerpt validation (deep-judgment)
@@ -194,6 +197,7 @@ def run_single_model_verification(
         deep_judgment_mode=deep_judgment_mode,
         # Rubric Configuration
         rubric_evaluation_strategy=rubric_evaluation_strategy,
+        callable_registry=callable_registry,
         # Deep-Judgment Configuration
         deep_judgment_max_excerpts_per_attribute=deep_judgment_max_excerpts_per_attribute,
         deep_judgment_fuzzy_match_threshold=deep_judgment_fuzzy_match_threshold,

--- a/src/karenina/benchmark/verification/stages/core/base.py
+++ b/src/karenina/benchmark/verification/stages/core/base.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from karenina.schemas.config import ModelConfig
 from karenina.schemas.entities import Rubric
-from karenina.schemas.entities.rubric import DynamicRubric
+from karenina.schemas.entities.rubric import DynamicRubric, RubricCallable
 from karenina.schemas.verification import PromptConfig
 from karenina.schemas.verification.config import (
     DEFAULT_DEEP_JUDGMENT_FUZZY_THRESHOLD,
@@ -282,6 +282,7 @@ class VerificationContext:
         deep_judgment_mode: Template deep-judgment mode ("disabled", "reasoning_only", "full").
         rubric_evaluation_strategy: Strategy for evaluating LLM rubric traits
             ("batch" or "sequential").
+        callable_registry: Runtime callable overrides keyed by callable trait name.
         deep_judgment_max_excerpts_per_attribute: Max excerpts per attribute.
         deep_judgment_fuzzy_match_threshold: Similarity threshold for excerpts.
         deep_judgment_excerpt_retry_attempts: Retry attempts for excerpt validation.
@@ -327,6 +328,7 @@ class VerificationContext:
 
     # Rubric Configuration
     rubric_evaluation_strategy: str = "batch"  # "batch" or "sequential"
+    callable_registry: dict[str, RubricCallable] | None = None  # Runtime overrides for callable traits
     rubric_trait_names: list[str] | None = None  # Optional filter for specific traits
     trait_provenance: dict[str, str] | None = None  # Trait provenance: "global", "question_specific", "dynamic"
 

--- a/src/karenina/benchmark/verification/stages/pipeline/rubric_evaluation.py
+++ b/src/karenina/benchmark/verification/stages/pipeline/rubric_evaluation.py
@@ -198,6 +198,7 @@ class RubricEvaluationStage(BaseVerificationStage):
                 context.parsing_model,
                 evaluation_strategy=context.rubric_evaluation_strategy,
                 prompt_config=context.prompt_config,
+                callable_registry=context.callable_registry,
             )
 
             # Apply deep judgment configuration resolution to LLM traits

--- a/src/karenina/schemas/entities/rubric.py
+++ b/src/karenina/schemas/entities/rubric.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 TraitKind = Literal["boolean", "score", "literal"]
+CallableResult = bool | int | float | str
+RubricCallable = Callable[[str], CallableResult]
 
 
 class LLMRubricTrait(BaseModel):
@@ -436,7 +438,7 @@ class CallableRubricTrait(BaseModel):
     def from_callable(
         cls,
         name: str,
-        func: Callable[[str], bool | int | float | str],
+        func: RubricCallable,
         kind: TraitKind,
         description: str | None = None,
         summary: str | None = None,
@@ -502,7 +504,7 @@ class CallableRubricTrait(BaseModel):
             classes=classes,
         )
 
-    def deserialize_callable(self) -> Callable[[str], bool | int | float | str]:
+    def deserialize_callable(self) -> RubricCallable:
         """
         Deserialize the callable function from stored bytes.
 
@@ -522,17 +524,25 @@ class CallableRubricTrait(BaseModel):
                 category=UserWarning,
                 stacklevel=2,
             )
-            callable_func: Callable[[str], bool | int | float | str] = cloudpickle.loads(self.callable_code)
+            callable_func: RubricCallable = cloudpickle.loads(self.callable_code)
             return callable_func
         except Exception as e:
             raise RuntimeError(f"Failed to deserialize callable for trait '{self.name}': {e}") from e
 
-    def evaluate(self, text: str) -> bool | int | float:
+    def evaluate(
+        self,
+        text: str,
+        *,
+        callable_override: RubricCallable | None = None,
+    ) -> bool | int | float:
         """
         Evaluate the trait against the provided text.
 
         Args:
             text: The text to evaluate (verification trace or answer text).
+            callable_override: Optional trusted runtime callable to use instead of
+                deserializing ``callable_code``. Result validation and conversion
+                are applied identically to embedded and override callables.
 
         Returns:
             For kind='boolean': bool result (possibly inverted).
@@ -544,7 +554,7 @@ class CallableRubricTrait(BaseModel):
             ValueError: If return type does not match kind or value is out of range.
         """
         try:
-            func = self.deserialize_callable()
+            func = callable_override if callable_override is not None else self.deserialize_callable()
             result = func(text)
 
             if self.kind == "boolean":

--- a/tests/unit/benchmark/test_task_eval.py
+++ b/tests/unit/benchmark/test_task_eval.py
@@ -929,3 +929,78 @@ class TestImports:
         assert task.global_logs[0].text == "text entry"
         assert task.global_logs[1].trace_messages is not None
         assert task.global_logs[2].trace_messages is not None
+
+
+@pytest.mark.unit
+class TestCallableRegistry:
+    """Verify TaskEval owns and forwards runtime callable overrides."""
+
+    def test_constructor_copies_registry(self) -> None:
+        registry = {"check": lambda _text: True}
+        task = TaskEval(callable_registry=registry)
+
+        registry["later"] = lambda _text: False
+
+        assert set(task.callable_registry) == {"check"}
+
+    def test_register_callable_accepts_all_trait_result_types(self) -> None:
+        task = TaskEval()
+
+        task.register_callable("boolean", lambda _text: True)
+        task.register_callable("score", lambda _text: 3.5)
+        task.register_callable("literal", lambda _text: "formal")
+
+        assert set(task.callable_registry) == {"boolean", "score", "literal"}
+
+    def test_registry_is_forwarded_to_verification_runner(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from karenina.schemas.config import ModelConfig
+        from karenina.schemas.entities.rubric import CallableRubricTrait, Rubric
+        from karenina.schemas.verification import VerificationConfig
+
+        def registered(_text: str) -> bool:
+            return True
+
+        task = TaskEval(callable_registry={"short": registered})
+        task.log("a short answer")
+        task.add_rubric(
+            Rubric(
+                callable_traits=[
+                    CallableRubricTrait.from_callable(
+                        name="short",
+                        func=lambda _text: False,
+                        kind="boolean",
+                    )
+                ]
+            )
+        )
+
+        mock_result = TestEvaluationLoop()._make_mock_verification_result()
+        call_kwargs: list[dict[str, Any]] = []
+
+        def mock_run(*_args, **kwargs):
+            call_kwargs.append(kwargs)
+            return mock_result
+
+        monkeypatch.setattr(
+            "karenina.benchmark.verification.runner.run_single_model_verification",
+            mock_run,
+        )
+
+        task.evaluate(
+            VerificationConfig(
+                parsing_models=[
+                    ModelConfig(
+                        id="mock",
+                        model_provider="mock",
+                        model_name="mock",
+                        interface="langchain",
+                    )
+                ],
+                parsing_only=True,
+            )
+        )
+
+        assert call_kwargs[0]["callable_registry"] == {"short": registered}

--- a/tests/unit/benchmark/verification/evaluators/test_callable_registry.py
+++ b/tests/unit/benchmark/verification/evaluators/test_callable_registry.py
@@ -1,0 +1,129 @@
+"""Tests for runtime callable registry overrides."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karenina.benchmark.verification.evaluators.rubric.evaluator import RubricEvaluator
+from karenina.schemas.config.models import ModelConfig
+from karenina.schemas.entities.rubric import CallableRubricTrait, Rubric
+
+
+def _make_evaluator(
+    monkeypatch: pytest.MonkeyPatch,
+    callable_registry: dict | None = None,
+) -> RubricEvaluator:
+    """Create a rubric evaluator without initializing a real LLM adapter."""
+    monkeypatch.setattr(
+        "karenina.benchmark.verification.evaluators.rubric.evaluator.get_llm",
+        lambda _config: MagicMock(),
+    )
+    return RubricEvaluator(
+        ModelConfig(id="test", model_name="test-model"),
+        callable_registry=callable_registry,
+    )
+
+
+@pytest.mark.unit
+class TestCallableRegistry:
+    """Verify registered callables override embedded trait code by name."""
+
+    def test_matching_callable_overrides_without_deserializing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        trait = CallableRubricTrait.from_callable(
+            name="short",
+            func=lambda _text: False,
+            kind="boolean",
+        )
+        evaluator = _make_evaluator(monkeypatch, {"short": lambda _text: True})
+
+        with patch.object(
+            CallableRubricTrait,
+            "deserialize_callable",
+            side_effect=AssertionError("embedded callable must not be deserialized"),
+        ):
+            results, _, _ = evaluator.evaluate_rubric(
+                question="",
+                answer="answer",
+                rubric=Rubric(callable_traits=[trait]),
+            )
+
+        assert results == {"short": True}
+
+    def test_unmatched_callable_falls_back_to_embedded(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        trait = CallableRubricTrait.from_callable(
+            name="embedded",
+            func=lambda text: text == "answer",
+            kind="boolean",
+        )
+        evaluator = _make_evaluator(monkeypatch, {"other": lambda _text: False})
+
+        with pytest.warns(UserWarning, match="Deserializing callable"):
+            results, _, _ = evaluator.evaluate_rubric(
+                question="",
+                answer="answer",
+                rubric=Rubric(callable_traits=[trait]),
+            )
+
+        assert results == {"embedded": True}
+
+    @pytest.mark.parametrize(
+        ("trait", "override", "expected"),
+        [
+            (
+                CallableRubricTrait.from_callable(
+                    name="inverted",
+                    func=lambda _text: False,
+                    kind="boolean",
+                    invert_result=True,
+                ),
+                lambda _text: True,
+                False,
+            ),
+            (
+                CallableRubricTrait.from_callable(
+                    name="score",
+                    func=lambda _text: 1,
+                    kind="score",
+                    min_score=0,
+                    max_score=10,
+                ),
+                lambda _text: 7.5,
+                7.5,
+            ),
+            (
+                CallableRubricTrait.from_callable(
+                    name="tone",
+                    func=lambda _text: "formal",
+                    kind="literal",
+                    classes={"formal": "Formal tone", "casual": "Casual tone"},
+                ),
+                lambda _text: "casual",
+                1,
+            ),
+        ],
+    )
+    def test_override_uses_existing_trait_result_handling(
+        self,
+        trait: CallableRubricTrait,
+        override,
+        expected: bool | int | float,
+    ) -> None:
+        assert trait.evaluate("answer", callable_override=override) == expected
+
+    def test_invalid_override_result_uses_existing_validation(self) -> None:
+        trait = CallableRubricTrait.from_callable(
+            name="bounded",
+            func=lambda _text: 1,
+            kind="score",
+            min_score=0,
+            max_score=5,
+        )
+
+        with pytest.raises(RuntimeError, match="above maximum"):
+            trait.evaluate("answer", callable_override=lambda _text: 6)

--- a/tests/unit/benchmark/verification/stages/test_rubric_evaluation_warnings.py
+++ b/tests/unit/benchmark/verification/stages/test_rubric_evaluation_warnings.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -14,7 +14,7 @@ from karenina.benchmark.verification.stages.pipeline.rubric_evaluation import (
     RubricEvaluationStage,
 )
 from karenina.schemas.config.models import ModelConfig
-from karenina.schemas.entities.rubric import LLMRubricTrait, Rubric
+from karenina.schemas.entities.rubric import CallableRubricTrait, LLMRubricTrait, Rubric
 
 
 def _make_context_with_rubric() -> VerificationContext:
@@ -117,3 +117,41 @@ class TestRubricEvaluationWarnings:
 
         assert ctx.warnings == []
         assert ctx.get_artifact(ArtifactKeys.RUBRIC_RESULT) == {"clarity": 1.0}
+
+    def test_callable_registry_is_forwarded_to_evaluator(self) -> None:
+        """The pipeline stage gives runtime callable overrides to RubricEvaluator."""
+        model = ModelConfig(id="test", model_name="test-model")
+
+        def runtime_callable(_text: str) -> bool:
+            return True
+
+        ctx = VerificationContext(
+            question_id="q1",
+            question_text="",
+            raw_answer="answer",
+            template_code="class Answer: pass",
+            answering_model=model,
+            parsing_model=model,
+            template_id="tpl1",
+            rubric=Rubric(
+                callable_traits=[
+                    CallableRubricTrait.from_callable(
+                        name="check",
+                        func=lambda _text: False,
+                        kind="boolean",
+                    )
+                ]
+            ),
+            callable_registry={"check": runtime_callable},
+        )
+        ctx.set_artifact(ArtifactKeys.RAW_LLM_RESPONSE, "answer")
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate_rubric.return_value = ({"check": True}, None, [])
+        with patch(
+            "karenina.benchmark.verification.stages.pipeline.rubric_evaluation.RubricEvaluator",
+            return_value=mock_evaluator,
+        ) as evaluator_class:
+            RubricEvaluationStage().execute(ctx)
+
+        assert evaluator_class.call_args.kwargs["callable_registry"] == {"check": runtime_callable}


### PR DESCRIPTION
## Summary

- thread TaskEval callable registrations through the verification pipeline
- prefer exact-name runtime callables while preserving embedded callable fallback
- reuse CallableRubricTrait result validation for boolean, score, and literal overrides
- clarify that partial registries are not a security boundary and sync paired notebooks

## Testing

- `uv run pytest -q tests/unit` (4812 passed, 26 skipped)
- focused callable registry tests (53 passed)
- `uv run mypy` on changed source files
- `uv run ruff check src/karenina` and changed tests
- Jupytext pair consistency check