### PR TITLE
fix: honor Anthropic connection fields in LangChain

### DIFF
--- a/docs/advanced-adapters/available-adapters.md
+++ b/docs/advanced-adapters/available-adapters.md
@@ -51,6 +51,28 @@ config = ModelConfig(
 
 **Environment variables**: Provider-specific API key (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`)
 
+### Custom Anthropic-Compatible Endpoint
+
+For an Anthropic-compatible gateway or proxy, configure its URL and key on
+`ModelConfig` instead of relying on `ANTHROPIC_API_KEY` from the environment:
+
+```python
+config = ModelConfig(
+    id="gateway-model",
+    model_name="gateway-model",
+    model_provider="anthropic",
+    interface="langchain",
+    anthropic_base_url="https://gateway.example/anthropic",
+    anthropic_api_key="gateway-key",
+)
+```
+
+Both fields are forwarded to LangChain's Anthropic model as `base_url` and
+`api_key`. They require `model_provider="anthropic"`; configuring either on a
+different provider or unsupported interface raises a validation error. Do not
+also set `extra_kwargs["base_url"]` or `extra_kwargs["api_key"]`, as ambiguous
+connection settings are rejected.
+
 ### Parser Behavior
 
 The LangChain parser does **not** use native structured output (`supports_structured_output = False`). Instead, it uses a two-stage approach:
@@ -194,6 +216,11 @@ config = ModelConfig(
 **Required fields**: `id`, `model_name`, `model_provider`
 
 **Environment variables**: Provider-specific API key (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`)
+
+For Anthropic-compatible gateways, use the same `anthropic_base_url` and
+`anthropic_api_key` fields shown in the `langchain` configuration above. They
+are forwarded to the underlying LangChain Anthropic model and require
+`model_provider="anthropic"`.
 
 **Install**: `pip install deepagents langchain-mcp-adapters`
 

--- a/docs/reference/configuration/env-vars.md
+++ b/docs/reference/configuration/env-vars.md
@@ -14,7 +14,7 @@ This is the exhaustive reference for every environment variable recognized by ka
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | `OPENAI_API_KEY` | `str` | — | OpenAI API key. Required when using the `langchain` interface with OpenAI models. |
-| `ANTHROPIC_API_KEY` | `str` | — | Anthropic API key. Required when using `claude_agent_sdk`, `claude_tool`, or `langchain` with Anthropic models. Loaded via `dotenv` in Claude adapters. |
+| `ANTHROPIC_API_KEY` | `str` | — | Anthropic API key. Used when no explicit `anthropic_api_key` is configured for an Anthropic model on `langchain`, `langchain_deep_agents`, `claude_agent_sdk`, or `claude_tool`. The dedicated model field takes precedence and can be paired with `anthropic_base_url` for an Anthropic-compatible gateway. Claude adapters load this variable via `dotenv`. |
 | `CLAUDE_CODE_OAUTH_TOKEN` | `str` | — | Claude subscription OAuth token (created by `claude setup-token`). When neither `ANTHROPIC_API_KEY` nor a model-level `anthropic_api_key` is configured, the `claude_agent_sdk` adapter forwards this from the host environment to the SDK subprocess, so the agent can authenticate through a Claude subscription instead of an API key. |
 | `ANTHROPIC_AUTH_TOKEN` | `str` | — | Alternative Anthropic auth token forwarded alongside `CLAUDE_CODE_OAUTH_TOKEN` by the `claude_agent_sdk` adapter when no API key is configured. |
 | `GOOGLE_API_KEY` | `str` | — | Google AI API key. Required when using the `langchain` interface with Google models (e.g., `google_genai` provider). |

--- a/docs/reference/configuration/model-config.md
+++ b/docs/reference/configuration/model-config.md
@@ -47,7 +47,10 @@ These fields apply only when `interface="openai_endpoint"`.
 
 ## Interface-Specific: Anthropic
 
-These fields apply when `interface="claude_agent_sdk"` or `interface="claude_tool"`.
+These fields apply when `interface="claude_agent_sdk"` or `interface="claude_tool"`, and for
+`model_provider="anthropic"` on the `langchain` and `langchain_deep_agents` interfaces. For
+other interfaces or providers, supplying either field raises a validation error rather than
+silently falling back to environment credentials.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|

--- a/docs/reference/configuration/preset-schema.md
+++ b/docs/reference/configuration/preset-schema.md
@@ -81,8 +81,8 @@ When a preset is saved, each model in `answering_models` and `parsing_models` is
 | `max_retries` | Present in config | Retry attempts |
 | `endpoint_base_url` | `interface == "openai_endpoint"` and value non-empty | Custom endpoint URL |
 | `endpoint_api_key` | `interface == "openai_endpoint"` and value non-empty | Custom API key |
-| `anthropic_base_url` | `interface` in `("claude_tool", "claude_agent_sdk")` and value non-empty | Custom Anthropic endpoint |
-| `anthropic_api_key` | `interface` in `("claude_tool", "claude_agent_sdk")` and value non-empty | Custom Anthropic API key |
+| `anthropic_base_url` | `interface` is `claude_tool` or `claude_agent_sdk`, or `interface` is `langchain` / `langchain_deep_agents` with `model_provider == "anthropic"`; value non-empty | Custom Anthropic endpoint |
+| `anthropic_api_key` | `interface` is `claude_tool` or `claude_agent_sdk`, or `interface` is `langchain` / `langchain_deep_agents` with `model_provider == "anthropic"`; value non-empty | Custom Anthropic API key |
 | `mcp_urls_dict` | Non-empty dict | MCP server URLs |
 | `mcp_tool_filter` | Non-empty list | Tool inclusion filter |
 | `agent_middleware` | Non-empty dict | Agent middleware config |

--- a/src/karenina/adapters/factory.py
+++ b/src/karenina/adapters/factory.py
@@ -445,6 +445,11 @@ def build_llm_kwargs(
         kwargs["endpoint_base_url"] = model_config.endpoint_base_url
         kwargs["endpoint_api_key"] = model_config.endpoint_api_key.get_secret_value()
 
+    elif model_config.interface == "langchain":
+        if model_config.model_provider == "anthropic":
+            kwargs["anthropic_base_url"] = model_config.anthropic_base_url
+            kwargs["anthropic_api_key"] = model_config.anthropic_api_key
+
     elif model_config.interface == "manual":
         if question_hash is not None:
             kwargs["question_hash"] = question_hash

--- a/src/karenina/adapters/langchain/agent.py
+++ b/src/karenina/adapters/langchain/agent.py
@@ -271,6 +271,8 @@ class LangChainAgentAdapter:
             interface=self._config.interface or "langchain",
             endpoint_base_url=self._config.endpoint_base_url,
             endpoint_api_key=self._config.endpoint_api_key,
+            anthropic_base_url=self._config.anthropic_base_url,
+            anthropic_api_key=self._config.anthropic_api_key,
             **kwargs,
         )
 

--- a/src/karenina/adapters/langchain/initialization.py
+++ b/src/karenina/adapters/langchain/initialization.py
@@ -35,6 +35,8 @@ def init_chat_model_unified(
     interface: str = "langchain",
     endpoint_base_url: str | None = None,
     endpoint_api_key: str | SecretStr | None = None,
+    anthropic_base_url: str | None = None,
+    anthropic_api_key: str | SecretStr | None = None,
     **kwargs: Any,
 ) -> Any:
     """Initialize a chat model using the unified interface.
@@ -54,6 +56,8 @@ def init_chat_model_unified(
         endpoint_base_url: Base URL for openai_endpoint interface. Required.
         endpoint_api_key: API key for openai_endpoint interface. Required.
             Must be explicitly provided; does NOT read from environment.
+        anthropic_base_url: Base URL for an Anthropic model on the langchain interface.
+        anthropic_api_key: API key for an Anthropic model on the langchain interface.
         **kwargs: Additional args passed to underlying model (temperature, etc.)
 
     Returns:
@@ -82,6 +86,14 @@ def init_chat_model_unified(
     filtered_kwargs = {k: v for k, v in kwargs.items() if k != "max_context_tokens"}
 
     if interface == "langchain":
+        # ChatAnthropic uses the generic LangChain argument names ``base_url``
+        # and ``api_key``. ModelConfig validates that these dedicated fields
+        # are only supplied for Anthropic-backed LangChain models.
+        if provider == "anthropic":
+            if anthropic_base_url is not None:
+                filtered_kwargs["base_url"] = anthropic_base_url
+            if anthropic_api_key is not None:
+                filtered_kwargs["api_key"] = anthropic_api_key
         return init_chat_model(model=model, model_provider=provider, **filtered_kwargs)
 
     if interface == "openrouter":

--- a/src/karenina/adapters/langchain/llm.py
+++ b/src/karenina/adapters/langchain/llm.py
@@ -157,6 +157,8 @@ class LangChainLLMAdapter:
             interface=self._config.interface,
             endpoint_base_url=self._config.endpoint_base_url,
             endpoint_api_key=self._config.endpoint_api_key,
+            anthropic_base_url=self._config.anthropic_base_url,
+            anthropic_api_key=self._config.anthropic_api_key,
             max_context_tokens=self._config.max_context_tokens,
             # Note: We don't pass MCP config here - simple LLM invocation
             # For agents with MCP, use LangChainAgentAdapter instead

--- a/src/karenina/adapters/langchain_deep_agents/initialization.py
+++ b/src/karenina/adapters/langchain_deep_agents/initialization.py
@@ -108,6 +108,12 @@ def create_chat_model(model_config: ModelConfig, **kwargs: Any) -> Any:
         )
 
     if model_config.model_provider == "anthropic":
+        if model_config.anthropic_base_url is not None:
+            model_kwargs["base_url"] = model_config.anthropic_base_url
+        if model_config.anthropic_api_key is not None:
+            model_kwargs["api_key"] = model_config.anthropic_api_key
+
+    if model_config.model_provider == "anthropic":
         adapter_extras = model_config.extra_kwargs or {}
         effort = adapter_extras.get("effort")
         if effort:

--- a/src/karenina/schemas/config/models.py
+++ b/src/karenina/schemas/config/models.py
@@ -563,7 +563,7 @@ class ModelConfig(BaseModel):
     # OpenAI Endpoint configuration (for openai_endpoint interface)
     endpoint_base_url: str | None = None  # Custom endpoint base URL
     endpoint_api_key: SecretStr | None = None  # User-provided API key
-    # Anthropic-specific configuration (for claude_tool and claude_agent_sdk interfaces)
+    # Anthropic-specific configuration (for Anthropic models on supported interfaces)
     anthropic_base_url: str | None = None  # Custom Anthropic API endpoint (for proxies, self-hosted)
     anthropic_api_key: SecretStr | None = None  # Override ANTHROPIC_API_KEY env var
     # Extra keyword arguments to pass to the underlying model interface.
@@ -628,6 +628,50 @@ class ModelConfig(BaseModel):
                 raise ValueError("id is required for non-manual interfaces")
             if self.model_name is None:
                 raise ValueError("model_name is required for non-manual interfaces")
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_anthropic_connection_fields(self) -> "ModelConfig":
+        """Prevent Anthropic credentials from being silently ignored.
+
+        The dedicated fields are consumed by the Claude adapters and by
+        Anthropic-backed LangChain adapters. Other interfaces must reject them
+        so a configured credential can never fall back to the environment at a
+        different host.
+        """
+        if self.anthropic_base_url is None and self.anthropic_api_key is None:
+            return self
+
+        supported_interfaces = {
+            "claude_agent_sdk",
+            "claude_tool",
+            "langchain",
+            "langchain_deep_agents",
+        }
+        if self.interface not in supported_interfaces:
+            raise ValueError(
+                "anthropic_base_url and anthropic_api_key are only supported for "
+                f"interfaces {sorted(supported_interfaces)}, got {self.interface!r}"
+            )
+
+        if self.interface in {"langchain", "langchain_deep_agents"} and self.model_provider != "anthropic":
+            raise ValueError(
+                "anthropic_base_url and anthropic_api_key require model_provider='anthropic' "
+                f"for interface={self.interface!r}"
+            )
+
+        extra_kwargs = self.extra_kwargs or {}
+        conflicting_fields = [
+            field
+            for field, value in (("base_url", self.anthropic_base_url), ("api_key", self.anthropic_api_key))
+            if value is not None and extra_kwargs.get(field) is not None
+        ]
+        if conflicting_fields:
+            raise ValueError(
+                "anthropic_base_url/anthropic_api_key conflict with extra_kwargs "
+                f"values for {conflicting_fields}. Configure each connection setting only once."
+            )
 
         return self
 

--- a/tests/unit/adapters/langchain/test_initialization.py
+++ b/tests/unit/adapters/langchain/test_initialization.py
@@ -1,0 +1,60 @@
+"""Tests for unified LangChain model initialization."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from karenina.adapters.factory import build_llm_kwargs
+from karenina.adapters.langchain.initialization import init_chat_model_unified
+from karenina.schemas.config import ModelConfig
+
+
+@pytest.mark.unit
+class TestAnthropicConnectionFields:
+    def test_factory_includes_dedicated_connection_settings(self) -> None:
+        config = ModelConfig(
+            id="gateway-model",
+            model_name="gateway-model",
+            model_provider="anthropic",
+            interface="langchain",
+            anthropic_base_url="https://gateway.example/anthropic",
+            anthropic_api_key="gateway-key",
+        )
+
+        kwargs = build_llm_kwargs(config)
+
+        assert kwargs["anthropic_base_url"] == "https://gateway.example/anthropic"
+        assert kwargs["anthropic_api_key"].get_secret_value() == "gateway-key"
+
+    def test_forwards_explicit_anthropic_connection_settings(self) -> None:
+        with patch("karenina.adapters.langchain.initialization.init_chat_model") as mock_init:
+            mock_init.return_value = MagicMock()
+
+            init_chat_model_unified(
+                model="gateway-model",
+                provider="anthropic",
+                anthropic_base_url="https://gateway.example/anthropic",
+                anthropic_api_key=SecretStr("gateway-key"),
+            )
+
+        _, kwargs = mock_init.call_args
+        assert kwargs["base_url"] == "https://gateway.example/anthropic"
+        assert kwargs["api_key"].get_secret_value() == "gateway-key"
+
+    def test_does_not_forward_anthropic_settings_to_another_provider(self) -> None:
+        with patch("karenina.adapters.langchain.initialization.init_chat_model") as mock_init:
+            mock_init.return_value = MagicMock()
+
+            init_chat_model_unified(
+                model="model",
+                provider="openai",
+                anthropic_base_url="https://gateway.example/anthropic",
+                anthropic_api_key="gateway-key",
+            )
+
+        _, kwargs = mock_init.call_args
+        assert "base_url" not in kwargs
+        assert "api_key" not in kwargs

--- a/tests/unit/adapters/langchain/test_llm_adapter.py
+++ b/tests/unit/adapters/langchain/test_llm_adapter.py
@@ -179,6 +179,23 @@ class TestLangChainLLMAdapter:
             assert adapter._converter is not None
             mock_init.assert_called_once()
 
+    def test_adapter_forwards_explicit_anthropic_connection_settings(self) -> None:
+        config = ModelConfig(
+            id="gateway-model",
+            model_name="gateway-model",
+            model_provider="anthropic",
+            interface="langchain",
+            anthropic_base_url="https://gateway.example/anthropic",
+            anthropic_api_key="gateway-key",
+        )
+        with patch("karenina.adapters.langchain.initialization.init_chat_model") as mock_init:
+            mock_init.return_value = MagicMock()
+            LangChainLLMAdapter(config)
+
+        _, kwargs = mock_init.call_args
+        assert kwargs["base_url"] == "https://gateway.example/anthropic"
+        assert kwargs["api_key"].get_secret_value() == "gateway-key"
+
     @pytest.mark.asyncio
     async def test_ainvoke_basic(self, model_config: Any) -> None:
         """Test basic async invocation."""

--- a/tests/unit/adapters/langchain_deep_agents/test_llm.py
+++ b/tests/unit/adapters/langchain_deep_agents/test_llm.py
@@ -120,6 +120,34 @@ class TestDeepAgentsSDKRetrySuppression:
 
         assert captured_kwargs.get("max_retries") == 3
 
+    def test_create_chat_model_forwards_explicit_anthropic_connection_settings(self, monkeypatch):
+        captured_kwargs: dict = {}
+
+        def _capture_init(*, model, model_provider, **kwargs):
+            captured_kwargs.update(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr(
+            "karenina.adapters.langchain_deep_agents.initialization.init_chat_model",
+            _capture_init,
+        )
+
+        from karenina.adapters.langchain_deep_agents.initialization import create_chat_model
+
+        create_chat_model(
+            ModelConfig(
+                id="gateway-model",
+                model_name="gateway-model",
+                model_provider="anthropic",
+                interface="langchain_deep_agents",
+                anthropic_base_url="https://gateway.example/anthropic",
+                anthropic_api_key="gateway-key",
+            )
+        )
+
+        assert captured_kwargs["base_url"] == "https://gateway.example/anthropic"
+        assert captured_kwargs["api_key"].get_secret_value() == "gateway-key"
+
 
 @pytest.mark.unit
 class TestDeepAgentsEndpointBaseUrlMode:

--- a/tests/unit/schemas/test_model_config_anthropic_fields.py
+++ b/tests/unit/schemas/test_model_config_anthropic_fields.py
@@ -1,0 +1,60 @@
+"""Validation tests for ModelConfig Anthropic connection settings."""
+
+from __future__ import annotations
+
+import pytest
+
+from karenina.schemas.config import ModelConfig
+
+
+@pytest.mark.unit
+class TestAnthropicConnectionFieldValidation:
+    @pytest.mark.parametrize("interface", ["openai_endpoint", "openrouter"])
+    def test_rejects_anthropic_fields_for_unsupported_interface(self, interface: str) -> None:
+        with pytest.raises(ValueError, match="only supported for interfaces"):
+            ModelConfig(
+                id="model",
+                model_name="model",
+                interface=interface,
+                anthropic_base_url="https://gateway.example/anthropic",
+            )
+
+    @pytest.mark.parametrize("interface", ["langchain", "langchain_deep_agents"])
+    def test_requires_anthropic_provider_for_langchain_interfaces(self, interface: str) -> None:
+        with pytest.raises(ValueError, match="require model_provider='anthropic'"):
+            ModelConfig(
+                id="model",
+                model_name="model",
+                model_provider="openai",
+                interface=interface,
+                anthropic_api_key="gateway-key",
+            )
+
+    @pytest.mark.parametrize("field", ["base_url", "api_key"])
+    def test_rejects_conflicting_extra_kwargs(self, field: str) -> None:
+        kwargs = {"anthropic_base_url": "https://gateway.example/anthropic"}
+        if field == "api_key":
+            kwargs = {"anthropic_api_key": "gateway-key"}
+
+        with pytest.raises(ValueError, match="conflict with extra_kwargs"):
+            ModelConfig(
+                id="model",
+                model_name="model",
+                model_provider="anthropic",
+                interface="langchain",
+                extra_kwargs={field: "different-value"},
+                **kwargs,
+            )
+
+    @pytest.mark.parametrize("interface", ["claude_tool", "claude_agent_sdk", "langchain", "langchain_deep_agents"])
+    def test_allows_anthropic_fields_for_supported_interface(self, interface: str) -> None:
+        config = ModelConfig(
+            id="model",
+            model_name="model",
+            model_provider="anthropic",
+            interface=interface,
+            anthropic_base_url="https://gateway.example/anthropic",
+            anthropic_api_key="gateway-key",
+        )
+
+        assert config.anthropic_base_url == "https://gateway.example/anthropic"


### PR DESCRIPTION
## Summary

- forward explicit Anthropic base URLs and API keys through the LangChain and LangChain Deep Agents adapters
- reject unsupported provider/interface combinations and conflicting extra_kwargs connection settings
- document custom Anthropic-compatible endpoints and update configuration references

## Tests

- 25 focused ModelConfig and LangChain tests passed
- 10 focused LangChain Deep Agents tests passed
- Ruff and documentation synchronization checks passed